### PR TITLE
ci(release): grant label permissions + fetch full history/tags

### DIFF
--- a/.changeset/release-workflow-permissions-and-fetch.md
+++ b/.changeset/release-workflow-permissions-and-fetch.md
@@ -1,0 +1,4 @@
+---
+---
+
+Chore: add `issues: write` + `pull-requests: write` permissions and `fetch-depth: 0` + `fetch-tags: true` to the release workflow. The 1.3.1 release exposed two silent failures in the aggregate-tag step: (1) `gh label create` and `gh pr edit --add-label` were unauthorized — both were masked by `|| true` — so the `vX.Y.Z` label was never created and only the triggering PR got (mis-)labeled attempts; (2) `actions/checkout` defaults to a shallow clone with no tags, so `PREV_TAG` resolved to `<none>` and `git log HEAD` saw only the merge commit, missing any other PRs merged in the release window. No version change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,21 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      # Needed by the aggregate-tag step: `gh label create` (issues) and
+      # `gh pr edit --add-label` (pull-requests). Without these, both calls
+      # fail silently under `|| true` — the label never gets created and no
+      # PRs get tagged with the vX.Y.Z marker.
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags so the aggregate-tag step can resolve
+          # `PREV_TAG` and walk `git log PREV_TAG..HEAD` to find every PR
+          # merged in this release window. Default shallow clone yields one
+          # commit, so only the triggering merge gets labeled.
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: pnpm/action-setup@v5
         with:


### PR DESCRIPTION
## Summary

Two silent failures in the 1.3.1 release's aggregate-tag step, fixed here so the next release doesn't need manual intervention.

### 1. `gh label create` / `gh pr edit --add-label` were unauthorized

The workflow's `permissions:` block granted only `contents: write` and `id-token: write`. GitHub Actions' default is "no other permissions granted" when any permission is explicitly listed — so `issues: write` (needed to create labels) and `pull-requests: write` (needed to add labels to PRs) were denied. Both calls 403'd and were swallowed by the `|| true` guards. Symptom: `v1.3.1` label never got created and the workflow log showed:

```
Labeling PR #23 with v1.3.1
'v1.3.1' not found
```

### 2. Default shallow clone missed tags and commits

`actions/checkout@v6` defaults to `fetch-depth: 1` and does not fetch tags. In the aggregate-tag step:

- `git tag -l 'v[0-9]*.[0-9]*.[0-9]*'` returned empty → `PREV_TAG=<none>` despite `v1.3.0` existing on the remote
- Fell into the fallback branch: `RANGE="HEAD"`. On a depth-1 clone this visits only the triggering merge commit, so only PR #23 was attempted to be labeled — PR #22, also in the release window, was missed

`gh release create --generate-notes` talks to the GitHub API directly, so the release notes themselves were unaffected.

## Fix

- Add `issues: write` + `pull-requests: write` to `permissions:`
- Add `fetch-depth: 0` + `fetch-tags: true` to the checkout step

## Backfilled

- `v1.3.1` label created
- PRs #22 and #23 labeled with `v1.3.1`

## Test plan

- [x] `pnpm lint` / `pnpm check` clean
- [ ] Next release workflow run applies the label and walks the full commit range (verified post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)