### PR TITLE
ci: bump workflows from Node 22 to Node 24

### DIFF
--- a/.changeset/node-24-upgrade.md
+++ b/.changeset/node-24-upgrade.md
@@ -1,0 +1,4 @@
+---
+---
+
+Chore: no version change. Bumps CI/Release/deploy-docs workflows from Node 22 → Node 24 and drops the fragile `Upgrade npm` step in release.yml (Node 24 ships with npm 11.x, which already satisfies Trusted Publishing's >= 11.5.1 requirement).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
-      # Trusted Publishing requires npm CLI >= 11.5.1; Node 22 ships with npm 10.x.
-      - name: Upgrade npm
-        run: npm install -g npm@latest
+      # Node 24 ships with npm 11.x, which already satisfies Trusted Publishing's
+      # >= 11.5.1 requirement — no manual upgrade step needed.
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Bumps `ci.yml`, `release.yml`, and `deploy-docs.yml` from Node 22 → Node 24.
- Drops the `Upgrade npm` step from `release.yml` — Node 24 ships with npm 11.x, which already satisfies Trusted Publishing's `>= 11.5.1` requirement.

Closes #5.

## Why

After PR #3 merged, the Release workflow fired on main and failed at the `Upgrade npm` step with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

[Failing run](https://github.com/jmenga/effect-dynamodb/actions/runs/24730724376). `npm install -g npm@latest` corrupts the bundled-npm install layout when run over Node 22's npm 10.x. The upgrade step exists because Trusted Publishing requires npm >= 11.5.1 and Node 22 ships with 10.x.

Rather than patching around the fragile in-place upgrade, move to Node 24 (bundles npm 11.x out of the box) and delete the upgrade step entirely. This also aligns with GitHub's direction — the deprecation banner on the failing run warns that Actions will be forced to run on Node 24 by default from June 2nd, 2026.

## What changed

- `.github/workflows/ci.yml`: `node-version: 22` → `24`
- `.github/workflows/release.yml`: `node-version: '22'` → `'24'`; `Upgrade npm` step removed
- `.github/workflows/deploy-docs.yml`: `node-version: 22` → `24`
- Empty changeset (chore, no version change)

## Test plan

- [x] `pnpm lint` on Node 24 — clean
- [x] `pnpm check` on Node 24 — clean across all packages
- [x] `pnpm test` on Node 24 — 872 (core) + 67 (language-service) + 44 (doctest) + 56 (geo) tests pass
- [ ] CI run once pushed — should go green
- [ ] Release workflow on merge — should skip publish (no version bump) without failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)