### PR TITLE
fix(entity): retain update serializes domain dates before marshal (1.3.1)

### DIFF
--- a/.changeset/release-runner-git-identity.md
+++ b/.changeset/release-runner-git-identity.md
@@ -1,4 +1,0 @@
----
----
-
-Chore: configure git user.email/user.name on the release runner so the aggregate-tag step's `git tag -a` succeeds. The previous run (v1.3.0) published to npm but failed at the aggregate-tag step because annotated tags require a committer identity that `actions/checkout` doesn't set by default. No version change.

--- a/packages/effect-dynamodb-geo/CHANGELOG.md
+++ b/packages/effect-dynamodb-geo/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @effect-dynamodb/geo
 
+## 1.3.1
+
+### Patch Changes
+
+- Fix: `Entity.update` retain path (`versioned: { retain: true }`) marshalled domain `DateTime.Utc` values as DynamoDB Maps, corrupting writes and breaking subsequent reads.
+
+  **Regression introduced in 1.3.0.** The retain path built `newItem` by spreading `currentRaw` (storage primitives from DynamoDB) with `hydratedUpdates` (decoded via the new `fromSelf` variants, so date fields are domain `DateTime.Utc` instances), then called `toAttributeMap(newItem)` without a `serializeDateFields` pass. AWS SDK's `marshall` with `convertClassInstanceToMap: true` then stored the DateTime class as a Map:
+
+  ```json
+  "updatedAt": { "M": { "epochMilliseconds": { "N": "..." }, "~effect/time/DateTime": { "S": "..." }, "_tag": { "S": "Utc" } } }
+  ```
+
+  Subsequent reads failed with `deserializeDateFromDynamo: expected string for DateTime.Utc/string, got object`.
+
+  **Fix:** Pre-serialize `hydratedUpdates` to storage primitives before merging into `newItem`, mirroring what the non-retain path already does. The system-field block reads from the serialized map, so user-supplied colliding `updatedAt` values also land as storage primitives (not Maps). Affects any entity with `versioned: { retain: true }` that has model-declared date fields or uses the collision-aware timestamp pattern from 1.3.0.
+
+  Put, upsert, append, and non-retain update paths were already correct — only the retain path was missing the serialization step.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/geo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Geospatial index and search for effect-dynamodb using H3 hexagonal grid",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/CHANGELOG.md
+++ b/packages/effect-dynamodb/CHANGELOG.md
@@ -1,5 +1,23 @@
 # effect-dynamodb
 
+## 1.3.1
+
+### Patch Changes
+
+- Fix: `Entity.update` retain path (`versioned: { retain: true }`) marshalled domain `DateTime.Utc` values as DynamoDB Maps, corrupting writes and breaking subsequent reads.
+
+  **Regression introduced in 1.3.0.** The retain path built `newItem` by spreading `currentRaw` (storage primitives from DynamoDB) with `hydratedUpdates` (decoded via the new `fromSelf` variants, so date fields are domain `DateTime.Utc` instances), then called `toAttributeMap(newItem)` without a `serializeDateFields` pass. AWS SDK's `marshall` with `convertClassInstanceToMap: true` then stored the DateTime class as a Map:
+
+  ```json
+  "updatedAt": { "M": { "epochMilliseconds": { "N": "..." }, "~effect/time/DateTime": { "S": "..." }, "_tag": { "S": "Utc" } } }
+  ```
+
+  Subsequent reads failed with `deserializeDateFromDynamo: expected string for DateTime.Utc/string, got object`.
+
+  **Fix:** Pre-serialize `hydratedUpdates` to storage primitives before merging into `newItem`, mirroring what the non-retain path already does. The system-field block reads from the serialized map, so user-supplied colliding `updatedAt` values also land as storage primitives (not Maps). Affects any entity with `versioned: { retain: true }` that has model-declared date fields or uses the collision-aware timestamp pattern from 1.3.0.
+
+  Put, upsert, append, and non-retain update paths were already correct — only the retain path was missing the serialization step.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-dynamodb",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Effect TS ORM for DynamoDB — schema-driven entity modeling, single-table design, composite keys, transactions, and Stream-based pagination",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/src/Entity.ts
+++ b/packages/effect-dynamodb/src/Entity.ts
@@ -2477,13 +2477,26 @@ const makeImpl = <
               })
             }
 
-            // Build new item: merge current + updates + rich ops + recompose keys
+            // Build new item: merge current + updates + rich ops + recompose keys.
+            //
+            // Pre-serialize domain date values from `hydratedUpdates` (decoded
+            // via `fromSelf`, so DateTime.Utc / Date instances) into storage
+            // primitives BEFORE merging into `newItem`. `currentRaw` is already
+            // storage-primitive (it came straight from `fromAttributeMap`), so
+            // we need both halves in the same shape — otherwise the final
+            // `toAttributeMap(newItem)` marshals the DateTime class instances
+            // as DynamoDB Maps (via AWS SDK's `convertClassInstanceToMap`),
+            // which corrupts the write and makes subsequent reads fail to
+            // decode.
+            const serializedRetainUpdates = {
+              ...(hydratedUpdates as globalThis.Record<string, unknown>),
+            }
+            serializeDateFields(serializedRetainUpdates)
+
             const newItem: globalThis.Record<string, unknown> = {
               ...(currentRaw as globalThis.Record<string, unknown>),
             }
