### PR TITLE
docs(claude-md): require all agent work on a Git worktree

### DIFF
--- a/.changeset/agent-worktree-rule.md
+++ b/.changeset/agent-worktree-rule.md
@@ -1,0 +1,4 @@
+---
+---
+
+Chore: add `Agent Workflow` section to `CLAUDE.md` requiring all agent work to be performed on a Git worktree. No version change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,18 @@ pnpm lint:fix     # Auto-fix lint + format issues (biome check --write)
 
 All commands run from the repo root.
 
+## Agent Workflow
+
+**All agent work MUST be performed on a Git worktree** — never directly on the user's main checkout.
+
+Use `git worktree add ../effect-dynamodb-<branch-name> -b <branch-name>` (or reuse an existing worktree) so the user's working tree, current branch, and any uncommitted in-flight work remain untouched. This isolation matters because:
+
+- The user routinely has uncommitted WIP on the main checkout for parallel tracks (e.g. `fix/sparse-unique-constraints` alongside an unrelated fix). Agent branch switches on the shared checkout drag that WIP across branches, force repeated `git stash push/pop` juggling, and risk losing changes via stash conflicts or `.DS_Store`-style untracked collisions.
+- Worktrees give the agent an independent filesystem path for `pnpm install`, `pnpm test`, and editor state — no contention with whatever the user is running in the main checkout.
+- Cleanup is explicit: `git worktree remove <path>` when the PR is merged or abandoned, leaving no orphaned branches on the main checkout.
+
+If the `Agent` tool's `isolation: "worktree"` parameter is available for the task, prefer it. Otherwise, create the worktree explicitly as the first step of any code-modifying task.
+
 ## Coding Conventions
 
 ### Effect TS Patterns


### PR DESCRIPTION
## Summary

Adds a new **Agent Workflow** section to `CLAUDE.md` mandating that agent runs use a Git worktree (via `git worktree add …` or the `Agent` tool's `isolation: "worktree"` parameter) instead of the user's main checkout.

## Motivation

Near-miss observed on the #16 fix session: the user had uncommitted sparse-unique-constraints WIP on the main checkout, and an agent working a separate fix on the same checkout ended up juggling that WIP through multiple `git stash push/pop` cycles to clear the working tree. That sequence dragged WIP across branch switches, risked stash conflicts (a `.DS_Store` untracked-file collision nearly dropped the restore), and left orphaned stashes behind.

Worktrees eliminate the contention entirely — the agent gets its own filesystem path, branch, and index, so the user's in-flight work is never touched.

## Scope

Docs-only. One new H2 section inserted between **Commands** and **Coding Conventions** — no code, no workflow, no tests changed.

## Release

Empty chore changeset — no version change.

## Test plan

- [x] `CLAUDE.md` renders cleanly
- [ ] CI "Enforce changeset-version consumption" passes (empty chore changeset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)