### PR TITLE
ci(release): set runner git identity for aggregate-tag step

### DIFF
--- a/.changeset/release-runner-git-identity.md
+++ b/.changeset/release-runner-git-identity.md
@@ -1,0 +1,4 @@
+---
+---
+
+Chore: configure git user.email/user.name on the release runner so the aggregate-tag step's `git tag -a` succeeds. The previous run (v1.3.0) published to npm but failed at the aggregate-tag step because annotated tags require a committer identity that `actions/checkout` doesn't set by default. No version change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,10 @@ jobs:
           PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vx "$AGG_TAG" | head -1 || true)
           echo "Previous aggregate tag: ${PREV_TAG:-<none>}"
 
+          # Annotated tags require a committer identity; runners don't have one
+          # by default. Use the GitHub Actions bot identity.
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           git tag -a "$AGG_TAG" -m "$AGG_TAG"
           git push origin "$AGG_TAG"
 


### PR DESCRIPTION
## Summary

- Configure git \`user.email\` / \`user.name\` on the release runner immediately before \`git tag -a\` — annotated tags require a committer identity that \`actions/checkout\` doesn't set by default.
- The v1.3.0 release workflow ([run](https://github.com/jmenga/effect-dynamodb/actions/runs/24801886602)) published successfully to npm, but failed at the "Create aggregate vX.Y.Z tag" step with:

  \`\`\`
  fatal: empty ident name (for <runner@…>) not allowed
  \`\`\`
- Publish / per-package GitHub Releases were unaffected — only the aggregate tag + release + PR-label traceability is missing for 1.3.0.

## Follow-up

v1.3.0's aggregate tag + release can be backfilled by hand against \`main\` HEAD (\`1a8267b\`) after this merges, if the label traceability matters. Next release picks up the fix automatically.

## Test plan

- [x] Ran \`pnpm lint\` / \`pnpm check\` locally
- [ ] Next release workflow run completes the aggregate-tag step (verified post-merge on the next minor/patch bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)