### PR TITLE
fix(Marshaller): pass convertClassInstanceToMap in toAttributeValue

### DIFF
--- a/.changeset/marshaller-class-instance-fix.md
+++ b/.changeset/marshaller-class-instance-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Chore: no version change. Fix `Marshaller.toAttributeValue` to pass `convertClassInstanceToMap: true` and `removeUndefinedValues: true`, matching `toAttributeMap`. Without this, `update()`/`append()` SET clauses and condition/filter values threw at runtime when the value was a `Schema.Class` instance (or contained one). Fixes #12.

--- a/packages/effect-dynamodb/src/Marshaller.ts
+++ b/packages/effect-dynamodb/src/Marshaller.ts
@@ -18,7 +18,8 @@ export const fromAttributeMap = (item: Record<string, AttributeValue>): Record<s
   unmarshall(item)
 
 /** Marshall a single value to a DynamoDB attribute value */
-export const toAttributeValue = (value: unknown): AttributeValue => marshall({ v: value }).v!
+export const toAttributeValue = (value: unknown): AttributeValue =>
+  marshall({ v: value }, { removeUndefinedValues: true, convertClassInstanceToMap: true }).v!
 
 /** Unmarshall a single DynamoDB attribute value */
 export const fromAttributeValue = (value: AttributeValue): unknown => unmarshall({ v: value }).v

--- a/packages/effect-dynamodb/test/Entity.test.ts
+++ b/packages/effect-dynamodb/test/Entity.test.ts
@@ -1915,6 +1915,62 @@ describe("Entity", () => {
         expect(error._tag).toBe("ItemNotFound")
       }).pipe(Effect.provide(TestLayer)),
     )
+
+    // Regression: update SET values marshalled via toAttributeValue previously
+    // threw on Schema.Class instances because convertClassInstanceToMap was not
+    // passed. https://github.com/jmenga/effect-dynamodb/issues/12
+    it.effect("SET accepts a Schema.Class-valued field (nested class instance)", () => {
+      class Point extends Schema.Class<Point>("Point")({
+        type: Schema.Literal("Point"),
+        coordinates: Schema.Array(Schema.Number),
+      }) {}
+      class Device extends Schema.Class<Device>("Device")({
+        deviceId: Schema.String,
+        location: Schema.optional(Point),
+      }) {}
+      const DeviceEntity = withConfig(
+        Entity.make({
+          model: Device,
+          entityType: "Device",
+          primaryKey: {
+            pk: { field: "pk", composite: ["deviceId"] },
+            sk: { field: "sk", composite: [] },
+          },
+        }),
+      )
+
+      return Effect.gen(function* () {
+        mockUpdateItem.mockResolvedValueOnce({
+          Attributes: toAttributeMap({
+            deviceId: "d-1",
+            location: { type: "Point", coordinates: [-87.6298, 41.8781] },
+            pk: "$myapp#v1#device#d-1",
+            sk: "$myapp#v1#device",
+            __edd_e__: "Device",
+          }),
+        })
+
+        const point = new Point({ type: "Point", coordinates: [-87.6298, 41.8781] })
+        yield* DeviceEntity.update({ deviceId: "d-1" }).pipe(
+          Entity.set({ location: point }),
+          Entity.asModel,
+        )
+
+        expect(mockUpdateItem).toHaveBeenCalledOnce()
+        const call = mockUpdateItem.mock.calls[0]![0]
+        // The class instance marshalls as a map with the inner Point as a nested map.
+        const valueKey = Object.keys(call.ExpressionAttributeValues).find(
+          (k) => call.ExpressionAttributeValues[k].M,
+        )
+        expect(valueKey).toBeDefined()
+        expect(call.ExpressionAttributeValues[valueKey!]).toEqual({
+          M: {
+            type: { S: "Point" },
+            coordinates: { L: [{ N: "-87.6298" }, { N: "41.8781" }] },
+          },
+        })
+      }).pipe(Effect.provide(TestLayer))
+    })
   })
 
   // ---------------------------------------------------------------------------

