### PR TITLE
feat(DynamoClient): add .primary() query accessor (symmetric with GSI)

### DIFF
--- a/.changeset/primary-index-accessor.md
+++ b/.changeset/primary-index-accessor.md
@@ -1,0 +1,26 @@
+---
+"effect-dynamodb": minor
+"@effect-dynamodb/geo": minor
+"@effect-dynamodb/language-service": minor
+---
+
+Add `.primary()` query accessor on the bound client
+
+Every entity now exposes a `.primary(...)` accessor on `db.entities.*` alongside the existing GSI accessors. The primary index is treated symmetrically with GSIs: pass required PK composites (and optionally one or more SK composites) to get back a `BoundQuery` with the full combinator surface (`.where()`, `.filter()`, `.select()`, `.limit()`, `.reverse()`, `.startFrom()`, `.consistentRead()`, `.collect()`, `.fetch()`, `.paginate()`, `.count()`).
+
+Previously the primary index was deliberately excluded from accessor generation, so the shared-PK join-table pattern (many items under one partition key, distinguished by SK) had no first-class typed query path — only `.get(fullKey)` or a raw `Query.make` escape hatch.
+
+```ts
+// List every membership in an organization — PK only, SK composites omitted
+const allMembers = yield* db.entities.Memberships.primary({
+  orgId: "org-acme",
+}).collect()
+
+// Narrow by partial SK composite (begins_with prefix match)
+const bobs = yield* db.entities.Memberships.primary({
+  orgId: "org-acme",
+  userId: "u-bob",
+}).collect()
+```
+
+`.get(fullKey)` remains the dedicated `GetItem` path for single-item strongly-consistent reads. Resolves #2.

