### PR TITLE
chore(release): aggregate vX.Y.Z tag/release + label merged PRs

### DIFF
--- a/.changeset/aggregate-release-tags.md
+++ b/.changeset/aggregate-release-tags.md
@@ -1,0 +1,4 @@
+---
+---
+
+Chore: extend release workflow to cut an aggregate `vX.Y.Z` tag and GitHub release on lockstep bumps, and label every merged PR in the release window with the corresponding `vX.Y.Z` label for traceability. No version change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,14 +89,61 @@ jobs:
           }
           EOF
 
-      - name: Create GitHub Releases
+      - name: Create per-package GitHub Releases
         if: steps.detect.outputs.should_publish == 'true'
         run: |
-          node -e "console.log(JSON.stringify(require('/tmp/publish.json')))" > /tmp/targets.json
-          for ROW in $(node -e "for (const t of require('/tmp/targets.json')) console.log(t.name + '@' + t.version)"); do
+          for ROW in $(node -e "for (const t of require('/tmp/publish.json')) console.log(t.name + '@' + t.version)"); do
             git tag "$ROW"
             git push origin "$ROW"
             gh release create "$ROW" --title "$ROW" --generate-notes
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # When all three lockstep packages bump to the same version, also cut a
+      # single aggregate vX.Y.Z tag + release and label every PR merged into
+      # this release window with vX.Y.Z for downstream traceability.
+      - name: Create aggregate vX.Y.Z tag, release, and PR labels
+        if: steps.detect.outputs.should_publish == 'true'
+        run: |
+          AGG_VER=$(node -e "
+            const PUBLISHABLE = ['effect-dynamodb', '@effect-dynamodb/geo', '@effect-dynamodb/language-service'];
+            const targets = require('/tmp/publish.json');
+            const byName = Object.fromEntries(targets.map(t => [t.name, t.version]));
+            const allPresent = PUBLISHABLE.every(n => byName[n]);
+            const versions = new Set(PUBLISHABLE.map(n => byName[n]));
+            if (allPresent && versions.size === 1) process.stdout.write([...versions][0]);
+          ")
+          if [ -z "$AGG_VER" ]; then
+            echo "Not a lockstep bump across all three packages; skipping aggregate tag."
+            exit 0
+          fi
+          AGG_TAG="v$AGG_VER"
+          echo "Aggregate release tag: $AGG_TAG"
+
+          PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vx "$AGG_TAG" | head -1 || true)
+          echo "Previous aggregate tag: ${PREV_TAG:-<none>}"
+
+          git tag -a "$AGG_TAG" -m "$AGG_TAG"
+          git push origin "$AGG_TAG"
+
+          if [ -n "$PREV_TAG" ]; then
+            gh release create "$AGG_TAG" --title "$AGG_TAG" --generate-notes --notes-start-tag "$PREV_TAG"
+            RANGE="$PREV_TAG..HEAD"
+          else
+            gh release create "$AGG_TAG" --title "$AGG_TAG" --generate-notes
+            RANGE="HEAD"
+          fi
+
+          gh label create "$AGG_TAG" --color 0366d6 --description "Shipped in $AGG_TAG" 2>/dev/null || true
+
+          git log --pretty=%H "$RANGE" | while read SHA; do
+            gh api "repos/${{ github.repository }}/commits/$SHA/pulls" --jq '.[].number' 2>/dev/null || true
+          done | sort -u | while read PR; do
+            if [ -n "$PR" ]; then
+              echo "Labeling PR #$PR with $AGG_TAG"
+              gh pr edit "$PR" --add-label "$AGG_TAG" || true
+            fi
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,10 @@ Before committing:
 8. New services must follow `Context.Service` pattern
 9. New or updated doc pages must have a backing example file with region markers
 
+## PR Conventions
+
+Every PR that resolves a tracked issue **MUST** reference the issue(s) it closes using a GitHub closing keyword (`Closes #N`, `Fixes #N`, or `Resolves #N`) in the PR body. This is non-negotiable — without a closing keyword, the issue stays open after merge and drifts out of sync with reality. A bare `#N` mention (e.g. "relates to #N") does **not** auto-close; use one of the keywords above, one per issue. If a PR only partially addresses an issue, reference it without a closing keyword and say so explicitly in the PR body.
+
 ## Release Workflow
 
 This repo uses [Changesets](https://github.com/changesets/changesets) with **fixed lockstep versioning** across the three publishable packages (`effect-dynamodb`, `@effect-dynamodb/geo`, `@effect-dynamodb/language-service`). Publishing is automated: every push to `main` runs `.github/workflows/release.yml`, which detects packages whose `package.json` version is ahead of npm and publishes them via Trusted Publishing (OIDC — no `NPM_TOKEN`).


### PR DESCRIPTION
Closes #17.

## Summary
- Extends `.github/workflows/release.yml`: when all three lockstep packages bump to the same version, also cut a single annotated `vX.Y.Z` tag + GitHub release (auto-notes since previous aggregate tag), and ensure a repo label `vX.Y.Z` exists and apply it to every PR merged in `previous-vX.Y.Z..HEAD` — so merged PRs carry a "shipped in vX.Y.Z" signal.
- Per-package tags and releases are unchanged — aggregate artifacts are additive.
- Adds a **PR Conventions** section to `CLAUDE.md` requiring every PR that resolves an issue to use a GitHub closing keyword (`Closes #N` / `Fixes #N` / `Resolves #N`). Without this, issues stay open after their fix merges (see #16 as the current cautionary example).
- Includes empty changeset (no version bump).

Retrospective backfill for 0.1.0 / 1.0.0 / 1.1.0 / 1.2.0 (aggregate tags, releases, PR labels) has already been applied manually on `main` and is visible at https://github.com/jmenga/effect-dynamodb/releases.

## Test plan
- [ ] CI "Require changeset or version bump" passes (empty changeset present)
- [ ] After merge, next lockstep release publishes per-package artifacts **and** a `vX.Y.Z` tag + release
- [ ] After merge, next release applies `vX.Y.Z` label to every merged PR in the window
- [ ] Non-lockstep future bumps (if any) skip the aggregate step cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)