-            for (const [attr, val] of Object.entries(
-              hydratedUpdates as globalThis.Record<string, unknown>,
-            )) {
+            for (const [attr, val] of Object.entries(serializedRetainUpdates)) {
               if (val !== undefined) newItem[attr] = val
             }
 
@@ -2522,13 +2535,13 @@ const makeImpl = <
 
             // Increment version and update timestamp. If the caller supplied a
             // value for `updatedAt` (allowed when the field collides with a
-            // model-declared field), respect it; else generate.
+            // model-declared field), respect it; else generate. Read from the
+            // pre-serialized map so both branches produce a storage primitive
+            // (ISO string / epoch number) — not a domain DateTime instance.
             const newVersion = currentVersion + 1
             if (systemFields.version) newItem[systemFields.version] = newVersion
             if (systemFields.updatedAt) {
-              const userSupplied = (hydratedUpdates as globalThis.Record<string, unknown>)[
-                systemFields.updatedAt
-              ]
+              const userSupplied = serializedRetainUpdates[systemFields.updatedAt]
               newItem[systemFields.updatedAt] =
                 userSupplied !== undefined
                   ? userSupplied

--- a/packages/effect-dynamodb/test/Entity.test.ts
+++ b/packages/effect-dynamodb/test/Entity.test.ts
@@ -7142,5 +7142,92 @@ describe("Entity", () => {
         expect(call.UpdateExpression).toContain("+ :vinc")
       }).pipe(Effect.provide(TestLayer)),
     )
+
+    // Regression for v1.3.0: retain-path `update` was marshalling domain
+    // DateTime.Utc values (from decoded updates + user-supplied colliding
+    // `updatedAt`) as DynamoDB Maps via `convertClassInstanceToMap`, because
+    // the path never called `serializeDateFields` on the merged `newItem`
+    // before `toAttributeMap`. Subsequent reads then failed with
+    // `deserializeDateFromDynamo: expected string for DateTime.Utc/string, got object`.
+    class RetainDoc extends Schema.Class<RetainDoc>("RetainDoc")({
+      id: Schema.String,
+      title: Schema.String,
+      occurredAt: Schema.DateTimeUtcFromString,
+      updatedAt: Schema.DateTimeUtcFromString,
+    }) {}
+
+    const RetainDocEntity = withConfig(
+      Entity.make({
+        model: RetainDoc,
+        entityType: "RetainDoc",
+        primaryKey: {
+          pk: { field: "pk", composite: ["id"] },
+          sk: { field: "sk", composite: [] },
+        },
+        timestamps: true,
+        versioned: { retain: true },
+      }),
+    )
+
+    it.effect("update (retain): domain date updates serialize to ISO strings, not Maps", () =>
+      Effect.gen(function* () {
+        // getItem returns the current state (library reads before transact-write in retain path).
+        mockGetItem.mockResolvedValueOnce({
+          Item: toAttributeMap({
+            pk: "$myapp#v1#retaindoc#r-1",
+            sk: "$myapp#v1#retaindoc",
+            id: "r-1",
+            title: "before",
+            occurredAt: "2024-01-01T00:00:00.000Z",
+            createdAt: "2024-01-01T00:00:00.000Z",
+            updatedAt: "2024-01-01T00:00:00.000Z",
+            __edd_e__: "RetainDoc",
+            version: 1,
+          }),
+        })
+        mockTransactWriteItems.mockResolvedValueOnce({})
+        const newOccurred = DateTime.makeUnsafe("2024-06-15T00:00:00.000Z")
+        const pinnedUpdatedAt = DateTime.makeUnsafe("2024-06-15T12:00:00.000Z")
+        yield* RetainDocEntity.update({ id: "r-1" })
+          .pipe(Entity.set({ occurredAt: newOccurred, updatedAt: pinnedUpdatedAt }))
+          .asEffect()
+
+        const putItem = mockTransactWriteItems.mock.calls[0]![0].TransactItems[0].Put.Item
+        // Neither field should be serialized as a DynamoDB Map (`M`).
+        expect(putItem.occurredAt).toEqual({ S: "2024-06-15T00:00:00.000Z" })
+        expect(putItem.updatedAt).toEqual({ S: "2024-06-15T12:00:00.000Z" })
+        // Sanity: the old `M` shape would have these keys; confirm absence.
+        expect(putItem.occurredAt.M).toBeUndefined()
+        expect(putItem.updatedAt.M).toBeUndefined()
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    it.effect(
+      "update (retain): library-generated updatedAt is a storage primitive, not a Map",
+      () =>
+        Effect.gen(function* () {
+          mockGetItem.mockResolvedValueOnce({
+            Item: toAttributeMap({
+              pk: "$myapp#v1#retaindoc#r-2",
+              sk: "$myapp#v1#retaindoc",
+              id: "r-2",
+              title: "before",
+              occurredAt: "2024-01-01T00:00:00.000Z",
+              createdAt: "2024-01-01T00:00:00.000Z",
+              updatedAt: "2024-01-01T00:00:00.000Z",
+              __edd_e__: "RetainDoc",
+              version: 1,
+            }),
+          })
+          mockTransactWriteItems.mockResolvedValueOnce({})
+          // No user-supplied updatedAt — library must generate.
+          yield* RetainDocEntity.update({ id: "r-2" })
+            .pipe(Entity.set({ title: "after" }))
+            .asEffect()
+          const putItem = mockTransactWriteItems.mock.calls[0]![0].TransactItems[0].Put.Item
+          expect(typeof putItem.updatedAt.S).toBe("string")
+          expect(putItem.updatedAt.M).toBeUndefined()
+        }).pipe(Effect.provide(TestLayer)),
+    )
   })
 })