--- a/packages/docs/src/content/docs/guides/indexes.mdx
+++ b/packages/docs/src/content/docs/guides/indexes.mdx
@@ -55,6 +55,28 @@ primaryKey: {
 | `sk.field` | `string` | Yes | Physical DynamoDB attribute name |
 | `sk.composite` | `string[]` | Yes | Model attributes composing the sort key |
 
+### Access Patterns via the Primary Index
+
+Every entity exposes a `.primary(...)` query accessor on the bound client — the primary index is treated symmetrically with GSI indexes. Pass the required PK composites (and optionally one or more SK composites) to return a `BoundQuery`:
+
+```typescript
+// `Memberships` primary key: pk = orgId, sk = userId
+//
+// List all items under a shared primary partition key (PK only)
+const allMembers = yield* db.entities.Memberships.primary({
+  orgId: "org-acme",
+}).collect()
+
+// Narrow by partial SK composite (begins_with prefix match)
+const acmeAdmins = yield* db.entities.Memberships.primary({
+  orgId: "org-acme",
+})
+  .filter({ role: "admin" })
+  .collect()
+```
+
+This is the natural access pattern for shared-PK single-table designs — for example a join table that holds many channel grants under one `accountId`. Use `.get(fullKey)` when you want a strongly-consistent single-item fetch by the full composite key; use `.primary(partialKey)` when you want a `Query` that returns every item in the partition (or a prefix-matched subset).
+
 ### GSI Access Patterns via Entity Indexes
 
 GSI access patterns are defined directly on the entity via the `indexes` property. Each index specifies the physical GSI, PK composites, and SK composites — see the `task-entity` block above for the canonical shape.

--- a/packages/docs/src/content/docs/guides/queries.mdx
+++ b/packages/docs/src/content/docs/guides/queries.mdx
@@ -43,13 +43,50 @@ const assigneeTasks = yield* db.entities.TaskEntity.byAssignee({
 }).collect()
 ```
 
+Every entity also exposes a `.primary(...)` accessor for the primary index — same contract as GSI accessors (required PK composites, optional SK composites with `begins_with` prefix matching):
+
+```typescript
+// Primary-index query — list every item under a shared primary partition.
+// Used when multiple items share the primary PK and are distinguished by SK
+// (the join-table single-table pattern).
+const allMembers = yield* db.entities.Memberships.primary({
+  orgId: "org-acme",
+}).collect()
+```
+
 ### Generated Accessor Mapping
+
+Every index — **including `primary`** — gets a query accessor. Accessors accept required PK composites and optional SK composites (partial SK composites apply `begins_with` prefix matching). `.get(fullKey)` remains the dedicated `GetItem` path for single-item fetches by full primary key.
 
 | Definition | Accessor | Argument Type |
 |-----------|----------|---------------|
 | `primaryKey: { pk: { composite: ["taskId"] }, ... }` | `db.entities.TaskEntity.get(...)` | `{ taskId: string }` |
+| `primaryKey: { pk: { composite: ["orgId"] }, sk: { composite: ["userId"] } }` | `db.entities.Memberships.primary(...)` | `{ orgId: string; userId?: string }` |
 | `indexes: { byProject: { name: "gsi1", pk: { composite: ["projectId"] }, ... } }` | `db.entities.TaskEntity.byProject(...)` | `{ projectId: string }` |
 | `indexes: { byAssignee: { name: "gsi2", pk: { composite: ["assigneeId"] }, ... } }` | `db.entities.TaskEntity.byAssignee(...)` | `{ assigneeId: string }` |
+
+### `.primary()` vs `.get()`
+
+Use `.get(fullKey)` when you know the full primary composite key and want a single item — it's a strongly-consistent `GetItem`, cheaper than a `Query`. Use `.primary(partialKey)` when you want to list items that share a primary partition key, for example a join-table where one partition holds many items distinguished by the sort key:
+
+```typescript
+// `Memberships` primary key: pk = orgId, sk = userId
+//
+// List every membership in an organization — PK only, SK composites omitted
+const allMembers = yield* db.entities.Memberships.primary({
+  orgId: "org-acme",
+}).collect()
+
+// Narrow by sort-key prefix — equivalent to `.get()` here because the full SK
+// composite is provided, but returns an array (possibly empty) rather than
+// failing with `ItemNotFound`.
+const bobs = yield* db.entities.Memberships.primary({
+  orgId: "org-acme",
+  userId: "u-bob",
+}).collect()
+```
+
+Behavior is symmetric with GSI accessors: `.where()`, `.filter()`, `.select()`, `.limit()`, `.reverse()`, `.startFrom()`, `.consistentRead()`, `.collect()`, `.fetch()`, `.paginate()`, and `.count()` all chain off the returned `BoundQuery`.
 
 ## Sort Key Conditions
 

--- a/packages/effect-dynamodb/src/DynamoClient.ts
+++ b/packages/effect-dynamodb/src/DynamoClient.ts
@@ -565,7 +565,7 @@ type ResolveSkFields<M extends Schema.Top, I, K extends keyof I, Provided, R = u
     ? { readonly [P in keyof SK]: SK[P] }
     : never
 
-/** Compute entity query accessors for each index (non-primary).
+/** Compute entity query accessors for each index — including `primary`.
  * Generic over provided input — `.where()` only exposes SK composites NOT already provided.
  * `R` (refs) lets ref-derived composite names (e.g. `playerId`) resolve to their
  * branded identifier types instead of being silently dropped. */
@@ -574,7 +574,7 @@ type EntityIndexAccessors<
   I extends Record<string, IndexDefinition>,
   R = undefined,
 > = {
-  readonly [K in Exclude<keyof I, "primary"> & string]: <Provided extends IndexPkInput<M, I, K, R>>(
+  readonly [K in keyof I & string]: <Provided extends IndexPkInput<M, I, K, R>>(
     composites: Provided,
   ) => import("./internal/BoundQuery.js").BoundQuery<
     Schema.Schema.Type<M>,
@@ -796,9 +796,8 @@ const makeFromConfig = (config: {
       const entityLike = entity as unknown as EntityLike
       const accessors: Record<string, unknown> = {}
 
-      // Add query accessor for each non-primary index
+      // Add query accessor for each index — including `primary`.
       for (const [indexName, indexDef] of Object.entries(entityLike.indexes)) {
-        if (indexName === "primary") continue
         if (!indexDef) continue
 
         accessors[indexName] = buildEntityQueryAccessor(entityLike, indexName, indexDef)

--- a/packages/effect-dynamodb/test/DynamoClient.test.ts
+++ b/packages/effect-dynamodb/test/DynamoClient.test.ts
@@ -581,4 +581,204 @@ describe("DynamoClient", () => {
       },
     )
   })
+
+  // -------------------------------------------------------------------------
+  // .primary() accessor — symmetric query accessor for the primary index.
+  //
+  // Mirrors the GSI accessor contract: required PK composites, optional SK
+  // composites (prefix-ordered), returns a BoundQuery. Prior to this, the
+  // primary index was excluded from accessor generation and the only way to
+  // query a shared primary partition was via a raw `Query.Query` escape
+  // hatch. See GH issue #2.
+  // -------------------------------------------------------------------------
+  describe(".primary() accessor", () => {
+    const AppSchema = DynamoSchema.make({ name: "primary-accessor", version: 1 })
+
+    class AccountChannel extends Schema.Class<AccountChannel>("AccountChannel")({
+      accountId: Schema.String,
+      channelId: Schema.String,
+      grantedBy: Schema.String,
+    }) {}
+
+    const AccountChannelEntity = Entity.make({
+      model: AccountChannel,
+      entityType: "AccountChannel",
+      // Shared-PK join-table pattern: many channels per account.
+      primaryKey: {
+        pk: { field: "pk", composite: ["accountId"] },
+        sk: { field: "sk", composite: ["channelId"] },
+      },
+    })
+
+    const MainTable = Table.make({
+      schema: AppSchema,
+      entities: { AccountChannel: AccountChannelEntity },
+    })
+
+    /** Build a client layer that captures `query` inputs into the provided array. */
+    const makeQueryCapturingClient = (captured: Array<unknown>) =>
+      Layer.succeed(DynamoClient, {
+        putItem: () => Effect.die("not used"),
+        getItem: () => Effect.die("not used"),
+        deleteItem: () => Effect.die("not used"),
+        updateItem: () => Effect.die("not used"),
+        query: (input) =>
+          Effect.sync(() => {
+            captured.push(input)
+            return { Items: [], Count: 0 } as never
+          }),
+        batchGetItem: () => Effect.die("not used"),
+        batchWriteItem: () => Effect.die("not used"),
+        transactGetItems: () => Effect.die("not used"),
+        transactWriteItems: () => Effect.die("not used"),
+        createTable: () => Effect.die("not used"),
+        deleteTable: () => Effect.die("not used"),
+        describeTable: () => Effect.die("not used"),
+        scan: () => Effect.die("not used"),
+      })
+
+    it.effect("PK-only query on primary targets the base table (no IndexName)", () => {
+      const captured: Array<any> = []
+      const ClientLayer = makeQueryCapturingClient(captured)
+      const TableLayer = MainTable.layer({ name: "primary-test-table" })
+
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { AccountChannel: AccountChannelEntity },
+          tables: { MainTable },
+        })
+
+        yield* db.entities.AccountChannel.primary({ accountId: "acct-1" }).collect()
+
+        expect(captured).toHaveLength(1)
+        const input = captured[0]
+        // Base table query — IndexName must be omitted.
+        expect(input.IndexName).toBeUndefined()
+        expect(input.TableName).toBe("primary-test-table")
+        // KeyConditionExpression pins the partition key only.
+        expect(input.KeyConditionExpression).toContain("#pk")
+        expect(input.KeyConditionExpression).not.toContain("begins_with")
+        expect(input.ExpressionAttributeNames["#pk"]).toBe("pk")
+        // PK value is the composed entity-type-prefixed key.
+        const pkValue = input.ExpressionAttributeValues[":pk"].S as string
+        expect(pkValue).toContain("accountchannel")
+        expect(pkValue).toContain("acct-1")
+      }).pipe(Effect.provide(Layer.merge(ClientLayer, TableLayer)))
+    })
+
+    it.effect("PK + partial SK applies begins_with on the composed SK prefix", () => {
+      const captured: Array<any> = []
+      const ClientLayer = makeQueryCapturingClient(captured)
+      const TableLayer = MainTable.layer({ name: "primary-test-table" })
+
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { AccountChannel: AccountChannelEntity },
+          tables: { MainTable },
+        })
+
+        yield* db.entities.AccountChannel.primary({
+          accountId: "acct-1",
+          channelId: "ch-42",
+        }).collect()
+
+        expect(captured).toHaveLength(1)
+        const input = captured[0]
+        expect(input.IndexName).toBeUndefined()
+        // begins_with is used even when the full SK composite is provided — the
+        // accessor treats any SK composite value as a prefix, consistent with
+        // how GSI accessors handle partial SK composites.
+        expect(input.KeyConditionExpression).toContain("begins_with")
+        const skValue = input.ExpressionAttributeValues[":sk"].S as string
+        expect(skValue).toContain("ch-42")
+      }).pipe(Effect.provide(Layer.merge(ClientLayer, TableLayer)))
+    })
+
+    it.effect(".primary() returns a BoundQuery that supports chained combinators", () => {
+      const captured: Array<any> = []
+      const ClientLayer = makeQueryCapturingClient(captured)
+      const TableLayer = MainTable.layer({ name: "primary-test-table" })
+
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { AccountChannel: AccountChannelEntity },
+          tables: { MainTable },
+        })
+
+        // .filter() and .limit() must chain without type errors and propagate
+        // to the underlying DynamoDB query input.
+        yield* db.entities.AccountChannel.primary({ accountId: "acct-1" })
+          .filter({ grantedBy: "admin" })
+          .limit(5)
+          .collect()
+
+        expect(captured).toHaveLength(1)
+        const input = captured[0]
+        expect(input.Limit).toBe(5)
+        expect(input.FilterExpression).toBeDefined()
+        // Attribute names are placeholder-aliased (#e0 etc.); look up the
+        // actual field via ExpressionAttributeNames values.
+        expect(Object.values(input.ExpressionAttributeNames)).toContain("grantedBy")
+        expect(
+          Object.values(input.ExpressionAttributeValues).some((v: any) => v.S === "admin"),
+        ).toBe(true)
+      }).pipe(Effect.provide(Layer.merge(ClientLayer, TableLayer)))
+    })
+
+    it.effect("entities with empty SK composites query by PK only", () => {
+      class User extends Schema.Class<User>("User")({
+        userId: Schema.String,
+        email: Schema.String,
+      }) {}
+
+      const UserEntity = Entity.make({
+        model: User,
+        entityType: "User",
+        primaryKey: {
+          pk: { field: "pk", composite: ["userId"] },
+          sk: { field: "sk", composite: [] },
+        },
+      })
+
+      const SimpleTable = Table.make({ schema: AppSchema, entities: { User: UserEntity } })
+
+      const captured: Array<any> = []
+      const ClientLayer = makeQueryCapturingClient(captured)
+      const TableLayer = SimpleTable.layer({ name: "simple-table" })
+
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { User: UserEntity },
+          tables: { SimpleTable },
+        })
+
+        yield* db.entities.User.primary({ userId: "u-1" }).collect()
+
+        expect(captured).toHaveLength(1)
+        const input = captured[0]
+        expect(input.IndexName).toBeUndefined()
+        // No begins_with clause when the entity has no SK composites.
+        expect(input.KeyConditionExpression).not.toContain("begins_with")
+      }).pipe(Effect.provide(Layer.merge(ClientLayer, TableLayer)))
+    })
+
+    it.effect("missing PK composite throws at runtime via validateQueryComposites", () => {
+      const ClientLayer = makeQueryCapturingClient([])
+      const TableLayer = MainTable.layer({ name: "primary-test-table" })
+
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { AccountChannel: AccountChannelEntity },
+          tables: { MainTable },
+        })
+
+        // Calling .primary() without the required PK composite throws
+        // synchronously — same contract as GSI accessors.
+        expect(() =>
+          // @ts-expect-error — accountId is required
+          db.entities.AccountChannel.primary({}),
+        ).toThrow(/EDD-9002.*accountId/)
+      }).pipe(Effect.provide(Layer.merge(ClientLayer, TableLayer)))
+    })
+  })
 })

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -120,7 +120,25 @@ const Tasks = Entity.make({
   softDelete: true,
 })
 
-const MainTable = Table.make({ schema: AppSchema, entities: { Users, Tasks } })
+// Shared-PK join-table fixture — exercises the `.primary()` accessor where
+// many items live under one partition key and are distinguished by SK.
+class Membership extends Schema.Class<Membership>("Membership")({
+  orgId: Schema.String,
+  userId: Schema.String,
+  role: Schema.Literals(["owner", "admin", "member"]),
+  joinedAt: Schema.String,
+}) {}
+
+const Memberships = Entity.make({
+  model: Membership,
+  entityType: "Membership",
+  primaryKey: {
+    pk: { field: "pk", composite: ["orgId"] },
+    sk: { field: "sk", composite: ["userId"] },
+  },
+})
+
+const MainTable = Table.make({ schema: AppSchema, entities: { Users, Tasks, Memberships } })
 
 // ---------------------------------------------------------------------------
 // Aggregate + Ref models
@@ -725,6 +743,175 @@ describeConnected("Connected integration tests", () => {
       Effect.gen(function* () {
         const count = yield* Tasks.query.byUser({ userId: "u-query" }).pipe(Query.count)
         expect(count).toBe(2)
+      }).pipe(provide),
+    )
+  })
+
+  // -------------------------------------------------------------------------
+  // Primary index query accessor (.primary) — GH #2.
+  //
+  // Symmetric to GSI accessors: required PK composites, optional SK composites
+  // (prefix-ordered). Exercises the shared-PK join-table pattern where many
+  // items live under one partition key and are distinguished by SK.
+  // -------------------------------------------------------------------------
+
+  describe(".primary() accessor (bound client)", () => {
+    // Use unique orgIds per describe block so we don't collide with other
+    // describe blocks that happen to reuse `Memberships`. Each primary test
+    // seeds its own partition explicitly; no cross-test dependencies.
+    const seedAcmeMemberships = Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { Memberships },
+        tables: { MainTable },
+      })
+      yield* db.entities.Memberships.put({
+        orgId: "org-acme",
+        userId: "u-alice",
+        role: "owner",
+        joinedAt: "2025-01-01",
+      })
+      yield* db.entities.Memberships.put({
+        orgId: "org-acme",
+        userId: "u-bob",
+        role: "admin",
+        joinedAt: "2025-02-01",
+      })
+      yield* db.entities.Memberships.put({
+        orgId: "org-acme",
+        userId: "u-carol",
+        role: "member",
+        joinedAt: "2025-03-01",
+      })
+      yield* db.entities.Memberships.put({
+        orgId: "org-other",
+        userId: "u-alice",
+        role: "admin",
+        joinedAt: "2025-01-15",
+      })
+    })
+
+    it.effect("lists all items under a shared primary partition key", () =>
+      Effect.gen(function* () {
+        yield* seedAcmeMemberships
+
+        const db = yield* DynamoClient.make({
+          entities: { Memberships },
+          tables: { MainTable },
+        })
+
+        const acmeMembers = yield* db.entities.Memberships.primary({
+          orgId: "org-acme",
+        }).collect()
+
+        expect(acmeMembers).toHaveLength(3)
+        expect(acmeMembers.every((m) => m.orgId === "org-acme")).toBe(true)
+        expect(acmeMembers.map((m) => m.userId).sort()).toEqual(["u-alice", "u-bob", "u-carol"])
+
+        // Cross-partition isolation — org-other should not leak into org-acme.
+        const otherMembers = yield* db.entities.Memberships.primary({
+          orgId: "org-other",
+        }).collect()
+        expect(otherMembers).toHaveLength(1)
+        expect(otherMembers[0]!.userId).toBe("u-alice")
+      }).pipe(provide),
+    )
+
+    it.effect("PK + full SK composite narrows to a single item", () =>
+      Effect.gen(function* () {
+        yield* seedAcmeMemberships
+
+        const db = yield* DynamoClient.make({
+          entities: { Memberships },
+          tables: { MainTable },
+        })
+
+        const bobs = yield* db.entities.Memberships.primary({
+          orgId: "org-acme",
+          userId: "u-bob",
+        }).collect()
+
+        expect(bobs).toHaveLength(1)
+        expect(bobs[0]!.role).toBe("admin")
+      }).pipe(provide),
+    )
+
+    it.effect("chains .filter() to post-filter results by a non-key attribute", () =>
+      Effect.gen(function* () {
+        yield* seedAcmeMemberships
+
+        const db = yield* DynamoClient.make({
+          entities: { Memberships },
+          tables: { MainTable },
+        })
+
+        const admins = yield* db.entities.Memberships.primary({ orgId: "org-acme" })
+          .filter({ role: "admin" })
+          .collect()
+
+        expect(admins).toHaveLength(1)
+        expect(admins[0]!.userId).toBe("u-bob")
+      }).pipe(provide),
+    )
+
+    it.effect("chains .limit() + .reverse() + .fetch() for paged descending reads", () =>
+      Effect.gen(function* () {
+        yield* seedAcmeMemberships
+
+        const db = yield* DynamoClient.make({
+          entities: { Memberships },
+          tables: { MainTable },
+        })
+
+        const page = yield* db.entities.Memberships.primary({ orgId: "org-acme" })
+          .reverse()
+          .limit(1)
+          .fetch()
+
+        expect(page.items).toHaveLength(1)
+        // Reversed SK sort: u-carol sorts last ascending, so it comes first reversed.
+        expect(page.items[0]!.userId).toBe("u-carol")
+        expect(page.cursor).not.toBeNull()
+      }).pipe(provide),
+    )
+
+    it.effect(".count() returns the number of items in the partition", () =>
+      Effect.gen(function* () {
+        yield* seedAcmeMemberships
+
+        const db = yield* DynamoClient.make({
+          entities: { Memberships },
+          tables: { MainTable },
+        })
+
+        const count = yield* db.entities.Memberships.primary({ orgId: "org-acme" }).count()
+        expect(count).toBe(3)
+      }).pipe(provide),
+    )
+
+    it.effect("works for entities with no SK composites (single-item partitions)", () =>
+      // Use Tasks — its primary key has `sk: { composite: [] }` (empty SK
+      // composites) and `versioned: true` WITHOUT retain, so there are no
+      // snapshot items polluting the partition.
+      Effect.gen(function* () {
+        yield* Tasks.put({
+          taskId: "t-primary-single-1",
+          userId: "u-primary-single",
+          title: "Primary-only task",
+          status: "todo",
+          priority: 1,
+        }).asEffect()
+
+        const db = yield* DynamoClient.make({
+          entities: { Tasks },
+          tables: { MainTable },
+        })
+
+        const result = yield* db.entities.Tasks.primary({
+          taskId: "t-primary-single-1",
+        }).collect()
+        expect(result).toHaveLength(1)
+        expect(result[0]!.taskId).toBe("t-primary-single-1")
+        expect(result[0]!.title).toBe("Primary-only task")
       }).pipe(provide),
     )
   })


### PR DESCRIPTION
## Summary

- Add `.primary(...)` query accessor on the bound client, symmetric with GSI accessors (required PK composites + optional SK composites → `BoundQuery`).
- Unblocks the shared-PK single-table pattern (join tables where many items share a partition key and differ only by SK).
- `.get(fullKey)` unchanged — remains the dedicated `GetItem` path for single-item strongly-consistent reads.

Closes #2.

## What changed

- **Types** (`src/DynamoClient.ts`): drop `Exclude<keyof I, "primary"> & string` from `EntityIndexAccessors` so the `primary` slot participates in accessor generation.
- **Runtime** (`src/DynamoClient.ts`): remove the `if (indexName === "primary") continue` skip in the bound accessor-building loop. Write-time key composition loops in `Entity.ts` are left alone — they legitimately skip `primary` because the primary key is handled separately.
- **Behavior**: for an entity with `primaryKey: { pk: [accountId], sk: [channelId] }`, `db.entities.AccountChannel.primary({ accountId })` now returns every channel under that account. Adding `channelId` applies `begins_with` prefix matching — same contract as GSI accessors.
- **Unbound `Entity['query']` namespace**: intentionally unchanged. Changing it introduced contravariance issues with the `AnyRefValue.entity: Entity<any, ...>` type used for refs (the mapped `query` signature's PK arg couldn't stay assignable to the `any`-substituted index signature). The user-facing need is solved by the bound-client accessor; the unbound namespace isn't required for the join-table use case.

## Docs

- `guides/indexes.mdx`: new "Access Patterns via the Primary Index" subsection under "Entity Primary Key".
- `guides/queries.mdx`: adds an illustrative block for `.primary()`, updates the Generated Accessor Mapping table, and adds a ".primary() vs .get()" subsection.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm check` — 0 errors across all publishable + docs packages
- [x] `pnpm test` — 877 core tests pass (5 new covering `.primary()`), all other package tests pass
- [x] `pnpm --filter @effect-dynamodb/doctest test` — 44 doctest sync tests pass
- [x] `pnpm --filter effect-dynamodb test:connected` against DynamoDB Local — 55 passed (6 new covering `.primary()` with a shared-PK `Memberships` fixture), 12 pre-existing baseline failures unchanged
- [ ] CI run once merged

## Versioning

Changeset bumps all three publishable packages to `0.2.0` (fixed lockstep). This PR depends on the CI chore PR #3 landing first so the new connected tests are actually exercised in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)