--- a/packages/effect-dynamodb/test/Marshaller.test.ts
+++ b/packages/effect-dynamodb/test/Marshaller.test.ts
@@ -1,4 +1,4 @@
-import { DateTime } from "effect"
+import { DateTime, Schema } from "effect"
 import { describe, expect, it } from "vitest"
 import type { DynamoEncoding } from "../src/DynamoModel.js"
 import {
@@ -9,6 +9,16 @@ import {
   toAttributeMap,
   toAttributeValue,
 } from "../src/Marshaller.js"
+
+class Point extends Schema.Class<Point>("Point")({
+  type: Schema.Literal("Point"),
+  coordinates: Schema.Array(Schema.Number),
+}) {}
+
+class Location extends Schema.Class<Location>("Location")({
+  timestamp: Schema.Number,
+  geometry: Point,
+}) {}
 
 describe("Marshaller", () => {
   describe("toAttributeMap / fromAttributeMap", () => {
@@ -49,6 +59,55 @@ describe("Marshaller", () => {
       const av = toAttributeValue(42)
       expect(av).toEqual({ N: "42" })
       expect(fromAttributeValue(av)).toBe(42)
+    })
+
+    // Regression: toAttributeValue previously did not pass
+    // convertClassInstanceToMap, so any Schema.Class-valued field marshalled
+    // through update/append SET clauses or condition values threw at runtime.
+    // See https://github.com/jmenga/effect-dynamodb/issues/12
+    it("marshalls a Schema.Class instance as a map", () => {
+      const point = new Point({ type: "Point", coordinates: [-87.6298, 41.8781] })
+      const av = toAttributeValue(point)
+      expect(av).toEqual({
+        M: {
+          type: { S: "Point" },
+          coordinates: { L: [{ N: "-87.6298" }, { N: "41.8781" }] },
+        },
+      })
+    })
+
+    it("marshalls a nested Schema.Class instance as a map", () => {
+      const loc = new Location({
+        timestamp: 1704067200000,
+        geometry: new Point({ type: "Point", coordinates: [-87.6298, 41.8781] }),
+      })
+      const av = toAttributeValue(loc)
+      expect(av).toEqual({
+        M: {
+          timestamp: { N: "1704067200000" },
+          geometry: {
+            M: {
+              type: { S: "Point" },
+              coordinates: { L: [{ N: "-87.6298" }, { N: "41.8781" }] },
+            },
+          },
+        },
+      })
+    })
+
+    it("produces the same shape as toAttributeMap for the same class instance", () => {
+      const loc = new Location({
+        timestamp: 1704067200000,
+        geometry: new Point({ type: "Point", coordinates: [-87.6298, 41.8781] }),
+      })
+      const mapped = toAttributeMap({ location: loc })
+      const perField = toAttributeValue(loc)
+      expect(mapped.location).toEqual(perField)
+    })
+
+    it("removes undefined values inside nested objects", () => {
+      const av = toAttributeValue({ a: "x", b: undefined })
+      expect(av).toEqual({ M: { a: { S: "x" } } })
     })
   })
 

--- a/packages/effect-dynamodb/test/TimeSeries.test.ts
+++ b/packages/effect-dynamodb/test/TimeSeries.test.ts
@@ -456,4 +456,80 @@ describe("TimeSeries — append payload shape", () => {
       expect(nameVals).toContain("gpio")
     }).pipe(Effect.provide(layer))
   })
+
+  // Regression: class-instance values in appendInput were marshalled via
+  // toAttributeValue without convertClassInstanceToMap, throwing at runtime.
+  // https://github.com/jmenga/effect-dynamodb/issues/12
+  it.effect("append accepts a nested Schema.Class instance in the SET clause", () => {
+    class Point extends Schema.Class<Point>("Point")({
+      type: Schema.Literal("Point"),
+      coordinates: Schema.Array(Schema.Number),
+    }) {}
+    class Reading extends Schema.Class<Reading>("Reading")({
+      channel: Schema.String,
+      deviceId: Schema.String,
+      timestamp: Schema.DateTimeUtc,
+      geometry: Schema.optional(Point),
+    }) {}
+    const AppendInput = Schema.Struct({
+      channel: Schema.String,
+      deviceId: Schema.String,
+      timestamp: Schema.DateTimeUtc,
+      geometry: Schema.optional(Point),
+    })
+
+    const entity = Entity.make({
+      model: Reading,
+      entityType: "Reading",
+      primaryKey: {
+        pk: { field: "pk", composite: ["channel", "deviceId"] },
+        sk: { field: "sk", composite: [] },
+      },
+      timeSeries: {
+        orderBy: "timestamp",
+        appendInput: AppendInput,
+      },
+    })
+    const { entity: wired, tableLayer } = makeEntityWithTag(entity)
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      mockTransactWriteItems.mockResolvedValueOnce({})
+      mockGetItem.mockResolvedValueOnce({
+        Item: {
+          pk: { S: "$tsapp#v1#reading#c-1#d-7" },
+          sk: { S: "$tsapp#v1#reading_1" },
+          channel: { S: "c-1" },
+          deviceId: { S: "d-7" },
+          timestamp: { S: "2026-04-22T10:00:00.000Z" },
+          geometry: {
+            M: {
+              type: { S: "Point" },
+              coordinates: { L: [{ N: "-87.6298" }, { N: "41.8781" }] },
+            },
+          },
+          __edd_e__: { S: "Reading" },
+        },
+      })
+
+      yield* wired.append({
+        channel: "c-1",
+        deviceId: "d-7",
+        timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+        geometry: new Point({ type: "Point", coordinates: [-87.6298, 41.8781] }),
+      })
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      // Update SET clause marshalls the class instance as a map.
+      const update = call.TransactItems[0].Update
+      const mapValue = Object.values(update.ExpressionAttributeValues).find(
+        (v: any) => v.M?.type?.S === "Point",
+      ) as any
+      expect(mapValue).toBeDefined()
+      expect(mapValue.M.coordinates.L).toEqual([{ N: "-87.6298" }, { N: "41.8781" }])
+      // Put of event item also marshalls through toAttributeMap (already worked).
+      const put = call.TransactItems[1].Put
+      expect(put.Item.geometry.M.type.S).toBe("Point")
+    }).pipe(Effect.provide(layer))
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #12. `Marshaller.toAttributeValue` now passes `convertClassInstanceToMap: true` and `removeUndefinedValues: true`, matching `toAttributeMap`. Previously `update()` / `append()` SET clauses and condition/filter values threw at runtime whenever the value was (or contained) a `Schema.Class` instance — `put()` silently worked because it routes through `toAttributeMap`.

One-line fix in `packages/effect-dynamodb/src/Marshaller.ts`. `removeUndefinedValues: true` is a tiny behavior change: a SET value of `undefined` previously threw from `util-dynamodb`, now the field is silently omitted — same as `put()`.

## Regression tests

Six new tests, all fail against the prior `Marshaller` and pass with the fix:

- `Marshaller.test.ts` — `toAttributeValue` on a `Schema.Class` instance, nested class, parity with `toAttributeMap`, `undefined` elision
- `Entity.test.ts` — `update()` SET accepting a class-instance value, asserting the emitted `ExpressionAttributeValues` map
- `TimeSeries.test.ts` — `append()` accepting a class-instance field in the SET clause (mirrors the reporter's exact repro)

Confirmed by temporarily reverting the Marshaller fix: all 6 new tests fail on the prior code; all pass on the fix.

## Release

Chore changeset — **no version bump** per project owner's direction.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm check`
- [x] `pnpm test` — 1069 tests green (effect-dynamodb 901, language-service 67, doctest 45, geo 56)
- [x] Regression tests fail without fix / pass with fix
- [ ] CI `changeset status` gate passes (empty changeset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)