--- a/packages/language-service/CHANGELOG.md
+++ b/packages/language-service/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @effect-dynamodb/language-service
 
+## 1.3.1
+
+### Patch Changes
+
+- Fix: `Entity.update` retain path (`versioned: { retain: true }`) marshalled domain `DateTime.Utc` values as DynamoDB Maps, corrupting writes and breaking subsequent reads.
+
+  **Regression introduced in 1.3.0.** The retain path built `newItem` by spreading `currentRaw` (storage primitives from DynamoDB) with `hydratedUpdates` (decoded via the new `fromSelf` variants, so date fields are domain `DateTime.Utc` instances), then called `toAttributeMap(newItem)` without a `serializeDateFields` pass. AWS SDK's `marshall` with `convertClassInstanceToMap: true` then stored the DateTime class as a Map:
+
+  ```json
+  "updatedAt": { "M": { "epochMilliseconds": { "N": "..." }, "~effect/time/DateTime": { "S": "..." }, "_tag": { "S": "Utc" } } }
+  ```
+
+  Subsequent reads failed with `deserializeDateFromDynamo: expected string for DateTime.Utc/string, got object`.
+
+  **Fix:** Pre-serialize `hydratedUpdates` to storage primitives before merging into `newItem`, mirroring what the non-retain path already does. The system-field block reads from the serialized map, so user-supplied colliding `updatedAt` values also land as storage primitives (not Maps). Affects any entity with `versioned: { retain: true }` that has model-declared date fields or uses the collision-aware timestamp pattern from 1.3.0.
+
+  Put, upsert, append, and non-retain update paths were already correct — only the retain path was missing the serialization step.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/language-service",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "TypeScript Language Service Plugin for effect-dynamodb — shows DynamoDB operations on hover",
   "license": "MIT",
   "author": "Justin Menga",


### PR DESCRIPTION
## Summary

Regression introduced in **1.3.0** reported from the field: `Entity.update` with `versioned: { retain: true }` was marshalling domain `DateTime.Utc` values as DynamoDB Maps, corrupting writes and breaking subsequent reads.

**Repro against 1.3.0** captures:

```json
"updatedAt": {
  "M": {
    "epochMilliseconds": { "N": "1718452800000" },
    "~effect/time/DateTime": { "S": "~effect/time/DateTime" },
    "_tag": { "S": "Utc" }
  }
}
```

Subsequent `get` fails with:

```
deserializeDateFromDynamo: expected string for DateTime.Utc/string, got object
```

## Root cause

1.3.0 switched runtime decode to `fromSelf` schemas to fix #19 — decoded date fields are now domain `DateTime.Utc` / `Date` instances instead of storage primitives. The retain path builds `newItem` by spreading `currentRaw` (storage, from `fromAttributeMap`) with `hydratedUpdates` (now domain), calls `toAttributeMap(newItem)` — AWS SDK's `marshall` with `convertClassInstanceToMap: true` stores the DateTime class as a Map.

Put / upsert / append / non-retain update paths all already called `serializeDateFields` before their respective marshals. **Only the retain path was missed** in the audit.

## Fix

Pre-serialize `hydratedUpdates` to storage primitives before merging into `newItem`, mirroring what the non-retain path does. The system-field block reads from the pre-serialized map, so user-supplied colliding `updatedAt` lands as a storage primitive (not a Map).

## Test plan

- [x] 947 unit tests pass (+2 regression: user-supplied domain date + library-generated updatedAt, both asserting `S`/`N` shape, not `M`)
- [x] 56 geo tests, 30 doctest, 59 language-service tests pass
- [x] `pnpm check` / `pnpm lint` clean
- [x] Changeset added; lockstep patch bump to **1.3.1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)