### PR TITLE
indexPolicy v1.7.1 — per-half eval gate + per-key cascade + set/remove asymmetry (closes #41)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -609,25 +609,22 @@ SK: ${schema}#{version}#{entityType}#deleted#{isoTimestamp}
 
 ### Policy-Aware GSI Composition (update & append)
 
-**Problem.** GSI composite attributes can be owned by different writers ("hybrid GSIs"). A device-ingest writer owns `timestamp` + `alertState`; an enrichment writer owns `accountId`. A GSI with `pk.composite = [accountId, alertState]` and `sk.composite = [timestamp]` is touched by *every* ingest event (via `timestamp`), but the ingest writer can't supply `accountId` without an extra read. The library needs a way to express what an *update payload* means for the GSI's stored keys when only some composites are in scope.
+**Problem.** GSI composite attributes can be owned by different writers ("hybrid GSIs"). A device-ingest writer owns `alertState` + `timestamp`; an enrichment writer owns `accountId`. A GSI with `pk.composite = [accountId]` and `sk.composite = [alertState, timestamp]` is touched by *every* ingest event (via `timestamp`), but the ingest writer can't supply `accountId` without an extra read. The library needs a way to express what an *update payload* means for the GSI's stored keys when only some composites are in scope — *and* must not let one writer's update silently corrupt the half another writer owns.
 
-**Two drop triggers, two policy values, one structural composition rule.** v3 has exactly two drop mechanisms — both predictable, both tied to clear caller intent — driving the lifetime of a GSI's `gsiNpk`/`gsiNsk` pair:
+**Mental model — three contracts.** v1.7.1 expresses GSI maintenance as three independent contracts, all per-half:
 
-| Trigger | Granularity | Where it lives | Intent |
-|---|---|---|---|
-| `Entity.remove([attr])` cascade | per-attribute | per-call, explicit | "this attribute no longer applies — cascade drop everywhere it appears" |
-| `'sparse'` policy + whole-half-empty | per-half | per-GSI declaration, implicit | "this index entry requires at least the leading composite — fall out otherwise" |
+> `'preserve'` is a contract with **other writers** ("don't disturb my key when you fire"); `'sparse'` is a contract with **yourself as the half's owner** ("drop my key if I touch this half but can't compose it"); `Entity.remove([attr])` is the explicit signal that a composite is gone — the library REMOVEs the half(s) containing the cleared attribute.
 
-Both are visible at design or call time. The v1.6 footgun wasn't *"implicit drops are bad"* — it was *"per-composite implicit drops fire across writers that didn't intend to touch the GSI."* v3 keeps the implicit drop pattern but narrows its trigger to **whole-half-empty**, which only writers that genuinely intended to clear that half ever produce. Multi-writer entities stop leaking; single-writer-per-half consumers get sparse semantics that fire exactly when intended.
+Per-half is the unifying property: declaration (`{ pk, sk }`), evaluation gate (per-half "touched?"), outcome (per-half SET / noop / REMOVE), and cascade (per-half via `removedSet`). There is no GSI-wide cascade left in the model — the v1.6 holdover that bug-1 of v1.7.0 inherited is gone.
 
-**API — per-half policy declaration.** Each GSI may declare an `indexPolicy`:
+**API — per-half policy declaration (unchanged from v1.7.0).** Each GSI may declare an `indexPolicy`:
 
 ```ts
 indexes: {
   byAccountAlert: {
     name: "gsi6",
-    pk: { field: "gsi6pk", composite: ["accountId", "alertState"] },
-    sk: { field: "gsi6sk", composite: ["timestamp"] },
+    pk: { field: "gsi6pk", composite: ["accountId"] },
+    sk: { field: "gsi6sk", composite: ["alertState", "timestamp"] },
     indexPolicy: { pk: "preserve", sk: "sparse" },
   },
 }
@@ -636,79 +633,123 @@ indexes: {
 - `indexPolicy: { pk: 'sparse' | 'preserve', sk: 'sparse' | 'preserve' }`. Both halves default to `'preserve'` if `indexPolicy` is omitted entirely or either half is unspecified.
 - The standard composition path has no per-composite information to discriminate within a half (it has only the merged payload, no read-before-write), so per-attribute policy callbacks were removed. A half is a single concatenated string; per-attribute mixing within a half has no coherent semantic.
 
-**Two-way payload classification.** v3 collapses the v1.6 three-way classification (present / explicit-clear / omitted) to two states: **present** or **absent**. `attr: null`, `attr: undefined`, and "key omitted from payload" all mean "absent" for GSI-composition purposes.
+**Two-way payload classification.** v1.7.x collapses the v1.6 three-way classification (present / explicit-clear / omitted) to two states: **present** or **absent**. `attr: null`, `attr: undefined`, and "key omitted from payload" all mean "absent" for GSI-composition purposes.
 
 | Payload state | What library does for GSI composition |
 |---|---|
 | `attr: <value>` | Use the value as a slot in the composed half |
 | `attr: null` *or* `attr: undefined` *or* (key omitted) | Treat as **absent** — the composition is built from the leading prefix of present values |
 
-`set({ attr: null })` is no longer a separate "drop signal" — it still REMOVEs the attribute from the item (the data-attribute REMOVE clause), but it does not separately cascade-drop the GSI keys. Drop-via-cascade goes through `Entity.remove([attr])` instead. Drop-via-implicit-sparse fires only when the whole half's composites are all absent.
+`set({ attr: null })` is no longer a separate "drop signal" — it still REMOVEs the attribute from the item (the data-attribute REMOVE clause), but it does not separately cascade-drop the GSI keys. Drop-via-cascade goes through `Entity.remove([attr])` instead.
 
-**Structural composition — longest valid leading prefix.** For each GSI half (PK and SK independently), walk the composite list left-to-right and build the longest valid leading prefix from values present in the merged record (`{ ...storedKeyAttrs, ...payload }`). The rule is **identical for PK and SK** — the v1.6 PK-clear-degrades-to-sparse asymmetry is gone. The composed half is whatever's reachable from the leading run of present composites:
+**Per-half evaluation gate (NEW in v1.7.1 — closes the multi-writer leak).** Before the structural rule even runs, each half is checked for whether the writer touched it. **If a half is untouched, it is skipped entirely — no SET, no REMOVE, no policy fires.** A half is "touched" iff at least one of its composite names appears in the update payload (regardless of value, including `undefined`) OR appears in `Entity.remove([...])`:
+
+```ts
+const halfTouched =
+  halfComposites.some((c) => c in updatePayload) ||
+  halfComposites.some((c) => removedSet?.has(c))
+if (!halfTouched) continue  // leave this half's key attribute alone
+```
+
+Why: `'sparse'`'s contract is *with the half's owner*. If the writer doesn't touch any of the half's composites, they aren't claiming ownership of this half on this call — sparse shouldn't fire. The writer-scope concept #38 was reaching for falls out of payload contents naturally.
+
+End-to-end consequences for the canonical multi-writer scenarios:
+
+- **Stamps** writing only `{ published: {...} }` → no half is touched → both halves left alone. (v1.7.0 bug-3: stamps blew away the sparse GSI half.)
+- **Enrichment** writing `{ accountId: 'X' }` → pk touched, sk untouched.
+- **Telemetry** writing `{ alertState: 'active', timestamp: T }` → pk untouched, sk touched.
+
+**Structural composition — longest valid leading prefix.** For each *touched* GSI half (PK and SK independently), walk the composite list left-to-right and build the longest valid leading prefix from values present in the merged record (`{ ...storedKeyAttrs, ...payload }`). The rule is **identical for PK and SK** — the v1.6 PK-clear-degrades-to-sparse asymmetry is gone. The composed half is whatever's reachable from the leading run of present composites:
 
 | Composite state | Result for that half |
 |---|---|
 | All composites present | Recompose the half with all values |
 | Trailing composites absent (`[A, B, _, _]`) | Truncate to the leading prefix `[A, B]` |
-| Whole half empty (no leading composites available) | Empty prefix → policy decides (see "Whole-half-empty" below) |
-| Hole pattern (`[A, _, C]`) | Policy decides between truncate and throw (see "Hole detection" below) |
+| Whole half empty (no leading composites available) | Empty prefix → can't compose → see "Per-half outcome" below |
+| Hole pattern (`[A, _, C]`) | Leading prefix is `[A]`, but a present trailing composite would be silently dropped → treated as can't-compose → see "Per-half outcome" below |
 
-Truncation on PK is the same hierarchical demotion as truncation on SK — an item with `pk.composite = ['accountId', 'fleetId']` and `fleetId` cleared composes a partition key of `account#A` and stays queryable at the account scope. The "partition migration is dangerous" objection that v1.6 used to justify the PK asymmetry is addressed differently in v3: clear-via-null is no longer a clear signal at all, so the case the v1.6 asymmetry was protecting against (consumer confusion about `set({pk: null})` semantics) is now closed at the type level (see EDD-9025 below).
+Truncation on PK is the same hierarchical demotion as truncation on SK — an item with `pk.composite = ['accountId', 'fleetId']` and `fleetId` cleared composes a partition key of `account#A` and stays queryable at the account scope.
 
-**Hole detection (policy-aware).** A "hole" is a composite at position `i` that is absent while a composite at position `j > i` is present (e.g. `[A, _, C]`). Composed keys can't carry holes meaningfully — `acc#A#child#Y` with `parent` cleared would compose to a syntactically invalid prefix that no `begins_with` query would match. Behavior depends on the half's policy:
+#### Per-half outcome (unified can't-compose rule — NEW in v1.7.1)
 
-| Policy | Hole pattern (`[A, _, C]`) | Hole pattern starting at position 0 (`[_, C]`) |
+When the structural rule **can compose** (leading prefix is non-empty and there's no information loss), the half SETs its key — full or truncated. When the structural rule **can't compose** (empty leading prefix, OR a hole pattern that would lose trailing data), the per-half outcome is decided by policy + cascade:
+
+| Outcome for this half's key attribute | Conditions |
+|---|---|
+| **noop** (leave key alone) | No composite of this half is in the payload AND none in `Entity.remove([...])` (per-half evaluation gate) |
+| **SET full** | Half touched + all composites have values supplied in payload (or available from primary key) |
+| **SET truncated** to leading prefix | Half touched + some leading composites have values, trailing absent, no hole |
+| **REMOVE** this half's key | Half touched + can't compose (empty leading prefix OR hole pattern), AND policy is `'sparse'` OR a composite is in `Entity.remove([...])` (cascade override) |
+| **noop** (stored key may go stale) | Half touched + can't compose, policy is `'preserve'`, AND no composite is in `Entity.remove` |
+
+The roll-up is **per-key** — each half's outcome applies to its own key attribute only. PK dropping doesn't drop SK; SK dropping doesn't drop PK. The item may be invisible in the GSI during a single-half-dropped period (DDB needs both for projection — the projection invariant for readers, not a library behavior), but the surviving half's value persists. When the missing half is later composed again (e.g. telemetry writes `{ alertState, timestamp }` after a clear), the item rejoins the GSI under the still-current other half *without that other writer needing to re-fire* — the v1.7.0 multi-writer bug (#41 bug-1) is closed.
+
+**Cascade override under preserve.** If a half is touched via `removedSet` AND the structural rule would no-op (preserve + can't-compose), the outcome is **REMOVE** instead of noop. Rationale: the consumer's explicit signal trumps stale-data preservation. `Entity.remove(["alertState"])` means "alertState is gone" — preserving the stored key with a value derived from the now-removed composite would lie to readers.
+
+**Hole patterns collapse into can't-compose.** A "hole" (composite at position `i` absent while a composite at position `j > i` is present, e.g. `[A, _, C]`) was a separate v1.7.0 outcome (truncate-or-throw). Under v1.7.1, holes follow the unified rule above: drop under sparse (or cascade), noop under preserve (no cascade). The previous "truncate to `[A]` and silently discard `C`" sparse behavior is gone — silent data loss is a worse failure mode than dropping the half. The previous "throw EDD-9024 under preserve" is also gone — see "EDD-9024 deprecation" below.
+
+#### The set/remove asymmetry (worth memorising)
+
+> `set` provides values to compose with. `remove` invalidates a composite without providing a replacement. The library has no read-before-write — so `remove` without surrounding `set` context can't truncate (it doesn't know what to truncate *to*) and instead REMOVEs the half's key entirely.
+
+```ts
+// Truncation works — surviving composites supplied via set, leaf invalidated via remove
+update(key).set({ region, country, city }).remove(["site"])
+// → SET gsi1sk truncated to "region#APAC#country#AU#city#Sydney"
+// (site is in removedSet → cascade override fires, but the surviving leading prefix
+// is non-empty → the structural rule composes the prefix and SETs.)
+
+// REMOVE — surviving composites not supplied
+update(key).remove(["site"])
+// → REMOVE gsi1sk entirely (library has no way to compose [region, country, city] —
+// no values supplied, and the library does not read-before-write to discover them).
+```
+
+If you want to demote (truncate) hierarchically, you must `set` the surviving composites in the same call — the `remove` invalidates the leaf without providing a replacement, but the surviving prefix is non-empty so the structural rule composes it.
+
+#### How to drop a half (call-site syntax)
+
+| Composite is... | Method 1: `Entity.remove` (always works) | Method 2: `set` with `undefined` |
 |---|---|---|
-| `'sparse'` | Truncate to leading prefix `[A]`; trailing values ignored. Consistent with sparse's "compose what you can" intent. | Leading prefix is empty → collapses to whole-half-empty → drop both halves (consistent with sparse-on-empty). |
-| `'preserve'` | Throw `CompositeKeyHoleError` (EDD-9024) at write time. Consistent with preserve's "don't move things on me — surface ambiguity loudly" intent. | Same — throw EDD-9024. |
+| **Required** in model (e.g. `Schema.String`) | `update(key).remove(["composite"])` | not available — TS rejects `undefined` for non-optional fields under `exactOptionalPropertyTypes` (the v1.7.0 NullishOr revert ensures payload types match model declarations) |
+| **Optional** in model (`Schema.optional(...)`) | `update(key).remove(["composite"])` | `update(key).set({ composite: undefined })` |
 
-The error names the GSI, the absent composite at position `i`, and the still-present trailing composite at `j`, so callers can locate the offending payload.
+Naming any one composite of a half is enough — `Entity.remove` doesn't require enumerating all of them. `null` is **never** valid for a composite (EDD-9025 rejects nullable composites at make-time).
 
-**Whole-half-empty.** When a half has no composites in scope at all (every composite is absent under the structural rule), policy decides:
+**`Entity.remove([attr])` cascade is per-half (NEW in v1.7.1).** When an update's REMOVE list contains a composite attribute, the cascade applies only to the half(s) containing that attribute. Other halves follow the per-half evaluation gate (untouched → noop). v1.7.0 issued a GSI-wide REMOVE (both `gsiNpk` AND `gsiNsk`) for any composite in the cascade set — that GSI-wide blast radius is gone in v1.7.1. The cascade still REMOVEs the affected half's key; if the surrounding `set` provides values for the half's other composites, the structural rule may still compose a truncated prefix (see set/remove asymmetry).
 
-- `'sparse'` → REMOVE both `gsiNpk` and `gsiNsk` (the item drops out of the GSI). This is the *implicit drop trigger*.
-- `'preserve'` → no-op (no SET, no REMOVE — leave the stored values intact). The half stays whatever it was before the update.
+**Decision algorithm (per GSI).** Given merged record `M = { ...storedKeyAttrs, ...payload }` (treating `null`/`undefined` payload values as absent) and `removedSet` (composites named in `Entity.remove([...])`):
 
-This is the *only* case in v3 where policy alone changes behavior. Note the symmetry: a sparse policy on a single half drops both `gsiNpk` and `gsiNsk` together — there's no notion of writing only one half of a key pair.
+For each half (PK then SK), independently:
 
-**`Entity.remove([attr])` cascade — unchanged.** When an update's REMOVE list contains a composite attribute of any GSI, that whole GSI is dropped (REMOVE both `gsiNpk` and `gsiNsk`) regardless of `indexPolicy`. This is the *explicit drop trigger*. `remove(["tenantId"])` means "the item no longer belongs in any index containing `tenantId`."
+1. **Evaluation gate.** If no composite of this half is in `payload` AND no composite of this half is in `removedSet` → `noop` (skip — leave the stored key untouched). Otherwise the half is **touched**, continue.
+2. **Structural rule.** Walk the half's composite list left-to-right. Find the longest leading prefix of present values in `M`.
+3. **Classify the outcome:**
+   - **Compose succeeded** (leading prefix is non-empty AND no hole — i.e. all absent composites are at trailing positions): SET this half's key from the leading prefix. Done.
+   - **Compose failed** (empty leading prefix OR hole pattern):
+     - Policy is `'sparse'` → `REMOVE` this half's key.
+     - Policy is `'preserve'` AND any composite of this half is in `removedSet` → `REMOVE` this half's key (cascade override).
+     - Policy is `'preserve'` AND no composite of this half is in `removedSet` → `noop` (preserve preservation; stored key may be stale).
 
-**Decision algorithm (per touched GSI).** Given merged record `M = { ...storedKeyAttrs, ...payload }` (treating `null`/`undefined` payload values as absent) and the cascade-remove set `R` (attrs named in `Entity.remove([...])`):
-
-1. **Cascade override.** If any composite of this GSI is in `R`, REMOVE both key fields. Done.
-2. **For each half (PK then SK), independently:**
-   - Walk the half's composite list left-to-right. Find the longest prefix of present values.
-   - If the prefix covers every composite → SET the half from the full composition.
-   - If the prefix is shorter than the full composite list AND no trailing composite is present → trailing-truncate. SET the half from the leading prefix (or, if the prefix is empty, fall through to whole-half-empty handling below).
-   - If the prefix is shorter than the full composite list AND a trailing composite is present (hole pattern) → consult policy. `'sparse'` truncates to the leading prefix; `'preserve'` throws `CompositeKeyHoleError` (EDD-9024).
-3. **Whole-half-empty handling.** If a half ended up with no composites composable (empty leading prefix and no trailing values either) → consult that half's policy. `'sparse'` REMOVEs both `gsiNpk` and `gsiNsk` (whole GSI drop). `'preserve'` is a no-op for that half.
-4. **Roll up.** The final outcome per GSI is one of:
-   - REMOVE both keys (cascade or sparse-on-empty),
-   - SET both keys (both halves have something composable),
-   - SET only one key (the other half no-ops under preserve-on-empty), or
-   - No writes at all (both halves preserve, both empty).
-
-**Evaluation gate.** Determines when a GSI is evaluated on update/append:
-
-- **GSI declares `indexPolicy`** → evaluated on **every** update/append. The declaration is a statement about the GSI's membership invariant; the library applies it unconditionally so the implicit-drop trigger fires consistently.
-- **GSI has no `indexPolicy`** → evaluated only when at least one of its composites is in the update payload, or when `Entity.remove([attr])` names one of its composites. Preserves conventional DynamoDB partial-update semantics for entities that haven't opted into policy-driven indexing.
+The two halves' outcomes are emitted independently — each affects only its own key attribute. There is no GSI-wide cascade. There is no longer a `'hole-throw'` outcome (EDD-9024 deprecated — see below).
 
 **`put()` semantics (unchanged).** `put()` does not consult `indexPolicy`. It writes a complete item from scratch — any missing composite means "this item is not in that GSI." The existing `tryComposeIndexKeys` path (omit GSI keys when any composite is absent) is preserved as-is. `indexPolicy` exists specifically to resolve the update/append ambiguity, not the put case.
 
-**`.append()` semantics (time-series) — same composer.** v3 unifies append with update. `.append(input)` calls the same composer as `.update(...).set(...)`, with `appendInput` as the payload. Composites outside `appendInput` are simply absent under the structural rule. There is no per-call policy filter wrapper (the v1.6 wrapper that filtered policy returns to `appendInput` members is gone — under v3's per-half model, there's nothing to filter).
+**`.append()` semantics (time-series) — same composer.** v1.7.x unifies append with update. `.append(input)` calls the same composer as `.update(...).set(...)`, with `appendInput` as the payload. Composites outside `appendInput` are simply absent under the structural rule, and the per-half evaluation gate applies — halves whose composites are entirely outside `appendInput` are untouched and follow the noop branch.
 
-For sparse GSIs whose composites are entirely outside `appendInput`, the relevant half empties → drop. This matches the consumer-side multi-writer recommendation: sparse GSIs should be single-writer-per-half by design. If `.append()` doesn't write any of a sparse GSI's composites, the GSI is effectively not in append's scope, and either (a) the half should be declared `'preserve'`, or (b) the GSI should drop on the append because the writer lacks the data to populate it.
+For sparse GSIs whose composites are entirely outside `appendInput`, the half is untouched → noop (under v1.7.1). Sparse only fires when the writer touches the half but can't compose it. This matches the consumer-side multi-writer recommendation: sparse GSIs should be single-writer-per-half by design.
 
-**EDD-9025 — composite attribute schemas must not include `null`.** At `Entity.make()` time, the library walks every composite across `primaryKey`, every entry in `indexes`, and every entry in `unique` constraints. For each composite attribute it inspects the field's Schema AST and throws `CompositeNullableError` (EDD-9025) if `null` is reachable in the type union (`Schema.NullOr`, `Schema.NullishOr`, `Schema.Union` with a Null branch, custom-named field via `DynamoModel.configure({ field })` rename that resolves to a nullable schema, etc.).
+**EDD-9024 (`CompositeKeyHoleError`) deprecation — runtime-irrelevant in v1.7.1.** The class is kept exported for back-compat but no longer thrown at runtime. The original v1.7.0 throw protected against an `[A, _, C]` shape under preserve — but the type system already catches the only "wrong" case the throw was guarding (required composites can't be omitted under `exactOptionalPropertyTypes` since v1.7.0 reverted the NullishOr widening; the only legitimate runtime hole is "optional leading composite absent + present trailing composite," which is a normal write the consumer expressly chose). Under v1.7.1 the hole pattern collapses into the unified can't-compose rule (drop under sparse, noop-or-cascade-override under preserve). See `Errors.ts` for the deprecation note on the class.
+
+**EDD-9025 — composite attribute schemas must not include `null` (unchanged from v1.7.0).** At `Entity.make()` time, the library walks every composite across `primaryKey`, every entry in `indexes`, and every entry in `unique` constraints. For each composite attribute it inspects the field's Schema AST and throws `CompositeNullableError` (EDD-9025) if `null` is reachable in the type union (`Schema.NullOr`, `Schema.NullishOr`, `Schema.Union` with a Null branch, custom-named field via `DynamoModel.configure({ field })` rename that resolves to a nullable schema, etc.).
 
 The semantic justification: composites participate in string composition (`acc#X#alert#Y`); null is not a meaningful slot value, only present-with-value or absent. Allowing `Schema.NullOr` on a composite would let `set({ composite: null })` typecheck and then immediately blow up at runtime (or worse, silently produce a key with the literal string `"null"` as a slot). EDD-9025 catches this at make-time.
 
-The sparse pattern is still expressible — use `Schema.optional(...)`, which produces `T | undefined` (without `null`). `undefined` is "absent" under the v3 two-way classification.
+The sparse pattern is still expressible — use `Schema.optional(...)`, which produces `T | undefined` (without `null`). `undefined` is "absent" under the two-way classification.
 
-**Footgun closed at the type level — `set({ composite: null })` no longer compiles.** Two changes work together:
+**Footgun closed at the type level — `set({ composite: null })` no longer compiles.** Two changes work together (both shipped in v1.7.0, kept in v1.7.1):
 
-1. v3 reverts the v1.6 update-payload type widening. The v1.6 schemas wrapped each update field in `Schema.optional(Schema.NullishOr(field))` to support the v1.6 three-way classification. v3 drops the `NullishOr` wrap — update payload field types match the model's declarations exactly (just wrapped in `Schema.optional` so the key can be omitted entirely).
+1. v1.7.x reverts the v1.6 update-payload type widening. The v1.6 schemas wrapped each update field in `Schema.optional(Schema.NullishOr(field))` to support the v1.6 three-way classification. v1.7.x drops the `NullishOr` wrap — update payload field types match the model's declarations exactly (just wrapped in `Schema.optional` so the key can be omitted entirely).
 2. EDD-9025 prevents the model from declaring a composite as nullable in the first place.
 
 Together: `set({ composite: null })` for a composite is a TypeScript error two ways — the model can't widen the composite to include `null`, and the update payload type isn't widened beyond the model. The stale-GSI-keys-via-`set-null` concern dissolves entirely at the type level. No runtime path is reachable from typed callers.
@@ -720,33 +761,31 @@ Together: `set({ composite: null })` for a composite is a TypeScript error two w
 // or an SK-truncate signal under preserve.
 entity.update(key).set({ alertState: null }).asEffect()
 
-// v3 — explicit per-attribute drop (per call) — atomic remove + GSI cascade.
+// v1.7.x — explicit per-attribute drop (per call) — atomic remove + per-half cascade.
 entity.update(key).remove(['alertState']).asEffect()
 
-// v3 — for "drop when this index has nothing to compose" intent,
+// v1.7.x — for "drop when this index has nothing to compose" intent,
 // declare the GSI half as 'sparse' once at the index definition.
 //   indexPolicy: { pk: 'sparse', sk: 'preserve' }
-// Then any update that doesn't supply the PK half's composites drops the GSI
-// implicitly per the whole-half-empty rule.
+// Then any update that touches the PK half but can't compose it drops the GSI
+// implicitly per the per-half can't-compose rule.
 ```
 
-**Decision table (worked).** GSI with `pk.composite = [A]`, `sk.composite = [B, C]`, casing `lowercase`. "absent" means the value isn't reachable in the merged record (key omitted, or `null`/`undefined`).
+**Final per-half decision table (worked).** GSI with `pk.composite = [accountId]`, `sk.composite = [alertState, timestamp]`, `indexPolicy = { pk: 'preserve', sk: 'sparse' }`. Item exists with `accountId = "acme"`, `alertState = "active"`, `timestamp = T1`. Both GSI keys composed.
 
-| Policy | Payload (merged with stored key attrs) | Result |
-|---|---|---|
-| no policy *(both preserve)* | `{A, B, C}` (all present) | SET both halves |
-| no policy | `{A}`, B+C absent | SET pk; sk no-op (preserve + empty SK half = no-op) |
-| no policy | `{B, C}`, A absent | pk no-op; SET sk |
-| no policy | `{A, B}`, C trailing-absent | SET pk; SET sk truncated to `[B]` |
-| no policy | `{A, C}`, B absent (hole) | **THROW EDD-9024** (preserve + hole) |
-| `{ pk: 'sparse', sk: 'preserve' }` | `{B, C}`, A absent | REMOVE both halves (PK whole-half-empty + sparse) |
-| `{ pk: 'preserve', sk: 'sparse' }` | `{A}`, B+C absent | REMOVE both halves (SK whole-half-empty + sparse) |
-| `{ pk: 'preserve', sk: 'sparse' }` | `{A, B}`, C trailing-absent | SET pk; SET sk truncated to `[B]` (sparse + non-empty leading = compose what you can) |
-| `{ pk: 'preserve', sk: 'sparse' }` | `{A, C}`, B absent (hole) | SET pk; SET sk truncated to empty (sparse hole = truncate) |
-| `{ pk: 'sparse', sk: 'sparse' }` | `{}`, A+B+C all absent | REMOVE both halves (both halves whole-half-empty + sparse) |
-| any policy | `Entity.remove(["A"])` | REMOVE both halves (cascade overrides policy) |
+| Writer | Payload | pk outcome | sk outcome | Item state in GSI |
+|---|---|---|---|---|
+| Enrichment | `{ accountId: "newAcct" }` | touched, SET full → new `account#newAcct` | untouched, **noop** | Visible under new account, sk position unchanged |
+| Telemetry (active alert) | `{ alertState: "active", timestamp: T2 }` | untouched, **noop** | touched, SET full → fresh `alert#active#ts#T2` | Visible under last accountId, fresh sk |
+| Telemetry (no alert) | `{ timestamp: T2 }` (alertState omitted, optional) | untouched, **noop** | touched (timestamp), can't compose (hole) + sparse → REMOVE gsi1sk | Invisible (DDB needs both); gsi1pk preserved |
+| Telemetry (explicit clear) | `{ alertState: undefined, timestamp: T2 }` | untouched, **noop** | touched, can't compose + sparse → REMOVE gsi1sk | Same — invisible, gsi1pk preserved |
+| Stamp (unrelated write) | `{ published: {...} }` | untouched, **noop** | untouched, **noop** | Unchanged — both halves preserved (the v1.7.0 leak is closed) |
+| Telemetry (rejoin) | `{ alertState: "active", timestamp: T3 }` | untouched, **noop** | touched, SET full → `alert#active#ts#T3` | Re-visible under preserved gsi1pk + new gsi1sk; **no enrichment re-fire needed** |
+| Hierarchical demote (different entity, multi-composite SK) | `update(key).set({ region, country, city }).remove(["site"])` | n/a | touched (set + removedSet), trailing-absent → SET truncated to `region#APAC#country#AU#city#Sydney` | Re-indexed at city scope |
+| Explicit drop | `update(key).remove(["alertState"])` | untouched, **noop** | touched (alertState in removedSet), can't compose → REMOVE gsi1sk | Invisible; gsi1pk preserved (per-half cascade — no longer GSI-wide) |
+| Cascade override under preserve | `{ pk: "preserve" }`, `update(key).remove(["accountId"])` (no surviving pk composites) | touched (cascade), can't compose + preserve + cascade override → REMOVE gsi1pk | untouched, **noop** | gsi1pk REMOVE'd via cascade override |
 
-**Multi-writer entity design rule.** Each GSI half should be entirely owned by a single writer's domain. The library does not paper over cross-writer composite ownership — that's a consumer-side modeling discipline. With v3's per-half policy and the structural composition rule, a writer that doesn't own a GSI's composites simply doesn't supply them, and the half no-ops under `preserve` or drops under `sparse` per its declaration. There is no per-composite leakage across writers like in v1.6.
+**Multi-writer entity design rule.** Each GSI half should be entirely owned by a single writer's domain. The library does not paper over cross-writer composite ownership — that's a consumer-side modeling discipline. With v1.7.1's per-half evaluation gate and the per-half outcome rule, a writer that doesn't touch a GSI's composites simply doesn't supply them, and the half no-ops regardless of policy. There is no per-composite leakage across writers like in v1.6, and no GSI-wide blast radius like in v1.7.0.
 
 ### Sparse Map Storage (`storedAs: DynamoModel.SparseMap()`)
 
@@ -997,7 +1036,7 @@ Hierarchical truncation — leaf composites being *refinements* that should *dem
 | Order grouping | `[customerId, orderId]` | After clearing `orderId`, group-by-customer queries still work |
 | Multi-tenant fleet | `[accountId, fleetId]` (PK) | Vehicle leaves a fleet but stays queryable at account scope |
 
-Under v3 (§7), this is the default behavior of the structural composition rule — there is no separate "pruning" code path. A trailing-absent composite simply truncates the half to its leading prefix, regardless of which half (PK or SK) and regardless of policy. PK and SK behave identically. The only asymmetry left is the policy-controlled handling of the *empty* leading prefix (`'sparse'` drops, `'preserve'` no-ops) and the *hole* pattern (`'sparse'` truncates, `'preserve'` throws EDD-9024).
+Under v1.7.1 (§7), trailing-absent truncation is part of the structural composition rule — there is no separate "pruning" code path. A trailing-absent composite simply truncates the half to its leading prefix, regardless of which half (PK or SK). PK and SK behave identically. The set/remove asymmetry (§7) governs how to invoke truncation: `set` provides surviving composites; `remove` invalidates the leaf — both must appear in the same call for truncation to happen, otherwise `remove` alone REMOVEs the half (no read-before-write).
 
 **Worked example — geographic asset hierarchy (PK + SK, both preserve).**
 
@@ -1015,40 +1054,49 @@ indexes: {
 // Stored: gsi1pk = "$app#v1#asset#region_americas",
 //         gsi1sk = "$app#v1#asset#country_us#city_sf#site_datacenter-1"
 
-// Asset leaves the datacenter — explicit per-attribute drop.
-// Use Entity.remove for the per-attribute, atomic remove + GSI cascade.
-yield* db.entities.Assets.update(key).remove(['site'])
-// REMOVE the whole gsi1pk/gsi1sk pair (cascade — `site` is a composite of gsi1).
+// Asset leaves the datacenter — *demote* (truncate, stay queryable at city scope).
+// Supply the surviving composites via `set` AND invalidate the leaf via `remove`
+// in the same call — the structural rule then composes the truncated leading prefix.
+yield* db.entities.Assets.update(key).set({ country: 'us', city: 'sf' }).remove(['site'])
+// gsi1pk unchanged (region untouched — pk half is not in the payload).
+// gsi1sk truncated to "$app#v1#asset#country_us#city_sf"
+// begins_with(gsi1sk, "$app#v1#asset#country_us#city_sf") still finds this asset.
 
-// Or, for a *demote-don't-evict* on `site`: omit it from the payload (or set
-// it to undefined). Under the structural rule, the SK half truncates to the
-// leading prefix.
-yield* db.entities.Assets.update(key).set({ city: 'la' })   // implicit: site omitted
-// gsi1pk unchanged (region still in stored attrs).
-// gsi1sk truncated to "$app#v1#asset#country_us#city_la"
-// begins_with(gsi1sk, "$app#v1#asset#country_us#city_la") still finds this asset.
+// Asset leaves the datacenter — *evict* (drop the whole half).
+// Without surviving composites in `set`, the library can't compose anything;
+// the cascade fires and REMOVEs gsi1sk entirely.
+yield* db.entities.Assets.update(key).remove(['site'])
+// pk untouched, noop. sk touched via removedSet, can't-compose (no surviving values),
+// preserve + removedSet → cascade override → REMOVE gsi1sk.
+// gsi1pk preserved; the per-half cascade no longer drops gsi1pk.
 
 // PK-side demotion — multi-composite PK example.
 //   pk.composite = ['accountId', 'fleetId']  (preserve on both halves)
 // Vehicle leaves a fleet but stays under the account scope:
-yield* db.entities.Vehicles.update(key).set({ accountId: 'acct-1' })
+yield* db.entities.Vehicles.update(key).set({ accountId: 'acct-1' }).remove(['fleetId'])
 // PK truncated to "$app#v1#vehicle#accountid_acct-1" — vehicle still queryable
 // by account, just not by the prior fleet. Same hierarchical demotion as SK,
-// applied symmetrically to PK under v3.
+// applied symmetrically to PK.
 
-// Decommission — drop from the index entirely.
-yield* db.entities.Assets.update(key).remove(['country'])
-// REMOVE gsi1pk, gsi1sk — cascade overrides any truncation.
+// Decommission — drop from the index entirely (sparse policy on the relevant half),
+// or use Entity.remove on every composite of the half to force the cascade.
+yield* db.entities.Assets.update(key).remove(['country', 'city', 'site'])
+// sk touched (multiple composites in removedSet), no surviving composites → REMOVE gsi1sk.
+// pk untouched (no pk composites in removedSet), noop. Item invisible in the GSI
+// (DDB projection rule: needs both keys), gsi1pk value retained for future rejoin.
 
-// Hole pattern under preserve — throws EDD-9024:
-// yield* db.entities.Assets.update(key).remove(['city']).set({ site: 'datacenter-2' })
-// → throws: composite "city" at sk position 1 was cleared, but composite
-//   "site" at position 2 is still present.
+// Hole pattern under preserve — collapses into can't-compose, no throw, no SET.
+// `city` invalidated, `site` supplied → would compose `[country_us, _, site_dc2]` (hole).
+// Per v1.7.1: hole = can't-compose; preserve + removedSet contains city → cascade
+// override → REMOVE gsi1sk.
+// yield* db.entities.Assets.update(key).remove(['city']).set({ country: 'us', site: 'datacenter-2' })
+// → REMOVE gsi1sk. (v1.7.0 would have thrown EDD-9024; that throw is now deprecated.)
 
-// Hole pattern under sparse — truncates to leading prefix:
+// Hole pattern under sparse — same outcome, REMOVE gsi1sk:
 //   indexPolicy: { pk: 'preserve', sk: 'sparse' }
-// yield* db.entities.Assets.update(key).remove(['city']).set({ site: 'datacenter-2' })
-// → SK truncated to "$app#v1#asset#country_us"; site value ignored.
+// yield* db.entities.Assets.update(key).remove(['city']).set({ country: 'us', site: 'datacenter-2' })
+// → REMOVE gsi1sk. Note: site value is invalidated (data loss in the index) —
+// this is the unified rule's "no silent partial composition on holes" intent.
 ```
 
 ---

--- a/packages/docs/src/content/docs/guides/index-policy.mdx
+++ b/packages/docs/src/content/docs/guides/index-policy.mdx
@@ -115,7 +115,7 @@ The "noop with stale risk" row is the one place sparse vs preserve actually diff
 // Lifecycle: alertState is the only sk composite, and it's owned by a
 // single ingest writer. Declaring sk: sparse means "if my event doesn't
 // have an alertState, drop my sk key — the item shouldn't be in this GSI."
-yield* db.entities.AlertEvents.put({
+yield* db.entities.Devices.put({
   channel: "c-1",
   deviceId: "d-1",
   accountId: "acme",
@@ -126,7 +126,7 @@ yield* db.entities.AlertEvents.put({
 // "No alert this event" — alertState explicitly undefined. sk touched
 // (alertState is in payload), can't compose (empty leading prefix) →
 // sparse → REMOVE sk. pk untouched → preserved.
-yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+yield* db.entities.Devices.update({ channel: "c-1", deviceId: "d-1" }).set({
   alertState: undefined,
   timestamp: "2026-04-30T11:00:00Z",
 })
@@ -139,9 +139,9 @@ yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
 
 ```typescript region="multi-writer" example="guide-index-policy.ts"
 // Item exists with all composites populated.
-yield* db.entities.AlertEvents.put({
-  channel: "c-1",
-  deviceId: "d-1",
+yield* db.entities.Devices.put({
+  channel: "c-2",
+  deviceId: "d-2",
   accountId: "acme",
   alertState: "active",
   timestamp: "2026-04-30T10:00:00Z",
@@ -150,7 +150,7 @@ yield* db.entities.AlertEvents.put({
 // Stamp writer — touches a non-composite attribute. Both halves untouched
 // → both preserved. (v1.7.0 would have REMOVE'd sk because sparse fired
 // on the untouched sk half.)
-yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
   published: "2026-04-30",
 })
 // Item still visible in GSI under acme + active.
@@ -158,20 +158,20 @@ yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
 // Enrichment writer rotates the account. pk touched → SET pk full
 // (account#newAcct). sk untouched → noop. Item re-indexes under newAcct;
 // stored gsi1sk unchanged.
-yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
   accountId: "newAcct",
 })
 
 // Telemetry writer fires fresh. sk touched → SET sk full
 // (alert#active#ts#T2). pk untouched → noop.
-yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
   alertState: "active",
   timestamp: "2026-04-30T11:00:00Z",
 })
 
 // Telemetry "no alert" event — sk touched, can't compose, sparse →
 // REMOVE sk. pk preserved. Item invisible in GSI but gsi1pk persists.
-yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
   alertState: undefined,
   timestamp: "2026-04-30T12:00:00Z",
 })
@@ -180,7 +180,7 @@ yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
 // untouched, value still acme from way back. Item re-visible under
 // newAcct + new sk — WITHOUT the enrichment writer re-firing. This is
 // the critical multi-writer property the v1.7.1 per-key roll-up enables.
-yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
   alertState: "active",
   timestamp: "2026-04-30T13:00:00Z",
 })

--- a/packages/docs/src/content/docs/guides/index-policy.mdx
+++ b/packages/docs/src/content/docs/guides/index-policy.mdx
@@ -1,30 +1,46 @@
 ---
 title: "indexPolicy — Per-Half GSI Membership Rules"
-description: "Per-half policy controlling what update payload absence means for GSI keys. Two drop triggers, structural composition, policy-aware hole detection, EDD-9025 invariant."
+description: "Per-half policy controlling what update payload absence means for GSI keys. Three contracts (preserve / sparse / Entity.remove), per-half evaluation gate, structural composition rule, set/remove asymmetry, EDD-9025 invariant."
 ---
 
 import { Aside } from "@astrojs/starlight/components"
 
 <Aside type="caution" title="This 'sparse' is not the SparseMap 'sparse'">
-This guide covers `indexPolicy: { pk, sk }` — controlling whether an *update* drops a *GSI* membership when a half's composites are absent. It is unrelated to the **SparseMap storage primitive** (`storedAs: DynamoModel.SparseMap()`), which controls how a `Schema.Record` field is *physically stored* on disk. The two were spelled the same up to 1.5.0 and that collision was a frequent source of confusion. See [Sparse Maps](/effect-dynamodb/guides/sparse-maps/) if you're looking for the storage primitive.
+This guide covers `indexPolicy: { pk, sk }` — controlling whether an *update* drops a *GSI* membership when a half's composites can't be composed. It is unrelated to the **SparseMap storage primitive** (`storedAs: DynamoModel.SparseMap()`), which controls how a `Schema.Record` field is *physically stored* on disk. The two were spelled the same up to 1.5.0 and that collision was a frequent source of confusion. See [Sparse Maps](/effect-dynamodb/guides/sparse-maps/) if you're looking for the storage primitive.
 </Aside>
 
-`Entity.update` and time-series `.append` accept partial payloads. `indexPolicy` lets you state, **per half** (PK and SK independently), what should happen when that half's composites can't all be composed from the available payload + stored values.
+## 1. The problem this solves
 
-## The two drop triggers
+A DynamoDB item is one row. In real systems, multiple writers may touch a single item for different reasons — a telemetry pipeline writing per-event clock and alert state, an enrichment job writing the owning account, a stamp writer marking a side-channel `published` timestamp. Each writer touches a different subset of attributes, and each one issues a partial `Entity.update` payload.
 
-v3 has exactly two ways an item drops out of a GSI. Both are predictable and tied to clear caller intent:
+GSI keys are derived from those attributes — a partition key like `gsi1pk` is composed from one or more *composite attributes* on the model. A writer that doesn't supply some composites shouldn't have to either read the item first or silently break the index. `indexPolicy` is how you tell the library what to do, **per half**, when an update doesn't have everything needed to recompose a GSI key.
 
-| Trigger | Granularity | Where it lives | Intent |
-|---|---|---|---|
-| `Entity.remove([attr])` cascade | per-attribute | per-call, explicit | "this attribute no longer applies — cascade drop everywhere it appears" |
-| `'sparse'` policy + whole-half-empty | per-half | per-GSI declaration, implicit | "this index entry requires at least the leading composite — fall out otherwise" |
+## 2. Mental model — three units, three contracts
 
-Both are visible at design or call time. The pre-1.6 footgun wasn't *"implicit drops are bad"* — it was *"per-composite implicit drops fire across writers that didn't intend to touch the GSI."* v3 narrows the implicit trigger to **whole-half-empty**, which only writers that genuinely intended to clear the half ever produce.
+Three units to keep distinct:
 
-## Per-half policy declaration
+- **Composite attribute** — a model field declared as part of a GSI's key (e.g. `accountId`, `alertState`).
+- **GSI key attribute** — the physical DynamoDB attribute the library writes (`gsi1pk`, `gsi1sk`). Each is *composed* from one or more composite attributes.
+- **GSI** — the queryable index. An item appears in GSI query results if and only if **both** `gsiNpk` and `gsiNsk` are present (DDB projection rule — invisible items are still in the table, just not in the GSI).
 
-Declare a per-half policy on each GSI that needs membership semantics:
+Three contracts, all per-half:
+
+> `preserve` is a contract with **other writers** ("don't disturb my key when you fire"); `sparse` is a contract with **yourself as the half's owner** ("drop my key if I touch this half but can't compose it"); `Entity.remove([attr])` is the explicit signal that a composite is gone — the library REMOVEs the half(s) containing the cleared attribute.
+
+That framing — declaration / evaluation / outcome / cascade are *all* per-half — is what makes the multi-writer story work. v1.7.0 had three connected bugs in how outcomes were rolled up; v1.7.1 makes the model uniformly per-half across all four pillars.
+
+## 3. The two settings, in plain language
+
+| Setting | What it means | When to use |
+|---|---|---|
+| `'preserve'` (default) | "If the update touches my half but I can't compose it, leave the stored GSI key alone." Stored value may go stale until the next write that *can* compose, or an `Entity.remove` cascade fires. | When the half's composites are **owned by another writer** — the other writer's key value is the source of truth, your update should pass through. |
+| `'sparse'` | "If the update touches my half but I can't compose it, REMOVE the stored GSI key — the item drops out of this half of the GSI." | When **this writer is the half's sole owner** and absence means "shouldn't be indexed here." |
+
+Both rules fire only when the half is *touched* — see the per-half evaluation gate below.
+
+## 4. Per-key declaration
+
+Declare an `indexPolicy` per GSI:
 
 ```typescript region="entity" example="guide-index-policy.ts"
 const Devices = Entity.make({
@@ -35,145 +51,239 @@ const Devices = Entity.make({
     sk: { field: "sk", composite: [] },
   },
   indexes: {
-    // byAlert — the membership key is `alertState`. When an event omits
-    // alertState, the PK half is whole-half-empty and sparse drops the GSI.
-    byAlert: {
+    // byCurrentAlert — the canonical hybrid GSI: pk is enrichment-owned
+    // (preserve so telemetry doesn't disturb it); sk is telemetry-owned
+    // (sparse so an event without an alert drops the half).
+    byCurrentAlert: {
       name: "gsi1",
-      pk: { field: "gsi1pk", composite: ["alertState"] },
-      sk: { field: "gsi1sk", composite: ["deviceId"] },
-      indexPolicy: { pk: "sparse", sk: "preserve" },
-    },
-    // byTenant — enrichment-owned. Ingest writers never supply tenantId; on
-    // every ingest update the PK half is whole-half-empty under preserve →
-    // no-op (the enrichment writer's stored gsi2pk is left untouched).
-    byTenant: {
-      name: "gsi2",
-      pk: { field: "gsi2pk", composite: ["tenantId"] },
-      sk: { field: "gsi2sk", composite: ["deviceId"] },
-      indexPolicy: { pk: "preserve", sk: "preserve" },
+      pk: { field: "gsi1pk", composite: ["accountId"] },
+      sk: { field: "gsi1sk", composite: ["alertState", "timestamp"] },
+      indexPolicy: { pk: "preserve", sk: "sparse" },
     },
   },
   timestamps: true,
 })
 ```
 
-Policy values:
+Halves omitted from `indexPolicy` default to `'preserve'`. If you don't declare `indexPolicy` at all, both halves are `'preserve'`.
 
-- `'sparse'` — the half *requires* its composites. Whole-half-empty REMOVEs both `gsiNpk` and `gsiNsk` (the item drops out of the GSI).
-- `'preserve'` (default) — leave the stored values intact when the half can't be composed. Halves omitted from `indexPolicy` default to `'preserve'`.
+## 5. The structural rule (longest valid leading prefix)
 
-If you don't declare `indexPolicy` at all, both halves are `'preserve'`.
-
-## Structural composition rule
-
-For each half (PK and SK independently), the library walks the composite list left-to-right and builds the **longest valid leading prefix** of values present in the merged record. This rule is identical for PK and SK — there is no "PK is special" asymmetry.
+For each *touched* half (PK and SK independently), the library walks the composite list left-to-right and builds the **longest valid leading prefix** of values present in the merged record (`{ ...storedKeyAttrs, ...payload }`).
 
 | Composite state for the half | Outcome |
 |---|---|
 | All composites present | SET the half from the full composition |
 | Trailing composites absent (`[A, B, _, _]`) | SET the half truncated to the leading prefix `[A, B]` |
-| Whole half empty (no leading composites available) | Policy decides — `'sparse'` REMOVEs both halves; `'preserve'` no-ops |
-| Hole pattern (`[A, _, C]`) | Policy decides — `'sparse'` truncates to leading prefix; `'preserve'` throws EDD-9024 |
+| Empty leading prefix OR hole pattern (`[_, C]` or `[A, _, C]`) | Compose failed — see "Per-half outcome" below |
 
 Truncation on PK is the same hierarchical demotion as truncation on SK. An item with `pk.composite = ['accountId', 'fleetId']` and `fleetId` absent composes a partition key of `account#A` and stays queryable at the account scope.
 
-## Two-way payload classification
+### Per-half evaluation gate (NEW in v1.7.1)
 
-`attr: null`, `attr: undefined`, and "key omitted from payload" all mean **absent** for GSI composition. v1.6's separate "explicit clear" classification is collapsed in v3.
+Before the structural rule even runs, each half is checked for whether the writer touched it. **If a half is untouched, it is skipped entirely — no SET, no REMOVE, no policy fires.**
 
-```typescript
-// All three of these produce the same GSI outcome (the structural rule sees
-// `tenantId` as absent in all three cases):
-yield* db.entities.Devices.update(key).set({ label: "x" })             // omit
-yield* db.entities.Devices.update(key).set({ label: "x", tenantId: undefined })
-// `set({ tenantId: null })` only typechecks if the model declares
-// `tenantId` as nullable (Schema.NullOr). If the field is composite-eligible
-// at all, EDD-9025 will reject the model.
+A half is *touched* iff at least one of its composite names appears in the update payload (regardless of value, including `undefined`) OR appears in `Entity.remove([...])`.
+
+This is what makes the multi-writer story work end-to-end:
+
+| Writer | Payload | byCurrentAlert eval |
+|---|---|---|
+| Stamp | `{ published: "2026-04-30" }` | Both halves untouched → noop, both halves preserved |
+| Enrichment | `{ accountId: "newAcct" }` | pk touched (SET); sk untouched (noop) |
+| Telemetry | `{ alertState: "active", timestamp: T }` | pk untouched (noop); sk touched (SET) |
+
+## 6. Per-key outcome rolls up to per-key storage
+
+The roll-up is **per-key** — each half's outcome applies to its own key attribute only. PK dropping doesn't drop SK; SK dropping doesn't drop PK. The item may be invisible in the GSI during a single-half-dropped period (DDB projection rule needs both keys for query visibility), but the surviving half's value persists. When the missing half is later composed again, the item rejoins the GSI **without the other writer needing to re-fire**.
+
+| Outcome for this half's key attribute | Conditions |
+|---|---|
+| **noop** (leave key alone) | The half is *untouched* (no composite in payload, none in `Entity.remove`) |
+| **SET full** | Half touched, all composites composable |
+| **SET truncated** to leading prefix | Half touched, leading prefix non-empty, no hole |
+| **REMOVE** this half's key | Half touched, can't compose (empty leading prefix OR hole pattern), AND policy is `'sparse'` OR a composite is in `Entity.remove([...])` (cascade override under preserve) |
+| **noop** (stored key may go stale) | Half touched, can't compose, policy is `'preserve'`, AND no composite is in `Entity.remove` |
+
+The "noop with stale risk" row is the one place sparse vs preserve actually differ at runtime. Under preserve, if you `set({ X: undefined })` for an optional composite without supplying surrounding context, the GSI key isn't updated — it retains whatever was stored last. To force a clean cleanup under preserve, use `Entity.remove(["X"])`: the cascade override fires and REMOVEs the half.
+
+## 7. Worked examples
+
+### 7.1 Single-writer sparse — alert lifecycle
+
+```typescript region="single-writer-sparse" example="guide-index-policy.ts"
+// Lifecycle: alertState is the only sk composite, and it's owned by a
+// single ingest writer. Declaring sk: sparse means "if my event doesn't
+// have an alertState, drop my sk key — the item shouldn't be in this GSI."
+yield* db.entities.AlertEvents.put({
+  channel: "c-1",
+  deviceId: "d-1",
+  accountId: "acme",
+  alertState: "active",
+  timestamp: "2026-04-30T10:00:00Z",
+})
+
+// "No alert this event" — alertState explicitly undefined. sk touched
+// (alertState is in payload), can't compose (empty leading prefix) →
+// sparse → REMOVE sk. pk untouched → preserved.
+yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+  alertState: undefined,
+  timestamp: "2026-04-30T11:00:00Z",
+})
+// Item invisible in byCurrentAlert (DDB needs both keys), but gsi1pk
+// preserved. Re-adding alertState recomposes sk → item rejoins WITHOUT
+// the enrichment writer needing to re-fire.
 ```
 
-Note that `set({ attr: null })` still REMOVEs the data attribute from the item — only the GSI-cascade behavior changed.
+### 7.2 Multi-writer preserve + sparse — full lifecycle
 
-## Hierarchical truncation — symmetric PK and SK
+```typescript region="multi-writer" example="guide-index-policy.ts"
+// Item exists with all composites populated.
+yield* db.entities.AlertEvents.put({
+  channel: "c-1",
+  deviceId: "d-1",
+  accountId: "acme",
+  alertState: "active",
+  timestamp: "2026-04-30T10:00:00Z",
+})
 
-Composite hierarchies where leaf values are *refinements* of parent context:
+// Stamp writer — touches a non-composite attribute. Both halves untouched
+// → both preserved. (v1.7.0 would have REMOVE'd sk because sparse fired
+// on the untouched sk half.)
+yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+  published: "2026-04-30",
+})
+// Item still visible in GSI under acme + active.
 
-| Domain | Composite hierarchy | Trailing-absent meaning |
-|---|---|---|
-| Geographic | `[region, country, city, site]` | Asset leaves a site but stays queryable at city/country/region |
-| Multi-tenant fleet | `[accountId, fleetId]` (PK) | Vehicle leaves a fleet but stays queryable at account scope |
-| Org | `[division, department, team, squad]` | Engineer rotates off a squad, stays queryable at team/department/division |
-| Workflow | `[stage, subStage, step]` | Approval step retracted; item stays queryable at parent stage |
-| Content | `[category, subcategory, tag]` | Leaf tag dropped; item stays in subcategory listings |
-| Permission | `[org, project, resource]` | Resource access lost; project-level access preserved |
-| Order grouping | `[customerId, orderId]` (SK) | After clearing `orderId`, group-by-customer queries via `begins_with(sk, "customer#C#")` still work |
+// Enrichment writer rotates the account. pk touched → SET pk full
+// (account#newAcct). sk untouched → noop. Item re-indexes under newAcct;
+// stored gsi1sk unchanged.
+yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+  accountId: "newAcct",
+})
 
-The unifying property: leaf composites are *refinements* of the parent context; the parent context remains queryable after pruning. Under v3 this is the default behavior of the structural composition rule for both halves — no separate "pruning" code path.
+// Telemetry writer fires fresh. sk touched → SET sk full
+// (alert#active#ts#T2). pk untouched → noop.
+yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+  alertState: "active",
+  timestamp: "2026-04-30T11:00:00Z",
+})
 
-### Worked example — geographic asset hierarchy (SK truncation)
+// Telemetry "no alert" event — sk touched, can't compose, sparse →
+// REMOVE sk. pk preserved. Item invisible in GSI but gsi1pk persists.
+yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+  alertState: undefined,
+  timestamp: "2026-04-30T12:00:00Z",
+})
+
+// Telemetry rejoins. sk touched, composes fine → SET sk full. pk
+// untouched, value still acme from way back. Item re-visible under
+// newAcct + new sk — WITHOUT the enrichment writer re-firing. This is
+// the critical multi-writer property the v1.7.1 per-key roll-up enables.
+yield* db.entities.AlertEvents.update({ channel: "c-1", deviceId: "d-1" }).set({
+  alertState: "active",
+  timestamp: "2026-04-30T13:00:00Z",
+})
+```
+
+### 7.3 Hierarchical truncation via set+remove
 
 ```typescript region="hierarchy-demo" example="guide-index-policy.ts"
-  // Initial state — full hierarchy populated.
-  yield* dbHier.entities.Assets.put({
-    assetId: "rack-42",
-    region: "americas",
-    country: "us",
-    city: "sf",
-    site: "datacenter-1",
-  })
-  // gsi3sk = "$indexpolicy-demo#v1#asset#country_us#city_sf#site_datacenter-1"
+// Initial state — full hierarchy populated.
+yield* db.entities.Assets.put({
+  assetId: "rack-42",
+  region: "americas",
+  country: "us",
+  city: "sf",
+  site: "datacenter-1",
+})
+// gsi1sk = "$indexpolicy-demo#v1#asset#country_us#city_sf#site_datacenter-1"
 
-  // Asset leaves the datacenter — omit `site` (or set it to undefined).
-  // Under the structural rule, the SK truncates at the leading prefix
-  // [country, city] — no separate "pruning" code path.
-  yield* dbHier.entities.Assets.update({ assetId: "rack-42" }).set({
-    country: "us",
-    city: "sf",
-  })
-  // gsi3sk = "$indexpolicy-demo#v1#asset#country_us#city_sf"  ← preserved at city level
+// Asset leaves the datacenter — *demote*, don't evict. Supply surviving
+// composites via set; invalidate the leaf via remove. Per the set/remove
+// asymmetry, the structural rule succeeds with the leading prefix
+// [country, city] → SET sk truncated. The cascade override only fires
+// when the rule CAN'T compose — here it composes fine.
+yield* db.entities.Assets.update({ assetId: "rack-42" })
+  .set({ country: "us", city: "sf" })
+  .remove(["site"])
+// gsi1sk = "$indexpolicy-demo#v1#asset#country_us#city_sf"
+// Asset still queryable at city level via begins_with.
 ```
 
-### Worked example — hierarchical PK truncation
+## 8. The two drop triggers (recap)
 
-```typescript region="pk-truncate-demo" example="guide-index-policy.ts"
-  // Initial state — vehicle assigned to a fleet under an account.
-  yield* dbFleet.entities.Vehicles.put({
-    vehicleId: "v-1",
-    accountId: "acct-1",
-    fleetId: "fleet-7",
-  })
-  // gsi4pk = "$indexpolicy-demo#v1#vehicle#accountid_acct-1#fleetid_fleet-7"
+| Trigger | Granularity | Where it lives | Intent |
+|---|---|---|---|
+| `'sparse'` policy + touched-half + can't-compose | per-half | per-GSI declaration, implicit | "I touched this half but can't compose it — drop me" |
+| `Entity.remove([attr])` cascade | per-half (per attribute, fires on the half(s) containing it) | per-call, explicit | "this composite is gone — drop the half(s) it belongs to" |
 
-  // Vehicle leaves the fleet but stays under the account — omit fleetId.
-  // PK truncates to the leading prefix [accountId] under the structural rule.
-  yield* dbFleet.entities.Vehicles.update({ vehicleId: "v-1" }).set({
-    accountId: "acct-1",
-  })
-  // gsi4pk = "$indexpolicy-demo#v1#vehicle#accountid_acct-1"
-  // Vehicle still queryable by account; just not by the prior fleet.
-```
+Cascade and sparse interact:
 
-This works under v3 because the structural composition rule applies symmetrically to PK and SK — the v1.6 PK-clear-degrades-to-sparse asymmetry is gone.
+- Cascade always makes its half *touched*.
+- For touched halves where the structural rule CAN compose (e.g. `set({ country, city }).remove(["site"])` — leading prefix `[country, city]` is non-empty), the structural rule wins → SET truncated.
+- For touched halves where the structural rule CAN'T compose, the per-half outcome rule fires:
+  - `'sparse'` → REMOVE this half's key.
+  - `'preserve'` + `removedSet` → REMOVE this half's key (cascade override under preserve).
+  - `'preserve'` + no `removedSet` → noop (stored key retained).
 
-## Hole detection — policy-aware
+## 9. Common pitfalls
 
-A "hole" is an absent composite at position `i` with a present composite at position `j > i` (e.g. `[A, _, C]`). Composed keys can't carry holes meaningfully — `acc#A#child#Y` with `parent` cleared composes to a syntactically invalid prefix that no `begins_with` query would match. Behavior depends on the half's policy:
+### `set({ X: null })` doesn't compile for composites
 
-| Policy | Hole pattern (`[A, _, C]`) |
-|---|---|
-| `'sparse'` | Truncate to the leading prefix `[A]`; trailing values ignored. (When the leading prefix is empty — `[_, C]` — collapses to whole-half-empty + drop.) |
-| `'preserve'` | Throw `CompositeKeyHoleError` (EDD-9024) at write time. |
+Composites can never be `null` (EDD-9025 — see [§10](#10-make-time-guarantees) below). The v1.7.0 update-payload type widening revert means the model's declaration is the source of truth: a `Schema.optional(Schema.String)` composite accepts `T | undefined`, not `T | null`. `set({ X: null })` on a composite is a TypeScript error.
 
 ```typescript
-// Hole pattern under preserve — throws at write time:
-yield* db.entities.Assets.update(key).set({ country: "us", site: "datacenter-2" })
-// → CompositeKeyHoleError [EDD-9024]:
-//   composite "city" at sk position 1 is absent, but composite "site" at
-//   sk position 2 is still present, and the sk half's indexPolicy is 'preserve'.
+// ❌ TypeScript error if X is a composite (model can't widen to include null,
+// payload doesn't widen beyond model)
+yield* db.entities.X.update(key).set({ X: null })
+
+// ✅ Use undefined for an optional composite, or Entity.remove for required
+yield* db.entities.X.update(key).set({ X: undefined })       // X must be Schema.optional
+yield* db.entities.X.update(key).remove(["X"])               // works for required + optional
 ```
 
-To resolve: supply a value for the absent composite, omit all trailing composites too, declare the half as `'sparse'` to opt into truncate-on-hole, or use `Entity.remove([attr])` to drop the whole GSI.
+### Preserve + `set({ X: undefined })` leaves stale risk
 
-## EDD-9025 — composite attributes can't be nullable
+Under preserve, an `set({ X: undefined })` on an optional composite touches the half but can't compose without `X`. Per the per-half outcome rule, preserve + can't-compose + no `removedSet` → noop. The stored gsi1sk **is not updated** — it retains whatever was last composed, possibly a stale value derived from the old `X`.
+
+To force the cleanup, use `Entity.remove(["X"])` instead. The composite is added to `removedSet`, the cascade override fires, and the half's key is REMOVE'd cleanly:
+
+```typescript
+// Stale risk — stored gsi1sk may reflect old X
+yield* db.entities.X.update(key).set({ X: undefined })
+
+// Force cleanup — REMOVE the half's key via cascade override
+yield* db.entities.X.update(key).remove(["X"])
+```
+
+### `Entity.remove(["X"])` doesn't truncate without supplied parents (set/remove asymmetry)
+
+> `set` provides values to compose with. `remove` invalidates a composite without providing a replacement. The library has no read-before-write — so `remove` without surrounding `set` context can't truncate (it doesn't know what to truncate *to*) and instead REMOVEs the half's key entirely.
+
+```typescript
+// Truncation works — surviving composites supplied via set, leaf invalidated via remove
+yield* db.entities.Assets.update(key)
+  .set({ region, country, city })
+  .remove(["site"])
+// → SET gsi1sk truncated to "region#R#country#C#city#S"
+
+// REMOVE the whole half — surviving composites not supplied
+yield* db.entities.Assets.update(key).remove(["site"])
+// → REMOVE gsi1sk entirely (no surviving values to compose with)
+```
+
+If you want to demote (truncate) hierarchically, you must `set` the surviving composites in the same call.
+
+### Multi-writer leak (v1.7.0 footgun, fixed in v1.7.1)
+
+In v1.7.0, a stamp writer that touched only a non-composite attribute (e.g. `set({ published: "2026-04-30" })`) would still trigger sparse-policy evaluation on every GSI half declared sparse — and REMOVE the half's key even though the stamp writer wasn't claiming ownership of the half. This made the multi-writer pattern impractical.
+
+v1.7.1's per-half evaluation gate fixes this: untouched halves are skipped entirely. The stamp writer above leaves both halves alone.
+
+## 10. Make-time guarantees
+
+### EDD-9025 — composite attributes can't be nullable
 
 At `Entity.make()` time, the library walks every composite across `primaryKey`, every entry in `indexes`, and every entry in `unique` constraints. For each composite's Schema, it inspects the AST and throws `CompositeNullableError` (EDD-9025) if `null` is reachable anywhere in the type union (`Schema.NullOr`, `Schema.NullishOr`, `Schema.Union` with a `Schema.Null` branch, etc.).
 
@@ -204,83 +314,21 @@ Entity.make({
 // ✅ Use Schema.optional(...) — produces T | undefined, no null:
 class OkModel extends Schema.Class<OkModel>("OkModel")({
   id: Schema.String,
-  tenantId: Schema.optional(Schema.String),  // ← T | undefined; sparse pattern
+  tenantId: Schema.optional(Schema.String),  // ← T | undefined; sparse pattern works
 }) {}
 ```
 
-Combined with the v3 update-payload type widening revert (the v1.6 `Schema.NullishOr` wrap on update field types is gone), `set({ composite: null })` is a TypeScript error two ways:
+Combined with the v1.7.x update-payload type widening revert, `set({ composite: null })` is a TypeScript error two ways — the model can't widen the composite to include `null`, and the update payload type isn't widened beyond the model. The stale-GSI-via-`set-null` footgun is closed at the type level.
 
-- The model can't widen the composite to include `null` (EDD-9025).
-- The update payload type isn't widened beyond the model.
+### EDD-9024 (`CompositeKeyHoleError`) — deprecated in v1.7.1
 
-The stale-GSI-via-`set-null` footgun is closed at the type level. No runtime path is reachable from typed callers.
-
-## Sparse drop — implicit, per-half
-
-```typescript region="sparse-drop" example="guide-index-policy.ts"
-  // Update WITHOUT alertState in the payload. Because byAlert declares
-  // `{ pk: 'sparse', sk: 'preserve' }`, the PK half is whole-half-empty
-  // (alertState absent) → sparse drops both gsi1pk/gsi1sk.
-  yield* db.entities.Devices.update({ channel: "c-1", deviceId: "d-1" }).set({ label: "quiet" })
-
-  const afterDrop = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-  // →  afterDrop is empty — item dropped out of the alert GSI
-```
-
-Re-adding the attr re-indexes the item:
-
-```typescript region="sparse-rehydrate" example="guide-index-policy.ts"
-  yield* db.entities.Devices.update({ channel: "c-1", deviceId: "d-1" }).set({
-    alertState: "cleared",
-  })
-
-  const cleared = yield* db.entities.Devices.byAlert({ alertState: "cleared" }).collect()
-  // →  cleared contains d-1 under its new alertState
-```
-
-## Preserve — the default
-
-With `'preserve'`, a writer that doesn't own a GSI's composites can update other attrs without disturbing the GSI:
-
-```typescript region="hybrid" example="guide-index-policy.ts"
-  // Start with an un-indexed device (no tenantId, no alertState).
-  yield* db.entities.Devices.put({ channel: "c-2", deviceId: "d-2" })
-
-  // Enrichment writer assigns tenantId.
-  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
-    tenantId: "initech",
-  })
-
-  // Later, ingest writer sets alertState. tenantId is NOT in this payload.
-  // byTenant's PK half is whole-half-empty under preserve → no-op (the
-  // stored gsi2pk is left intact).
-  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
-    alertState: "active",
-  })
-
-  // Both indexes correct — neither writer clobbered the other's composites.
-  const finalAlert = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-  const finalTenant = yield* db.entities.Devices.byTenant({ tenantId: "initech" }).collect()
-  // →  both queries return d-2
-```
-
-## Cascade — `Entity.remove([attr])`
-
-```typescript region="cascade" example="guide-index-policy.ts"
-  // Regardless of indexPolicy, removing a GSI composite attribute drops the
-  // item out of that GSI. Cascade takes precedence over preserve/sparse.
-  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).remove(["tenantId"])
-
-  const tenantAfterRemove = yield* db.entities.Devices.byTenant({ tenantId: "initech" }).collect()
-  // →  tenantAfterRemove is empty — cascade overrode the preserve policy
-```
-
-`Entity.remove(["tenantId"])` always REMOVEs every GSI whose composites include `tenantId`, regardless of policy or position. Cascade is the explicit *full drop* primitive; sparse + whole-half-empty is the implicit *per-half drop* primitive. Both are tied to clear caller intent.
+The error class is still exported for back-compat with consumers who type-imported it for `Effect.catchTag` handlers, but it is **no longer thrown at runtime** under v1.7.1. Hole patterns now collapse into the unified per-half can't-compose rule (drop under sparse, noop-or-cascade-override under preserve). Remove any `Effect.catchTag("CompositeKeyHoleError", ...)` handlers — the throw site is gone and the catch is dead code.
 
 ## When is a GSI evaluated?
 
-- **GSI declares `indexPolicy`** → evaluated on **every** update. Policy-first: the declaration is a statement about the membership invariant.
-- **GSI has no `indexPolicy`** → evaluated only when at least one of its composites is in the update payload, or when `Entity.remove([attr])` names one of its composites. Matches conventional partial-update semantics.
+Per the [per-half evaluation gate](#per-half-evaluation-gate-new-in-v171), each *half* is evaluated only when at least one of its composites is in the update payload, or when `Entity.remove([attr])` names one of its composites. Halves whose composites are entirely outside the payload are skipped — no SET, no REMOVE, no policy fires.
+
+The presence of an `indexPolicy` declaration does **not** force evaluation of every update under v1.7.1 (this is a behavior change from v1.7.0). The per-half gate is the same regardless of whether `indexPolicy` is declared.
 
 ## Interaction with `put()`
 
@@ -288,34 +336,34 @@ With `'preserve'`, a writer that doesn't own a GSI's composites can update other
 
 ## Interaction with time-series `.append()`
 
-v3 unifies `.append()` with `.update()` — both call the same composer. Composites outside `appendInput` are simply absent under the structural rule. Per-half policy decides whether each half drops or no-ops on every append.
+v1.7.x unifies `.append()` with `.update()` — both call the same composer with the same per-half evaluation gate. Composites outside `appendInput` are absent under the structural rule, AND the half is untouched per the gate (composite name is not in payload, not in removedSet). Halves whose composites are entirely outside `appendInput` are skipped.
 
-This is a real simplification from v1.6's `appendInput`-policy-filter wrapper. A multi-writer entity should declare its GSI shape so each half is owned by a single writer's domain — that's the v3 design rule and the natural fit with per-half policy.
-
-## Quick reference
-
-| Scenario | Policy | Payload | Result |
-|---|---|---|---|
-| Full recompose | any | all composites present | SET both halves |
-| Trailing-absent (PK or SK) | any | leading prefix present, trailing absent | SET truncated to leading prefix |
-| Whole-half-empty | `'sparse'` on that half | nothing composable on the half | REMOVE both halves |
-| Whole-half-empty | `'preserve'` on that half | nothing composable on the half | No-op for that half |
-| Hole pattern (`[A, _, C]`) | `'sparse'` on the half | leading prefix non-empty | SET truncated to leading prefix |
-| Hole pattern (`[_, C]`) starting at position 0 | `'sparse'` on the half | leading prefix empty | REMOVE both halves (collapses to whole-half-empty) |
-| Hole pattern | `'preserve'` on the half | any | **THROW EDD-9024** |
-| `Entity.remove(["A"])` cascade | any | any | REMOVE both halves (cascade overrides) |
+A multi-writer entity should declare its GSI shape so each half is owned by a single writer's domain — that's the design rule and the natural fit with per-half policy.
 
 ## Multi-writer entity design rule
 
 Each GSI half should be entirely owned by a single writer's domain. The library does not paper over cross-writer composite ownership — that's a consumer-side modeling discipline.
 
-With per-half policy and the structural composition rule, a writer that doesn't own a GSI's composites simply doesn't supply them, and the half no-ops under `'preserve'` or drops under `'sparse'` per its declaration. There is no per-composite leakage across writers like in v1.6.
+With per-half policy, the per-half evaluation gate, and the structural composition rule, a writer that doesn't own a GSI's composites simply doesn't supply them, and the half is skipped entirely. There is no per-composite leakage across writers like in v1.6, and no GSI-wide blast radius like in v1.7.0.
 
-Concretely: if you have a hybrid GSI with `pk = [accountId, alertState]` where `accountId` is enrichment-owned and `alertState` is ingest-owned, restructure to put each writer's composites on its own half — `pk = [accountId]`, `sk = [alertState, ...]` — so each half has a single owner. The per-half policy then expresses each writer's intent cleanly.
+Concretely: if you have a hybrid GSI with `pk = [accountId, alertState]` where `accountId` is enrichment-owned and `alertState` is ingest-owned, restructure to put each writer's composites on its own half — `pk = [accountId]`, `sk = [alertState, ...]` — so each half has a single owner. The per-half policy then expresses each writer's intent cleanly, and the per-half gate ensures one writer never disturbs the other's key.
+
+## Migrating from 1.7.0
+
+v1.7.1 is a patch release fixing three connected bugs in the v1.7.0 roll-up. **No API changes** — same `indexPolicy: { pk, sk }` declaration, same `Entity.remove([...])` API, same EDD-9025 invariants.
+
+**Behavior changes** (all bug fixes — strictly more correct than v1.7.0):
+
+1. **GSI-wide cascade on can't-compose → per-key REMOVE.** v1.7.0 REMOVE'd both `gsiNpk` AND `gsiNsk` whenever either half couldn't compose; v1.7.1 REMOVEs only the half that couldn't compose. The other half's stored value persists (preserved across writers).
+2. **Per-half evaluation gate (NEW).** v1.7.0 fired the policy on every update of every GSI declaring `indexPolicy`, regardless of whether the writer touched the half. v1.7.1 skips untouched halves entirely.
+3. **`Entity.remove([attr])` is per-half (not GSI-wide).** v1.7.0 REMOVE'd both halves of every GSI containing the cleared attribute; v1.7.1 REMOVEs only the half(s) whose composite list contains it.
+4. **`CompositeKeyHoleError` (EDD-9024) deprecated — no longer thrown.** Hole patterns collapse into the unified per-half can't-compose rule.
+
+Most consumers won't see any difference because v1.7.0 just shipped. The behavior changes mainly affect the multi-writer pattern that v1.7.0 was designed to enable — and didn't actually enable correctly.
 
 ## Migrating from 1.6.0
 
-1.7.0 simplifies the v1.6 per-attribute callback model to per-half declaration. This is a **breaking change** in 1.7.0 (shipped as a minor bump because in-the-wild consumer count is ~1).
+1.7.x simplifies the v1.6 per-attribute callback model to per-half declaration. This is a **breaking change** in 1.7.0 (shipped as a minor bump because in-the-wild consumer count is ~1).
 
 **Per-attribute callback → per-half object.** Replace the callback API with the per-half object literal. Take the most-restrictive per-attribute policy on each half:
 
@@ -327,7 +375,7 @@ indexPolicy: () => ({
   alertState: "sparse",
 })
 
-// 1.7.0 — pick the most-restrictive per-half. If alertState is on the SK
+// 1.7.x — pick the most-restrictive per-half. If alertState is on the SK
 // half and is the membership key, declare the SK half sparse.
 indexPolicy: { pk: "preserve", sk: "sparse" }
 ```
@@ -338,19 +386,17 @@ indexPolicy: { pk: "preserve", sk: "sparse" }
 // 1.6.0 — implicitly cascaded to drop the GSI
 yield* db.entities.Devices.update(key).set({ alertState: null })
 
-// 1.7.0 — explicit per-attribute drop + GSI cascade
+// 1.7.x — explicit per-attribute drop + per-half cascade
 yield* db.entities.Devices.update(key).remove(["alertState"])
 ```
 
 **Mixed sparse/preserve attrs in same half → not expressible.** Pick one per half. The half is a single concatenated string; per-attribute mixing within a half had no coherent runtime semantic anyway under the v1.6 model.
 
-**Update-payload type widening reverted.** v1.6 wrapped each update field in `Schema.NullishOr` so `set({ attr: null })` would always typecheck. v1.7 reverts this; `set({ attr: null })` only compiles when the model declares the attr as nullable. Combined with EDD-9025, this closes the stale-GSI footgun at the type level.
+**Update-payload type widening reverted.** v1.6 wrapped each update field in `Schema.NullishOr` so `set({ attr: null })` would always typecheck. v1.7.x reverts this; `set({ attr: null })` only compiles when the model declares the attr as nullable. Combined with EDD-9025, this closes the stale-GSI footgun at the type level.
 
-**EDD-9025 — composite attribute schemas must not include `null`.** Convert any nullable composites to `Schema.optional(...)` (T | undefined). This catches a footgun that v1.6 silently allowed and is part of v3's "make the type system enforce the structural invariant" story.
+**EDD-9025 — composite attribute schemas must not include `null`.** Convert any nullable composites to `Schema.optional(...)` (T | undefined). This catches a footgun that v1.6 silently allowed.
 
 **Hierarchical PK truncation is now supported (additive).** The v1.6 PK-clear-degrades-to-sparse asymmetry is gone — `pk.composite = ['accountId', 'fleetId']` with `fleetId` absent now truncates the PK to `account#A` instead of dropping the GSI. If you relied on the old PK-drop behavior, declare the PK half as `'sparse'` to keep that semantic.
-
-**Hole detection is now policy-aware.** Under `'preserve'`, holes still throw EDD-9024. Under `'sparse'`, holes silently truncate to the leading prefix. If you want the v1.6 strict behavior on a sparse half, restructure so holes can't form (e.g. by putting only one composite on each half).
 
 ## Runnable example
 

--- a/packages/docs/src/content/docs/guides/indexes.mdx
+++ b/packages/docs/src/content/docs/guides/indexes.mdx
@@ -451,7 +451,7 @@ Each composite value in a key is prefixed with its attribute name (e.g., `employ
 
 ## What's Next?
 
-- [indexPolicy — Per-Half GSI Membership Rules](/effect-dynamodb/guides/index-policy/) -- Per-half sparse/preserve declaration, two drop triggers (cascade + sparse-on-empty), structural composition with policy-aware hole detection, EDD-9025 invariant
+- [indexPolicy — Per-Half GSI Membership Rules](/effect-dynamodb/guides/index-policy/) -- Per-half sparse/preserve declaration, per-half evaluation gate, structural composition with the unified per-half can't-compose rule, set/remove asymmetry, per-half cascade, EDD-9025 invariant
 - [Queries](/effect-dynamodb/guides/queries/) -- Query by index, filter by sort key composites, paginate results
 - [Data Integrity](/effect-dynamodb/guides/data-integrity/) -- Unique constraints and optimistic concurrency
 - [Lifecycle](/effect-dynamodb/guides/lifecycle/) -- Soft delete and version retention

--- a/packages/docs/src/content/docs/reference/api-reference.mdx
+++ b/packages/docs/src/content/docs/reference/api-reference.mdx
@@ -1203,7 +1203,7 @@ import {
 | `OptimisticLockError` | `"OptimisticLockError"` | Version mismatch on `expectedVersion()` |
 | `ItemDeleted` | `"ItemDeleted"` | Item is soft-deleted (get returns this instead of the item) |
 | `ItemNotDeleted` | `"ItemNotDeleted"` | Restore called on an item that isn't soft-deleted |
-| `CompositeKeyHoleError` | `"CompositeKeyHoleError"` | EDD-9024 — hole pattern under `'preserve'` policy on a half (an absent composite at position `i` with a present composite at `j > i`). Carries `entityType`, `indexName`, `clearedComposite`, `trailingComposite`, positions, `half` (`"pk"` or `"sk"`). |
+| `CompositeKeyHoleError` | `"CompositeKeyHoleError"` | EDD-9024 — **deprecated in v1.7.1**, no longer thrown at runtime. Class export retained for back-compat with consumers who type-imported it for `Effect.catchTag` handlers. Hole patterns now collapse into the unified per-half can't-compose rule (drop under sparse, noop-or-cascade-override under preserve). |
 | `CompositeNullableError` | `"CompositeNullableError"` | EDD-9025 — composite attribute Schema includes `null`. Raised at `Entity.make()` time. Carries `entityType`, `surface` (e.g. `"primaryKey"`, `"index:..."`, `"unique:..."`), `compositeAttribute`, `schemaPath`. |
 | `RefNotFound` | `"RefNotFound"` | Referenced entity not found during ref hydration (`entity`, `field`, `refEntity`, `refId`) |
 | `AggregateAssemblyError` | `"AggregateAssemblyError"` | Aggregate read path failed — missing items, structural violations, or decode errors (`aggregate`, `reason`, `key`) |

--- a/packages/effect-dynamodb-geo/CHANGELOG.md
+++ b/packages/effect-dynamodb-geo/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @effect-dynamodb/geo
 
+## 1.7.1
+
+### Patch Changes
+
+- **indexPolicy v1.7.1 — per-half roll-up corrections (closes [#41](https://github.com/jmenga/effect-dynamodb/issues/41)).**
+
+  v1.7.0 shipped the per-key declaration model (`indexPolicy: { pk, sk }`) but had three connected bugs in how outcomes were rolled up. All three were rooted in the same defect: the model was per-half on declaration but not on evaluation, outcome, or cascade. v1.7.1 makes all four uniformly per-half.
+
+  **Bug fixes** (strictly more correct than v1.7.0):
+  1. **GSI-wide cascade on can't-compose → per-key REMOVE.** v1.7.0 REMOVE'd both `gsiNpk` AND `gsiNsk` whenever either half couldn't compose. v1.7.1 REMOVEs only the half that couldn't compose; the other half's stored value persists. Closes the multi-writer enrichment-on-pk + telemetry-on-sk scenario that v1.7.0 was designed to enable but didn't actually enable correctly.
+  2. **`CompositeKeyHoleError` (EDD-9024) deprecated — no longer thrown.** The v1.7.0 throw under preserve+hole was a defensive runtime safety net for a case the type system already catches (required composites can't be omitted under `exactOptionalPropertyTypes` since v1.7.0 reverted the NullishOr widening). The class export is preserved for back-compat with consumers who type-imported it for `Effect.catchTag` handlers, but no code path raises it anymore. Hole patterns now collapse into the unified per-half can't-compose rule.
+  3. **Per-half evaluation gate (NEW in v1.7.1).** v1.7.0 fired the policy on every update of every GSI declaring `indexPolicy`, regardless of whether the writer touched the half. This made stamps and unrelated writers blow away sparse halves they didn't own. v1.7.1 skips untouched halves entirely — a half is touched iff at least one of its composite names appears in the update payload OR in `Entity.remove([...])`.
+
+  **Behavior change:**
+  - **`Entity.remove([attr])` is now per-half** (no longer GSI-wide). Removing a composite REMOVEs only the half(s) whose composite list contains it. Other halves follow the per-half evaluation gate (untouched → noop). Combined with the new "cascade override under preserve" rule, the consumer's explicit signal still gets honored — preserve + can't-compose + composite in `removedSet` → REMOVE that half.
+
+  **No API changes:**
+  - Same `indexPolicy: { pk, sk }` declaration shape.
+  - Same `Entity.remove([...])` API.
+  - Same EDD-9025 invariants (composite attributes can't be `Schema.NullOr`).
+  - Same `Schema.optional(...)` pattern for sparse composites.
+
+  **v3 model preserved:** the per-key declaration, two-way payload classification, and EDD-9025 footgun gate from v1.7.0 are all preserved unchanged. v1.7.1 only fixes the roll-up.
+
+  See `DESIGN.md §7` for the full v1.7.1 decision algorithm and the `guides/index-policy.mdx` rewrite for the concept-first walkthrough.
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/geo",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Geospatial index and search for effect-dynamodb using H3 hexagonal grid",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/CHANGELOG.md
+++ b/packages/effect-dynamodb/CHANGELOG.md
@@ -1,5 +1,31 @@
 # effect-dynamodb
 
+## 1.7.1
+
+### Patch Changes
+
+- **indexPolicy v1.7.1 — per-half roll-up corrections (closes [#41](https://github.com/jmenga/effect-dynamodb/issues/41)).**
+
+  v1.7.0 shipped the per-key declaration model (`indexPolicy: { pk, sk }`) but had three connected bugs in how outcomes were rolled up. All three were rooted in the same defect: the model was per-half on declaration but not on evaluation, outcome, or cascade. v1.7.1 makes all four uniformly per-half.
+
+  **Bug fixes** (strictly more correct than v1.7.0):
+  1. **GSI-wide cascade on can't-compose → per-key REMOVE.** v1.7.0 REMOVE'd both `gsiNpk` AND `gsiNsk` whenever either half couldn't compose. v1.7.1 REMOVEs only the half that couldn't compose; the other half's stored value persists. Closes the multi-writer enrichment-on-pk + telemetry-on-sk scenario that v1.7.0 was designed to enable but didn't actually enable correctly.
+  2. **`CompositeKeyHoleError` (EDD-9024) deprecated — no longer thrown.** The v1.7.0 throw under preserve+hole was a defensive runtime safety net for a case the type system already catches (required composites can't be omitted under `exactOptionalPropertyTypes` since v1.7.0 reverted the NullishOr widening). The class export is preserved for back-compat with consumers who type-imported it for `Effect.catchTag` handlers, but no code path raises it anymore. Hole patterns now collapse into the unified per-half can't-compose rule.
+  3. **Per-half evaluation gate (NEW in v1.7.1).** v1.7.0 fired the policy on every update of every GSI declaring `indexPolicy`, regardless of whether the writer touched the half. This made stamps and unrelated writers blow away sparse halves they didn't own. v1.7.1 skips untouched halves entirely — a half is touched iff at least one of its composite names appears in the update payload OR in `Entity.remove([...])`.
+
+  **Behavior change:**
+  - **`Entity.remove([attr])` is now per-half** (no longer GSI-wide). Removing a composite REMOVEs only the half(s) whose composite list contains it. Other halves follow the per-half evaluation gate (untouched → noop). Combined with the new "cascade override under preserve" rule, the consumer's explicit signal still gets honored — preserve + can't-compose + composite in `removedSet` → REMOVE that half.
+
+  **No API changes:**
+  - Same `indexPolicy: { pk, sk }` declaration shape.
+  - Same `Entity.remove([...])` API.
+  - Same EDD-9025 invariants (composite attributes can't be `Schema.NullOr`).
+  - Same `Schema.optional(...)` pattern for sparse composites.
+
+  **v3 model preserved:** the per-key declaration, two-way payload classification, and EDD-9025 footgun gate from v1.7.0 are all preserved unchanged. v1.7.1 only fixes the roll-up.
+
+  See `DESIGN.md §7` for the full v1.7.1 decision algorithm and the `guides/index-policy.mdx` rewrite for the concept-first walkthrough.
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/effect-dynamodb/examples/guide-index-policy.ts
+++ b/packages/effect-dynamodb/examples/guide-index-policy.ts
@@ -1,12 +1,18 @@
 /**
- * indexPolicy v3 Guide — effect-dynamodb
+ * indexPolicy v1.7.1 Guide — effect-dynamodb
  *
- * Demonstrates per-half `indexPolicy` for controlling how `Entity.update` and
- * time-series `.append` handle absent composite attributes:
- *   - Default `preserve` on both halves — absent composites leave the GSI's keys alone.
- *   - `'sparse'` on a half — when the half is whole-half-empty, REMOVE both gsiNpk/gsiNsk.
- *   - Hierarchical truncation (PK and SK symmetric) — absent trailing composites truncate the half to its leading prefix.
- *   - Two drop triggers in action: `Entity.remove([attr])` cascade vs `'sparse'` + whole-half-empty.
+ * Demonstrates the three contracts of the v1.7.1 per-half model:
+ *   - `'preserve'` (default) — contract with other writers ("don't disturb my
+ *     key when you fire").
+ *   - `'sparse'` — contract with yourself as the half's owner ("drop my key
+ *     if I touch this half but can't compose it").
+ *   - `Entity.remove([attr])` — explicit signal that a composite is gone;
+ *     the library REMOVEs the half(s) containing the cleared attribute.
+ *
+ * Three runnable scenarios, each backing a worked example in the docs:
+ *   1. Single-writer sparse — alert lifecycle on a hybrid GSI.
+ *   2. Multi-writer preserve + sparse — full rejoin-without-re-firing flow.
+ *   3. Hierarchical truncation — set surviving + remove leaf demotes the SK.
  *
  * Prerequisites:
  *   docker run -p 8000:8000 amazon/dynamodb-local
@@ -34,26 +40,25 @@ const assertEq = <T>(actual: T, expected: T, label: string): void => {
 }
 
 // =============================================================================
-// 1. Model — a telemetry-style device with attrs owned by different writers
+// 1. Model — a hybrid telemetry-style device
 // =============================================================================
 
 // #region model
 class Device extends Schema.Class<Device>("Device")({
   channel: Schema.String,
   deviceId: Schema.String,
-  // Owned by an enrichment writer (set once, rarely changes).
-  // Schema.optional → T | undefined. EDD-9025 forbids Schema.NullOr on a
-  // composite, but Schema.optional is the right way to express "this attr
-  // may be absent."
-  tenantId: Schema.optional(Schema.String),
-  // Owned by the ingest writer; per-event, may be absent on non-alert events.
+  // Enrichment-owned (preserve on pk).
+  accountId: Schema.optional(Schema.String),
+  // Telemetry-owned (sparse on sk).
   alertState: Schema.optional(Schema.Literals(["active", "cleared"])),
-  label: Schema.optional(Schema.String),
+  timestamp: Schema.optional(Schema.String),
+  // Stamp attribute — not in any GSI.
+  published: Schema.optional(Schema.String),
 }) {}
 // #endregion
 
 // =============================================================================
-// 2. Schema + Entity with per-half indexPolicy on each GSI
+// 2. Entity with per-half indexPolicy on the canonical hybrid GSI
 // =============================================================================
 
 // #region schema
@@ -69,22 +74,14 @@ const Devices = Entity.make({
     sk: { field: "sk", composite: [] },
   },
   indexes: {
-    // byAlert — the membership key is `alertState`. When an event omits
-    // alertState, the PK half is whole-half-empty and sparse drops the GSI.
-    byAlert: {
+    // byCurrentAlert — the canonical hybrid GSI: pk is enrichment-owned
+    // (preserve so telemetry doesn't disturb it); sk is telemetry-owned
+    // (sparse so an event without an alert drops the half).
+    byCurrentAlert: {
       name: "gsi1",
-      pk: { field: "gsi1pk", composite: ["alertState"] },
-      sk: { field: "gsi1sk", composite: ["deviceId"] },
-      indexPolicy: { pk: "sparse", sk: "preserve" },
-    },
-    // byTenant — enrichment-owned. Ingest writers never supply tenantId; on
-    // every ingest update the PK half is whole-half-empty under preserve →
-    // no-op (the enrichment writer's stored gsi2pk is left untouched).
-    byTenant: {
-      name: "gsi2",
-      pk: { field: "gsi2pk", composite: ["tenantId"] },
-      sk: { field: "gsi2sk", composite: ["deviceId"] },
-      indexPolicy: { pk: "preserve", sk: "preserve" },
+      pk: { field: "gsi1pk", composite: ["accountId"] },
+      sk: { field: "gsi1sk", composite: ["alertState", "timestamp"] },
+      indexPolicy: { pk: "preserve", sk: "sparse" },
     },
   },
   timestamps: true,
@@ -94,139 +91,145 @@ const Devices = Entity.make({
 const AppTable = Table.make({ schema: AppSchema, entities: { Devices } })
 
 // =============================================================================
-// 3. Program — demonstrates every scenario
+// 3. Scenario 1 — Single-writer sparse (alert lifecycle)
 // =============================================================================
 
-const program = Effect.gen(function* () {
+const scenario1 = Effect.gen(function* () {
   const db = yield* DynamoClient.make({
     entities: { Devices },
     tables: { AppTable },
   })
 
-  yield* db.tables.AppTable.create()
+  yield* Console.log("\n=== Scenario 1: Single-writer sparse — alert lifecycle ===")
 
-  yield* Console.log("\n=== 1. put with full composites — item indexed under both GSIs ===")
-
-  // #region put-full
+  // #region single-writer-sparse
+  // Lifecycle: alertState is the only sk composite, and it's owned by a
+  // single ingest writer. Declaring sk: sparse means "if my event doesn't
+  // have an alertState, drop my sk key — the item shouldn't be in this GSI."
   yield* db.entities.Devices.put({
     channel: "c-1",
     deviceId: "d-1",
-    tenantId: "acme",
+    accountId: "acme",
     alertState: "active",
-    label: "initial",
+    timestamp: "2026-04-30T10:00:00Z",
   })
 
-  const alertActive = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-  const acmeTenant = yield* db.entities.Devices.byTenant({ tenantId: "acme" }).collect()
-  // →  alertActive contains d-1; acmeTenant contains d-1
-  // #endregion
-
-  assertEq(alertActive.length, 1, "byAlert has d-1")
-  assertEq(acmeTenant.length, 1, "byTenant has d-1")
-  yield* Console.log(`  byAlert(active): ${alertActive.length}, byTenant(acme): ${acmeTenant.length}`)
-
-  yield* Console.log(
-    "\n=== 2. sparse drop — omitting alertState empties the PK half + drops the GSI ===",
-  )
-
-  // #region sparse-drop
-  // Update WITHOUT alertState in the payload. Because byAlert declares
-  // `{ pk: 'sparse', sk: 'preserve' }`, the PK half is whole-half-empty
-  // (alertState absent) → sparse drops both gsi1pk/gsi1sk.
-  yield* db.entities.Devices.update({ channel: "c-1", deviceId: "d-1" }).set({ label: "quiet" })
-
-  const afterDrop = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-  // →  afterDrop is empty — item dropped out of the alert GSI
-  // #endregion
-
-  assertEq(afterDrop.length, 0, "d-1 dropped from byAlert")
-  yield* Console.log(`  byAlert(active) after clearing: ${afterDrop.length}`)
-
-  // byTenant preserved — the enrichment-owned half was left alone (preserve +
-  // whole-half-empty = no-op).
-  const tenantStillThere = yield* db.entities.Devices.byTenant({ tenantId: "acme" }).collect()
-  assertEq(tenantStillThere.length, 1, "byTenant still has d-1")
-  yield* Console.log(`  byTenant(acme) preserved: ${tenantStillThere.length}`)
-
-  yield* Console.log("\n=== 3. Re-adding the sparse composite re-indexes the item ===")
-
-  // #region sparse-rehydrate
+  // "No alert this event" — alertState explicitly undefined. sk touched
+  // (alertState is in payload), can't compose (empty leading prefix) →
+  // sparse → REMOVE sk. pk untouched → preserved.
   yield* db.entities.Devices.update({ channel: "c-1", deviceId: "d-1" }).set({
-    alertState: "cleared",
+    alertState: undefined,
+    timestamp: "2026-04-30T11:00:00Z",
   })
-
-  const cleared = yield* db.entities.Devices.byAlert({ alertState: "cleared" }).collect()
-  // →  cleared contains d-1 under its new alertState
+  // Item invisible in byCurrentAlert (DDB needs both keys), but gsi1pk
+  // preserved. Re-adding alertState recomposes sk → item rejoins WITHOUT
+  // the enrichment writer needing to re-fire.
   // #endregion
 
-  assertEq(cleared.length, 1, "d-1 back in byAlert(cleared)")
-  yield* Console.log(`  byAlert(cleared): ${cleared.length}`)
-
-  yield* Console.log("\n=== 4. Hybrid writers never clobber each other's GSI state ===")
-
-  // #region hybrid
-  // Start with an un-indexed device (no tenantId, no alertState).
-  yield* db.entities.Devices.put({ channel: "c-2", deviceId: "d-2" })
-
-  // Enrichment writer assigns tenantId.
-  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
-    tenantId: "initech",
-  })
-
-  // Later, ingest writer sets alertState. tenantId is NOT in this payload.
-  // byTenant's PK half is whole-half-empty under preserve → no-op (the
-  // stored gsi2pk is left intact).
-  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
-    alertState: "active",
-  })
-
-  // Both indexes correct — neither writer clobbered the other's composites.
-  const finalAlert = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-  const finalTenant = yield* db.entities.Devices.byTenant({ tenantId: "initech" }).collect()
-  // →  both queries return d-2
-  // #endregion
-
-  assertEq(finalAlert.some((d) => d.deviceId === "d-2"), true, "hybrid: d-2 in byAlert")
-  assertEq(finalTenant.some((d) => d.deviceId === "d-2"), true, "hybrid: d-2 in byTenant")
-  yield* Console.log(`  After hybrid updates: byAlert has d-2 + byTenant has d-2`)
-
-  yield* Console.log("\n=== 5. Entity.remove() cascade — explicit per-attribute drop ===")
-
-  // #region cascade
-  // Regardless of indexPolicy, removing a GSI composite attribute drops the
-  // item out of that GSI. Cascade takes precedence over preserve/sparse.
-  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).remove(["tenantId"])
-
-  const tenantAfterRemove = yield* db.entities.Devices.byTenant({ tenantId: "initech" }).collect()
-  // →  tenantAfterRemove is empty — cascade overrode the preserve policy
-  // #endregion
-
+  const dropped = yield* db.entities.Devices.byCurrentAlert({
+    accountId: "acme",
+  }).collect()
   assertEq(
-    tenantAfterRemove.some((d) => d.deviceId === "d-2"),
+    dropped.some((d) => d.deviceId === "d-1"),
     false,
-    "cascade: d-2 dropped from byTenant",
+    "scenario 1 — d-1 dropped from GSI",
   )
-  yield* Console.log(`  After Entity.remove(tenantId): byTenant(initech) has d-2? ${
-    tenantAfterRemove.some((d) => d.deviceId === "d-2")
-  }`)
 
-  yield* Console.log("\nAll indexPolicy v3 scenarios passed.")
-
-  yield* db.tables.AppTable.delete()
+  // Re-add alertState — item should rejoin under preserved pk.
+  yield* db.entities.Devices.update({ channel: "c-1", deviceId: "d-1" }).set({
+    alertState: "active",
+    timestamp: "2026-04-30T12:00:00Z",
+  })
+  const rejoined = yield* db.entities.Devices.byCurrentAlert({
+    accountId: "acme",
+  }).collect()
+  assertEq(
+    rejoined.some((d) => d.deviceId === "d-1"),
+    true,
+    "scenario 1 — d-1 rejoined under preserved pk",
+  )
+  yield* Console.log("  d-1 dropped under sparse → rejoined under preserved pk")
 })
 
 // =============================================================================
-// 4. Hierarchical SK truncation demo (separate program — uses its own table)
+// 4. Scenario 2 — Multi-writer preserve + sparse (full lifecycle)
 // =============================================================================
 
-// #region hierarchy-model
-// A geographic asset hierarchy: country → city → site. Omitting a trailing
-// SK composite (preserve policy) truncates gsi3sk to the leading prefix
-// instead of dropping the GSI entirely. The asset stays queryable at the
-// parent (coarser) hierarchy depth.
+const scenario2 = Effect.gen(function* () {
+  const db = yield* DynamoClient.make({
+    entities: { Devices },
+    tables: { AppTable },
+  })
+
+  yield* Console.log("\n=== Scenario 2: Multi-writer preserve + sparse — full lifecycle ===")
+
+  // #region multi-writer
+  // Item exists with all composites populated.
+  yield* db.entities.Devices.put({
+    channel: "c-2",
+    deviceId: "d-2",
+    accountId: "acme",
+    alertState: "active",
+    timestamp: "2026-04-30T10:00:00Z",
+  })
+
+  // Stamp writer — touches a non-composite attribute. Both halves untouched
+  // → both preserved. (v1.7.0 would have REMOVE'd sk because sparse fired
+  // on the untouched sk half.)
+  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
+    published: "2026-04-30",
+  })
+  // Item still visible in GSI under acme + active.
+
+  // Enrichment writer rotates the account. pk touched → SET pk full
+  // (account#newAcct). sk untouched → noop. Item re-indexes under newAcct;
+  // stored gsi1sk unchanged.
+  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
+    accountId: "newAcct",
+  })
+
+  // Telemetry writer fires fresh. sk touched → SET sk full
+  // (alert#active#ts#T2). pk untouched → noop.
+  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
+    alertState: "active",
+    timestamp: "2026-04-30T11:00:00Z",
+  })
+
+  // Telemetry "no alert" event — sk touched, can't compose, sparse →
+  // REMOVE sk. pk preserved. Item invisible in GSI but gsi1pk persists.
+  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
+    alertState: undefined,
+    timestamp: "2026-04-30T12:00:00Z",
+  })
+
+  // Telemetry rejoins. sk touched, composes fine → SET sk full. pk
+  // untouched, value still acme from way back. Item re-visible under
+  // newAcct + new sk — WITHOUT the enrichment writer re-firing. This is
+  // the critical multi-writer property the v1.7.1 per-key roll-up enables.
+  yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
+    alertState: "active",
+    timestamp: "2026-04-30T13:00:00Z",
+  })
+  // #endregion
+
+  const final = yield* db.entities.Devices.byCurrentAlert({
+    accountId: "newAcct",
+  }).collect()
+  assertEq(
+    final.some((d) => d.deviceId === "d-2"),
+    true,
+    "scenario 2 — d-2 visible under newAcct after rejoin",
+  )
+  yield* Console.log("  Multi-writer round-trip succeeded — d-2 in GSI under newAcct")
+})
+
+// =============================================================================
+// 5. Scenario 3 — Hierarchical truncation via set+remove
+// =============================================================================
+
 class Asset extends Schema.Class<Asset>("Asset")({
   assetId: Schema.String,
-  region: Schema.String,
+  region: Schema.optional(Schema.String),
   country: Schema.optional(Schema.String),
   city: Schema.optional(Schema.String),
   site: Schema.optional(Schema.String),
@@ -241,123 +244,56 @@ const Assets = Entity.make({
   },
   indexes: {
     byLocation: {
-      name: "gsi3",
-      pk: { field: "gsi3pk", composite: ["region"] },
-      sk: { field: "gsi3sk", composite: ["country", "city", "site"] },
+      name: "gsi1",
+      pk: { field: "gsi1pk", composite: ["region"] },
+      sk: { field: "gsi1sk", composite: ["country", "city", "site"] },
       indexPolicy: { pk: "preserve", sk: "preserve" },
     },
   },
 })
-// #endregion
 
-const HierarchyTable = Table.make({ schema: AppSchema, entities: { Assets } })
+const HierTable = Table.make({ schema: AppSchema, entities: { Assets } })
 
-const hierarchyProgram = Effect.gen(function* () {
-  const dbHier = yield* DynamoClient.make({
+const scenario3 = Effect.gen(function* () {
+  const db = yield* DynamoClient.make({
     entities: { Assets },
-    tables: { HierarchyTable },
+    tables: { HierTable },
   })
-  yield* dbHier.tables.HierarchyTable.create()
 
-  yield* Console.log("\n=== 6. Hierarchical SK truncation — preserve + trailing-absent demotes ===")
+  yield* Console.log("\n=== Scenario 3: Hierarchical truncation via set+remove ===")
 
   // #region hierarchy-demo
   // Initial state — full hierarchy populated.
-  yield* dbHier.entities.Assets.put({
+  yield* db.entities.Assets.put({
     assetId: "rack-42",
     region: "americas",
     country: "us",
     city: "sf",
     site: "datacenter-1",
   })
-  // gsi3sk = "$indexpolicy-demo#v1#asset#country_us#city_sf#site_datacenter-1"
+  // gsi1sk = "$indexpolicy-demo#v1#asset#country_us#city_sf#site_datacenter-1"
 
-  // Asset leaves the datacenter — omit `site` (or set it to undefined).
-  // Under the structural rule, the SK truncates at the leading prefix
-  // [country, city] — no separate "pruning" code path.
-  yield* dbHier.entities.Assets.update({ assetId: "rack-42" }).set({
-    country: "us",
-    city: "sf",
-  })
-  // gsi3sk = "$indexpolicy-demo#v1#asset#country_us#city_sf"  ← preserved at city level
+  // Asset leaves the datacenter — *demote*, don't evict. Supply surviving
+  // composites via set; invalidate the leaf via remove. Per the set/remove
+  // asymmetry, the structural rule succeeds with the leading prefix
+  // [country, city] → SET sk truncated. The cascade override only fires
+  // when the rule CAN'T compose — here it composes fine.
+  yield* db.entities.Assets.update({ assetId: "rack-42" })
+    .set({ country: "us", city: "sf" })
+    .remove(["site"])
+  // gsi1sk = "$indexpolicy-demo#v1#asset#country_us#city_sf"
+  // Asset still queryable at city level via begins_with.
   // #endregion
 
-  // Verify: query at the region level still finds the asset (it's still in
-  // the GSI — gsi3sk just got pruned to the parent prefix).
-  const atRegion = yield* dbHier.entities.Assets.byLocation({
+  const atRegion = yield* db.entities.Assets.byLocation({
     region: "americas",
   }).collect()
-  assertEq(atRegion.some((a) => a.assetId === "rack-42"), true, "rack-42 still in GSI after prune")
-  yield* Console.log(`  After implicit-omit-site: byLocation(americas) finds rack-42: ${
-    atRegion.some((a) => a.assetId === "rack-42")
-  }`)
-
-  yield* dbHier.tables.HierarchyTable.delete()
-})
-
-// =============================================================================
-// 5. Hierarchical PK truncation demo — additive in v3
-// =============================================================================
-
-// #region pk-truncate-model
-// A vehicle assigned to a fleet under an account. The PK is multi-composite —
-// under v3, the structural rule applies symmetrically to PK, so omitting a
-// trailing PK composite truncates the partition key to its leading prefix.
-// Vehicle leaves a fleet but stays queryable at the account scope.
-class Vehicle extends Schema.Class<Vehicle>("Vehicle")({
-  vehicleId: Schema.String,
-  accountId: Schema.optional(Schema.String),
-  fleetId: Schema.optional(Schema.String),
-}) {}
-
-const Vehicles = Entity.make({
-  model: Vehicle,
-  entityType: "Vehicle",
-  primaryKey: {
-    pk: { field: "pk", composite: ["vehicleId"] },
-    sk: { field: "sk", composite: [] },
-  },
-  indexes: {
-    byAccountFleet: {
-      name: "gsi4",
-      pk: { field: "gsi4pk", composite: ["accountId", "fleetId"] },
-      sk: { field: "gsi4sk", composite: [] },
-      indexPolicy: { pk: "preserve", sk: "preserve" },
-    },
-  },
-})
-// #endregion
-
-const FleetTable = Table.make({ schema: AppSchema, entities: { Vehicles } })
-
-const fleetProgram = Effect.gen(function* () {
-  const dbFleet = yield* DynamoClient.make({
-    entities: { Vehicles },
-    tables: { FleetTable },
-  })
-  yield* dbFleet.tables.FleetTable.create()
-
-  yield* Console.log("\n=== 7. Hierarchical PK truncation — symmetric with SK in v3 ===")
-
-  // #region pk-truncate-demo
-  // Initial state — vehicle assigned to a fleet under an account.
-  yield* dbFleet.entities.Vehicles.put({
-    vehicleId: "v-1",
-    accountId: "acct-1",
-    fleetId: "fleet-7",
-  })
-  // gsi4pk = "$indexpolicy-demo#v1#vehicle#accountid_acct-1#fleetid_fleet-7"
-
-  // Vehicle leaves the fleet but stays under the account — omit fleetId.
-  // PK truncates to the leading prefix [accountId] under the structural rule.
-  yield* dbFleet.entities.Vehicles.update({ vehicleId: "v-1" }).set({
-    accountId: "acct-1",
-  })
-  // gsi4pk = "$indexpolicy-demo#v1#vehicle#accountid_acct-1"
-  // Vehicle still queryable by account; just not by the prior fleet.
-  // #endregion
-
-  yield* dbFleet.tables.FleetTable.delete()
+  assertEq(
+    atRegion.some((a) => a.assetId === "rack-42"),
+    true,
+    "scenario 3 — rack-42 still in GSI after demote",
+  )
+  yield* Console.log("  rack-42 demoted from datacenter → still queryable at city level")
 })
 
 // =============================================================================
@@ -372,16 +308,56 @@ const ClientLayer = DynamoClient.layer({
 })
 
 const AppLayer = Layer.mergeAll(ClientLayer, AppTable.layer({ name: "indexpolicy-demo" }))
-const HierarchyLayer = Layer.mergeAll(
+const HierLayer = Layer.mergeAll(
   ClientLayer,
-  HierarchyTable.layer({ name: "indexpolicy-demo-hier" }),
+  HierTable.layer({ name: "indexpolicy-demo-hier" }),
 )
-const FleetLayer = Layer.mergeAll(ClientLayer, FleetTable.layer({ name: "indexpolicy-demo-fleet" }))
 
 const main = Effect.gen(function* () {
-  yield* program.pipe(Effect.provide(AppLayer))
-  yield* hierarchyProgram.pipe(Effect.provide(HierarchyLayer))
-  yield* fleetProgram.pipe(Effect.provide(FleetLayer))
+  // Setup tables.
+  const setupApp = Effect.gen(function* () {
+    const db = yield* DynamoClient.make({
+      entities: { Devices },
+      tables: { AppTable },
+    })
+    yield* db.tables.AppTable.create()
+  }).pipe(Effect.provide(AppLayer))
+  const setupHier = Effect.gen(function* () {
+    const db = yield* DynamoClient.make({
+      entities: { Assets },
+      tables: { HierTable },
+    })
+    yield* db.tables.HierTable.create()
+  }).pipe(Effect.provide(HierLayer))
+
+  yield* setupApp
+  yield* setupHier
+
+  // Run scenarios.
+  yield* scenario1.pipe(Effect.provide(AppLayer))
+  yield* scenario2.pipe(Effect.provide(AppLayer))
+  yield* scenario3.pipe(Effect.provide(HierLayer))
+
+  // Teardown.
+  const teardownApp = Effect.gen(function* () {
+    const db = yield* DynamoClient.make({
+      entities: { Devices },
+      tables: { AppTable },
+    })
+    yield* db.tables.AppTable.delete()
+  }).pipe(Effect.provide(AppLayer))
+  const teardownHier = Effect.gen(function* () {
+    const db = yield* DynamoClient.make({
+      entities: { Assets },
+      tables: { HierTable },
+    })
+    yield* db.tables.HierTable.delete()
+  }).pipe(Effect.provide(HierLayer))
+
+  yield* teardownApp
+  yield* teardownHier
+
+  yield* Console.log("\nAll v1.7.1 indexPolicy scenarios passed.")
 })
 
 Effect.runPromise(main).then(

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-dynamodb",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Effect TS ORM for DynamoDB — schema-driven entity modeling, single-table design, composite keys, transactions, and Stream-based pagination",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/src/Entity.ts
+++ b/packages/effect-dynamodb/src/Entity.ts
@@ -27,7 +27,6 @@ import {
 import * as DynamoSchema from "./DynamoSchema.js"
 import {
   CascadePartialFailure,
-  CompositeKeyHoleError,
   ConditionalCheckFailed,
   ItemNotFound,
   isAwsConditionalCheckFailed,
@@ -2902,60 +2901,60 @@ const makeImpl = <
             const primaryKeyMap = composePrimaryKey(newItem)
             Object.assign(newItem, primaryKeyMap)
 
-            // GSI keys: route through the policy-aware composer so the v3
-            // structural rule + `Entity.remove` cascade match the standard
-            // update path. `newItem` carries stored values for any composite
-            // the user did not touch — passing it as `keyRecord` lets the
-            // composer treat omissions as no-ops (the half stays untouched
-            // because the stored value is present), while still firing the
-            // cascade and the structural truncation rule. See DESIGN.md §7.
+            // GSI keys: route through the policy-aware composer so the
+            // v1.7.1 per-half evaluation gate, structural rule, and per-half
+            // cascade match the standard update path. `newItem` carries
+            // stored values for any composite the user did not touch — used
+            // as the merged record for the structural rule. The composer
+            // emits per-half SETs/REMOVEs/noops that we apply directly to
+            // `newItem` (which becomes the put-style item written back).
+            //
+            // No try/catch needed — EDD-9024 was deprecated in v1.7.1 and
+            // the composer no longer throws.
             const retainRemovedSet = uState.remove ? new Set(uState.remove) : undefined
-            try {
-              const gsiUpdate = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+            const gsiUpdate = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+              schema,
+              entityType,
+              entityVersion,
+              allIndexes,
+              hydratedUpdates as globalThis.Record<string, unknown>,
+              newItem,
+              { removedSet: retainRemovedSet },
+            )
+            for (const [field, value] of Object.entries(gsiUpdate.sets)) {
+              newItem[field] = value
+            }
+            for (const field of gsiUpdate.removes) {
+              delete newItem[field]
+            }
+            // GSIs where neither half was touched (per the v1.7.1 evaluation
+            // gate): retain path semantics are Put-style — recompose from
+            // `newItem` and drop both keys when any composite is missing.
+            // For touched halves, trust the composer's per-half decision
+            // (SET / REMOVE / leave-stored-value-on-newItem-alone for noop).
+            const addressed = new Set<string>([
+              ...Object.keys(gsiUpdate.sets),
+              ...gsiUpdate.removes,
+            ])
+            for (const [indexName, indexDef] of Object.entries(allIndexes)) {
+              if (indexName === "primary") continue
+              // If either half was addressed, the composer made the per-half
+              // decision; the other half's stored value already lives on
+              // `newItem` from the read-then-write merge above.
+              if (addressed.has(indexDef.pk.field) || addressed.has(indexDef.sk.field)) continue
+              const keys = KeyComposer.tryComposeIndexKeys(
                 schema,
                 entityType,
                 entityVersion,
-                allIndexes,
-                hydratedUpdates as globalThis.Record<string, unknown>,
+                indexDef,
                 newItem,
-                { removedSet: retainRemovedSet },
               )
-              for (const [field, value] of Object.entries(gsiUpdate.sets)) {
-                newItem[field] = value
+              if (keys) {
+                Object.assign(newItem, keys)
+              } else {
+                delete newItem[indexDef.pk.field]
+                delete newItem[indexDef.sk.field]
               }
-              for (const field of gsiUpdate.removes) {
-                delete newItem[field]
-              }
-              // Untouched GSIs (no policy + no payload + no cascade): retain
-              // path semantics are Put-style — recompose from `newItem` and
-              // drop both keys when any composite is missing. Matches the
-              // existing `composeAllKeys` behavior for those GSIs.
-              const addressed = new Set<string>([
-                ...Object.keys(gsiUpdate.sets),
-                ...gsiUpdate.removes,
-              ])
-              for (const [indexName, indexDef] of Object.entries(allIndexes)) {
-                if (indexName === "primary") continue
-                if (addressed.has(indexDef.pk.field) || addressed.has(indexDef.sk.field)) continue
-                const keys = KeyComposer.tryComposeIndexKeys(
-                  schema,
-                  entityType,
-                  entityVersion,
-                  indexDef,
-                  newItem,
-                )
-                if (keys) {
-                  Object.assign(newItem, keys)
-                } else {
-                  delete newItem[indexDef.pk.field]
-                  delete newItem[indexDef.sk.field]
-                }
-              }
-            } catch (e) {
-              if (e instanceof CompositeKeyHoleError) {
-                return yield* e
-              }
-              throw e
             }
 
             // Compute sentinel rotation values while newItem is in domain names.
@@ -3355,33 +3354,25 @@ const makeImpl = <
             removeClauses.push(nameKey)
           }
 
-          // Policy-aware GSI key composition (v3 — per-half structural rule).
-          // One call covers SETs (full recompose, truncated leading prefix,
-          // or no-op), sparse whole-half-empty REMOVEs, and cascade REMOVEs
-          // when an Entity.remove() targets a GSI composite. See DESIGN.md
-          // §7 Policy-Aware GSI Composition.
+          // Policy-aware GSI key composition (v1.7.1 — per-half evaluation
+          // gate, structural rule, and per-half cascade). One call covers
+          // SETs (full recompose, truncated leading prefix), per-half REMOVEs
+          // (sparse can't-compose, or preserve + cascade override), and
+          // per-half noops (preserve + can't-compose without cascade). See
+          // DESIGN.md §7 Policy-Aware GSI Composition.
           //
-          // The composer throws CompositeKeyHoleError (EDD-9024) when the
-          // merged payload describes a hole pattern AND the relevant half's
-          // policy is `'preserve'`. Under `'sparse'`, holes silently truncate.
-          // Catch the error synchronously and surface as a typed Effect failure.
-          let gsiUpdate: KeyComposer.GsiUpdateResult
-          try {
-            gsiUpdate = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-              schema,
-              entityType,
-              entityVersion,
-              allIndexes,
-              hydratedUpdates as globalThis.Record<string, unknown>,
-              decodedKey as globalThis.Record<string, unknown>,
-              { removedSet },
-            )
-          } catch (e) {
-            if (e instanceof CompositeKeyHoleError) {
-              return yield* e
-            }
-            throw e
-          }
+          // No try/catch — EDD-9024 was deprecated in v1.7.1 and the
+          // composer no longer throws. Hole patterns collapse into the
+          // unified can't-compose rule.
+          const gsiUpdate = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+            schema,
+            entityType,
+            entityVersion,
+            allIndexes,
+            hydratedUpdates as globalThis.Record<string, unknown>,
+            decodedKey as globalThis.Record<string, unknown>,
+            { removedSet },
+          )
           for (const [field, value] of Object.entries(gsiUpdate.sets)) {
             const nameKey = `#u${counter}`
             const valKey = `:u${counter}`
@@ -4282,26 +4273,19 @@ const makeImpl = <
         }
       }
 
-      // The composer can throw CompositeKeyHoleError (EDD-9024) when a hole
-      // pattern is encountered AND the relevant half's policy is `'preserve'`.
-      // Under `'sparse'`, holes silently truncate. Surface the error as a
-      // typed Effect failure.
-      let gsiUpdate: KeyComposer.GsiUpdateResult
-      try {
-        gsiUpdate = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          entityType,
-          entityVersion,
-          allIndexes,
-          nonPkAppendFields,
-          encoded,
-        )
-      } catch (e) {
-        if (e instanceof CompositeKeyHoleError) {
-          return yield* e
-        }
-        throw e
-      }
+      // No try/catch — EDD-9024 was deprecated in v1.7.1 and the composer
+      // no longer throws. Per-half evaluation gate skips halves whose
+      // composites are entirely outside `appendInput`; touched halves
+      // follow the unified per-half outcome rule (sparse drops; preserve
+      // noops or cascades).
+      const gsiUpdate = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+        schema,
+        entityType,
+        entityVersion,
+        allIndexes,
+        nonPkAppendFields,
+        encoded,
+      )
       for (const [field, value] of Object.entries(gsiUpdate.sets)) {
         const nameKey = `#a${counter}`
         const valKey = `:a${counter}`

--- a/packages/effect-dynamodb/src/Errors.ts
+++ b/packages/effect-dynamodb/src/Errors.ts
@@ -246,27 +246,38 @@ export class VersionConflict extends Data.TaggedError("VersionConflict")<{
 }> {}
 
 /**
- * EDD-9024 — A GSI composite at half-position `i` was absent while a composite
- * at position `j > i` was still present, AND the half's `indexPolicy` is
- * `'preserve'`. Composed keys can't carry holes meaningfully — `acc#A#child#Y`
- * with `parent` cleared composes to a syntactically invalid prefix that no
- * `begins_with` query would match. Under `'preserve'`, the library refuses to
- * silently drop the trailing composite and raises this error instead. Under
- * `'sparse'`, the trailing composite is silently truncated to the leading
- * prefix and no error is raised (and when the leading prefix is empty,
- * the half collapses to whole-half-empty which sparse drops together with
- * the other half).
+ * EDD-9024 — DEPRECATED in v1.7.1.
  *
- * Raised at write time (Entity.update / time-series .append). The error
- * names the GSI, the absent composite at position `i`, and the still-present
- * trailing composite at position `j` so callers can locate the offending
- * payload field.
+ * @deprecated Since v1.7.1, this error is no longer thrown at runtime. It is
+ *   kept as an exported class for back-compat with consumers who type-imported
+ *   it (e.g. inside `Effect.catchTag("CompositeKeyHoleError", ...)` blocks).
+ *   No code path constructs or throws this error anymore.
  *
- * Resolutions: supply a value for the absent composite, clear (omit or
- * `Entity.remove(...)`) all trailing composites too, or set
- * `indexPolicy.<key>` to `'sparse'` to opt into truncate-on-hole semantics.
+ * **Why deprecated.** v1.7.0's "throw under preserve on hole pattern" was a
+ * defensive runtime safety net for a case the type system already catches:
+ * required composites can't be omitted under `exactOptionalPropertyTypes`
+ * since v1.7.0 reverted the v1.6 NullishOr widening. The only remaining
+ * runtime "hole" shape is "optional leading composite absent + present
+ * trailing composite," which is a normal write the consumer expressly chose.
  *
- * See `DESIGN.md §7 Policy-Aware GSI Composition`.
+ * **What replaces it.** Hole patterns now collapse into the unified per-half
+ * can't-compose rule:
+ * - `'sparse'` half → REMOVE that half's key (drops the half).
+ * - `'preserve'` half + composite of the half is in `Entity.remove([...])`
+ *   → REMOVE that half's key (cascade override fires).
+ * - `'preserve'` half + no composite in `Entity.remove([...])` → noop (the
+ *   stored key is left untouched; may be stale until the next write that
+ *   touches the half supplies enough composites to recompose, or an
+ *   `Entity.remove` cascade fires).
+ *
+ * See `DESIGN.md §7 Policy-Aware GSI Composition` (v1.7.1 unified rule).
+ *
+ * **Migration.** Remove any `Effect.catchTag("CompositeKeyHoleError", ...)`
+ * handlers — the throw site is gone and the catch is dead code. If you were
+ * relying on the throw to detect bad payloads, switch to declaring the
+ * relevant GSI half as `'sparse'` (the consumer-side semantic that always
+ * matches the throw's intent — drop the index entry on can't-compose) or
+ * supply the surviving composites via `set` in the same update.
  */
 export class CompositeKeyHoleError extends Data.TaggedError("CompositeKeyHoleError")<{
   readonly entityType: string
@@ -282,8 +293,11 @@ export class CompositeKeyHoleError extends Data.TaggedError("CompositeKeyHoleErr
 }> {}
 
 /**
- * Build a {@link CompositeKeyHoleError} with a formatted message. Centralises
- * the message format so call sites (KeyComposer, Entity) stay consistent.
+ * Build a {@link CompositeKeyHoleError} with a formatted message.
+ *
+ * @deprecated Since v1.7.1 this builder is unused — no code path raises EDD-9024
+ *   at runtime. Kept exported only for back-compat with consumers who imported
+ *   the helper. See {@link CompositeKeyHoleError} for the migration path.
  */
 export const makeCompositeKeyHoleError = (params: {
   readonly entityType: string
@@ -297,14 +311,11 @@ export const makeCompositeKeyHoleError = (params: {
   new CompositeKeyHoleError({
     ...params,
     message:
-      `[EDD-9024] Composite key hole on GSI "${params.indexName}" of entity "${params.entityType}": ` +
+      `[EDD-9024 — DEPRECATED] Composite key hole on GSI "${params.indexName}" of entity "${params.entityType}": ` +
       `composite "${params.clearedComposite}" at ${params.key} position ${params.clearedPosition} is absent, ` +
-      `but composite "${params.trailingComposite}" at ${params.key} position ${params.trailingPosition} is still present, ` +
-      `and indexPolicy.${params.key} is 'preserve'. ` +
-      `Composed keys cannot carry holes — either supply a value for "${params.clearedComposite}", ` +
-      `clear all trailing composites (>= position ${params.trailingPosition}) too, ` +
-      `set indexPolicy.${params.key} = 'sparse' to opt into truncate-on-hole, ` +
-      `or use Entity.remove(["${params.clearedComposite}"]) to drop the whole GSI.`,
+      `but composite "${params.trailingComposite}" at ${params.key} position ${params.trailingPosition} is still present. ` +
+      `Since v1.7.1 this error is no longer thrown — hole patterns collapse into the unified per-half can't-compose rule ` +
+      `(REMOVE the half under 'sparse' or removedSet cascade; noop under 'preserve' without removedSet).`,
   })
 
 /**

--- a/packages/effect-dynamodb/src/KeyComposer.ts
+++ b/packages/effect-dynamodb/src/KeyComposer.ts
@@ -635,7 +635,14 @@ export const composeGsiKeysForUpdatePolicyAware = (
         sets[index.sk.field] =
           skOutcome.length === skComposites.length
             ? composeSk(schema, entityType, entityVersion, index, merged)
-            : composeSkPrefixUpTo(schema, entityType, entityVersion, index, merged, skOutcome.length)
+            : composeSkPrefixUpTo(
+                schema,
+                entityType,
+                entityVersion,
+                index,
+                merged,
+                skOutcome.length,
+              )
       }
       // noop — emit nothing for this half.
     }

--- a/packages/effect-dynamodb/src/KeyComposer.ts
+++ b/packages/effect-dynamodb/src/KeyComposer.ts
@@ -15,7 +15,7 @@ import {
   composeIsolatedSortKey,
   composeKey,
 } from "./DynamoSchema.js"
-import { type CompositeKeyHoleError, makeCompositeKeyHoleError } from "./Errors.js"
+import type { CompositeKeyHoleError } from "./Errors.js"
 
 /** Index key part definition (pk or sk of an index) */
 export interface KeyPart {
@@ -25,20 +25,30 @@ export interface KeyPart {
 
 /**
  * Per-half policy value controlling how `Entity.update` and time-series
- * `.append` handle a GSI half whose composites are absent from the merged
- * update payload.
+ * `.append` handle a GSI half the writer touches but can't compose.
  *
- * - `"sparse"` — when the half's composites are entirely absent (whole-half
- *   empty), REMOVE both `gsiNpk` and `gsiNsk` (item drops out of the GSI).
- *   On a hole pattern (`[A, _, C]`), truncate the half to the leading prefix
- *   `[A]` and ignore trailing values.
- * - `"preserve"` — whole-half-empty is a no-op; the stored values for that
- *   half stay intact. On a hole pattern, throw `CompositeKeyHoleError`
- *   (EDD-9024) at write time.
+ * Per-half evaluation gate (v1.7.1): a half is *touched* iff at least one of
+ * its composite names appears in the update payload (regardless of value,
+ * including `undefined`) OR appears in `Entity.remove([...])`. Untouched
+ * halves are skipped entirely — no SET, no REMOVE, no policy fires.
+ *
+ * For *touched* halves the policy decides the outcome when the structural
+ * rule can't compose (empty leading prefix OR hole pattern):
+ * - `"sparse"` — REMOVE this half's key attribute (the half drops out of the
+ *   GSI). The other half follows its own per-half outcome independently —
+ *   there is no GSI-wide cascade. The DDB projection rule means an item with
+ *   only one key attribute is invisible in the GSI; the surviving half's
+ *   value is preserved for rejoin without other writers re-firing.
+ * - `"preserve"` — noop (leave the stored key for this half untouched). The
+ *   stored value may go stale until either (a) the next write that touches
+ *   this half supplies enough composites to recompose, or (b) a composite of
+ *   this half is named in `Entity.remove([...])` — the cascade override
+ *   then REMOVEs this half's key.
  *
  * Halves not declared in `indexPolicy` default to `"preserve"`. See
  * `DESIGN.md §7 Policy-Aware GSI Composition` for the full decision rules
- * (structural composition, two drop triggers, decision table).
+ * (per-half evaluation gate, per-half outcome, cascade override, decision
+ * table).
  */
 export type IndexPolicyKey = "sparse" | "preserve"
 
@@ -395,44 +405,62 @@ export const composeSkPrefixUpTo = (
 }
 
 /**
- * Per-half outcome of the structural composition rule.
+ * Per-half outcome of the v1.7.1 structural composition rule.
  *
  * - `kind: "set"` — the half composed to a (possibly truncated) value.
  *   `length` is the number of leading composites included.
- * - `kind: "noop"` — preserve policy + whole-half-empty: leave the stored
- *   key field untouched.
- * - `kind: "drop"` — sparse policy + whole-half-empty: REMOVE the half (and,
- *   per the GSI roll-up rule, also REMOVE the other half).
- * - `kind: "hole-throw"` — preserve policy + hole pattern: throw EDD-9024.
- *   The position is the absent composite; trailingPosition is the first
- *   present trailing composite.
+ * - `kind: "noop"` — preserve policy + can't-compose AND no composite of this
+ *   half is in `removedSet`: leave the stored key field untouched (stored
+ *   value may go stale).
+ * - `kind: "drop"` — REMOVE this half's key. Fires when the half is touched
+ *   AND the structural rule can't compose AND either (a) policy is
+ *   `'sparse'` OR (b) a composite of this half is in `removedSet` (cascade
+ *   override under preserve).
+ *
+ * No `hole-throw` outcome — EDD-9024 was deprecated in v1.7.1 (hole patterns
+ * collapse into can't-compose under the unified rule).
  */
 type HalfOutcome =
   | { readonly kind: "set"; readonly length: number }
   | { readonly kind: "noop" }
   | { readonly kind: "drop" }
-  | {
-      readonly kind: "hole-throw"
-      readonly absentPosition: number
-      readonly trailingPosition: number
-    }
 
 /**
- * Apply v3's structural composition rule to a single half.
+ * Apply v1.7.1's structural composition rule to a single *touched* half.
+ *
+ * The caller is responsible for the per-half evaluation gate — `classifyHalf`
+ * is only called once the half is known to be touched (some composite of the
+ * half appears in payload OR in `removedSet`).
  *
  * Walks the composite list left-to-right, finds the longest leading prefix of
- * present values, and classifies the result based on whether the prefix is
- * partial, whether trailing values are present (hole), and whether the half
- * is empty. Policy is consulted only for hole + whole-half-empty cases.
+ * present values in `record`, and classifies the result:
+ *
+ * - **Compose succeeded** (non-empty leading prefix AND no hole — i.e. all
+ *   absent composites are at trailing positions only): SET.
+ * - **Compose failed** (empty leading prefix OR hole pattern): outcome
+ *   depends on `policy` and whether any composite of this half is in
+ *   `removedSet`:
+ *   - `'sparse'` → drop.
+ *   - `'preserve'` AND any composite in `removedSet` → drop (cascade
+ *     override under preserve — the consumer's explicit signal trumps
+ *     stale-data preservation).
+ *   - `'preserve'` AND no composite in `removedSet` → noop (preserve
+ *     preservation; stored key may be stale).
+ *
+ * Hole patterns collapse into can't-compose — silent partial composition
+ * (truncate-and-discard-trailing) is a worse failure mode than dropping the
+ * half because it would lie about the data shape to readers. The previous
+ * v1.7.0 sparse-truncate-on-hole behavior is gone.
  */
 const classifyHalf = (
   composites: ReadonlyArray<string>,
   record: Record<string, unknown>,
   policy: IndexPolicyKey,
+  halfHasRemoved: boolean,
 ): HalfOutcome => {
   // No composites at all (e.g. sk.composite = []) — emit a SET of length 0
-  // (the bare entity prefix). Policy is irrelevant in this case; this is the
-  // standard "primary key with empty SK composite" shape.
+  // (the bare entity prefix). Policy is irrelevant; this is the standard
+  // "primary key with empty SK composite" shape.
   if (composites.length === 0) {
     return { kind: "set", length: 0 }
   }
@@ -450,39 +478,25 @@ const classifyHalf = (
   }
 
   // Some absent. Check for hole (a present composite after the absent run).
-  let firstTrailingPresent = -1
+  let hasHole = false
   for (let j = leadingLen + 1; j < composites.length; j++) {
     const v = record[composites[j]!]
     if (v !== undefined && v !== null) {
-      firstTrailingPresent = j
+      hasHole = true
       break
     }
   }
 
-  if (firstTrailingPresent !== -1) {
-    // Hole pattern. Policy decides.
-    if (policy === "preserve") {
-      return {
-        kind: "hole-throw",
-        absentPosition: leadingLen,
-        trailingPosition: firstTrailingPresent,
-      }
-    }
-    // sparse → truncate to leading prefix. If the leading prefix is empty
-    // (the absent run starts at position 0), this collapses to whole-half-
-    // empty, which sparse drops.
-    return leadingLen === 0 ? { kind: "drop" } : { kind: "set", length: leadingLen }
+  // Compose-can-succeed iff non-empty leading prefix AND no hole.
+  // (Trailing-absent without a hole is a clean truncation.)
+  if (!hasHole && leadingLen > 0) {
+    return { kind: "set", length: leadingLen }
   }
 
-  // No hole — pure trailing-absent. If the leading prefix is empty, the whole
-  // half is empty; policy decides.
-  if (leadingLen === 0) {
-    return policy === "sparse" ? { kind: "drop" } : { kind: "noop" }
-  }
-
-  // Non-empty leading prefix with trailing absent → truncate. Same outcome
-  // under both policies.
-  return { kind: "set", length: leadingLen }
+  // Compose failed (empty leading prefix OR hole pattern). Per-half outcome:
+  if (policy === "sparse") return { kind: "drop" }
+  // preserve — cascade override under removedSet, otherwise noop.
+  return halfHasRemoved ? { kind: "drop" } : { kind: "noop" }
 }
 
 /**
@@ -498,34 +512,51 @@ const resolveIndexPolicy = (
 
 /**
  * Policy-aware GSI key composition for `Entity.update` and time-series
- * `.append` — v3 per-half structural composition.
+ * `.append` — v1.7.1 per-half structural composition with per-half evaluation
+ * gate and per-half cascade.
  *
- * Implements two-way payload classification:
+ * **Per-half evaluation gate (v1.7.1).** Each half (PK and SK) is independently
+ * checked for whether the writer touched it. A half is "touched" iff at least
+ * one of its composite names appears in `updatePayload` (regardless of value,
+ * including `undefined`) OR appears in `removedSet`. **Untouched halves are
+ * skipped entirely — no SET, no REMOVE, no policy fires.** This closes the
+ * v1.7.0 multi-writer leak where a "stamp" writer that doesn't touch a GSI's
+ * composites would still trigger the policy and blow away another writer's
+ * key.
+ *
+ * **Two-way payload classification.**
  * - **present** (`attr: <value>` in payload, or inherited from `keyRecord`)
  *   — value is used in composition.
  * - **absent** (key omitted, or `attr: null`, or `attr: undefined`) — the
  *   structural rule treats all three identically.
  *
- * For each touched GSI half (PK and SK independently), walk the composite
- * list left-to-right and build the longest valid leading prefix. Policy is
- * consulted only for the hole pattern (truncate under sparse, throw EDD-9024
- * under preserve) and the whole-half-empty case (drop both keys under
- * sparse, no-op under preserve).
+ * **Per-half outcome (v1.7.1 unified rule).** For each touched half:
+ * 1. Run the structural rule (longest leading prefix of present values in
+ *    the merged record).
+ * 2. If the prefix is non-empty AND there's no hole → SET (full or truncated).
+ * 3. Otherwise (empty leading prefix OR hole pattern):
+ *    - `'sparse'` → REMOVE this half's key.
+ *    - `'preserve'` AND any composite of this half is in `removedSet` →
+ *      REMOVE (cascade override under preserve).
+ *    - `'preserve'` AND no composite in `removedSet` → noop (stored key
+ *      retained, may be stale until next write touches the half).
  *
- * Cascade (`Entity.remove([attr])`) overrides everything: any composite in
- * `removedSet` forces a full GSI drop (REMOVE both `gsiNpk` and `gsiNsk`).
+ * **Per-half roll-up (v1.7.1).** Each half's outcome applies to its own key
+ * attribute only. PK dropping doesn't drop SK; SK dropping doesn't drop PK.
+ * The item may be invisible in the GSI during a single-half-dropped period
+ * (DDB projection rule needs both keys for query visibility), but the
+ * surviving half's value persists for rejoin without other writers re-firing.
+ * The v1.7.0 GSI-wide cascade is gone.
  *
- * A GSI is considered "touched" when any of its composites appears in
- * `updatePayload`, or `removedSet`. GSIs without an `indexPolicy` are skipped
- * when none of their composites are touched. GSIs with a policy are always
- * evaluated — the policy is a declarative statement about the GSI's
- * membership invariant.
+ * **`Entity.remove([attr])` cascade (v1.7.1: per-half).** Composites in
+ * `removedSet` contribute to the merged record as "absent" (same as
+ * undefined-in-payload) AND make their containing half "touched" for the
+ * evaluation gate AND trigger the cascade override under preserve. The
+ * cascade no longer drops both halves of every GSI containing the cleared
+ * attribute — only the half(s) whose composite list contains it.
  *
  * See `DESIGN.md §7 Policy-Aware GSI Composition` for the full decision
- * algorithm, decision table, and the two-drop-trigger framing.
- *
- * @throws {CompositeKeyHoleError} EDD-9024 on hole-pattern detection under
- *   `'preserve'` policy.
+ * table and worked multi-writer examples.
  */
 export const composeGsiKeysForUpdatePolicyAware = (
   schema: DynamoSchema.DynamoSchema,
@@ -547,25 +578,26 @@ export const composeGsiKeysForUpdatePolicyAware = (
 
     const pkComposites = index.pk.composite
     const skComposites = index.sk.composite
-    const allComposites = [...pkComposites, ...skComposites]
 
-    const cascadeRemove =
-      removedSet !== undefined && allComposites.some((attr) => removedSet.has(attr))
-    const touchedByPayload = allComposites.some((attr) => attr in updatePayload)
-    const hasPolicy = index.indexPolicy !== undefined
+    // Per-half evaluation gate (v1.7.1). A half is touched iff at least one
+    // of its composite names appears in `updatePayload` (regardless of value)
+    // OR in `removedSet`. Untouched halves are skipped — leave the stored
+    // key attribute alone.
+    const pkHasRemoved =
+      removedSet !== undefined && pkComposites.some((attr) => removedSet.has(attr))
+    const skHasRemoved =
+      removedSet !== undefined && skComposites.some((attr) => removedSet.has(attr))
+    const pkTouched = pkHasRemoved || pkComposites.some((attr) => attr in updatePayload)
+    const skTouched = skHasRemoved || skComposites.some((attr) => attr in updatePayload)
 
-    if (!cascadeRemove && !touchedByPayload && !hasPolicy) continue
-
-    // Cascade takes precedence over policy.
-    if (cascadeRemove) {
-      removes.push(index.pk.field, index.sk.field)
-      continue
-    }
+    if (!pkTouched && !skTouched) continue
 
     // Build merged record for value extraction. Two-way classification: any
-    // payload value that is `null` or `undefined` is treated as absent (the
-    // attribute is excluded from `merged`). `keyRecord` provides values for
-    // composites the consumer didn't touch.
+    // payload value that is `null` or `undefined` is treated as absent. Any
+    // composite in `removedSet` is also treated as absent (the cascade
+    // signal). `keyRecord` provides values for composites the consumer did
+    // not touch (typically the entity's primary-key composites pulled
+    // through to GSI composites that share the names).
     const merged: Record<string, unknown> = { ...keyRecord }
     for (const [k, v] of Object.entries(updatePayload)) {
       if (v === null || v === undefined) {
@@ -574,55 +606,38 @@ export const composeGsiKeysForUpdatePolicyAware = (
       }
       merged[k] = v
     }
+    if (removedSet !== undefined) {
+      for (const attr of removedSet) {
+        delete merged[attr]
+      }
+    }
 
     const policy = resolveIndexPolicy(index.indexPolicy)
-    const pkOutcome = classifyHalf(pkComposites, merged, policy.pk)
-    const skOutcome = classifyHalf(skComposites, merged, policy.sk)
 
-    // Hole-throw on either half raises EDD-9024 with the offending location.
-    if (pkOutcome.kind === "hole-throw") {
-      throw makeCompositeKeyHoleError({
-        entityType,
-        indexName: index.index ?? indexName,
-        clearedComposite: pkComposites[pkOutcome.absentPosition]!,
-        trailingComposite: pkComposites[pkOutcome.trailingPosition]!,
-        clearedPosition: pkOutcome.absentPosition,
-        trailingPosition: pkOutcome.trailingPosition,
-        key: "pk",
-      })
-    }
-    if (skOutcome.kind === "hole-throw") {
-      throw makeCompositeKeyHoleError({
-        entityType,
-        indexName: index.index ?? indexName,
-        clearedComposite: skComposites[skOutcome.absentPosition]!,
-        trailingComposite: skComposites[skOutcome.trailingPosition]!,
-        clearedPosition: skOutcome.absentPosition,
-        trailingPosition: skOutcome.trailingPosition,
-        key: "sk",
-      })
+    if (pkTouched) {
+      const pkOutcome = classifyHalf(pkComposites, merged, policy.pk, pkHasRemoved)
+      if (pkOutcome.kind === "drop") {
+        removes.push(index.pk.field)
+      } else if (pkOutcome.kind === "set") {
+        sets[index.pk.field] =
+          pkOutcome.length === pkComposites.length
+            ? composePk(schema, entityType, index, merged)
+            : composePkPrefixUpTo(schema, entityType, index, merged, pkOutcome.length)
+      }
+      // noop — emit nothing for this half.
     }
 
-    // Whole-GSI drop: any half declared sparse + whole-half-empty drops both
-    // halves together. This is the implicit drop trigger.
-    if (pkOutcome.kind === "drop" || skOutcome.kind === "drop") {
-      removes.push(index.pk.field, index.sk.field)
-      continue
-    }
-
-    // Per-half SET / no-op. Halves are emitted independently — preserve +
-    // empty leaves the stored value alone.
-    if (pkOutcome.kind === "set") {
-      sets[index.pk.field] =
-        pkOutcome.length === pkComposites.length
-          ? composePk(schema, entityType, index, merged)
-          : composePkPrefixUpTo(schema, entityType, index, merged, pkOutcome.length)
-    }
-    if (skOutcome.kind === "set") {
-      sets[index.sk.field] =
-        skOutcome.length === skComposites.length
-          ? composeSk(schema, entityType, entityVersion, index, merged)
-          : composeSkPrefixUpTo(schema, entityType, entityVersion, index, merged, skOutcome.length)
+    if (skTouched) {
+      const skOutcome = classifyHalf(skComposites, merged, policy.sk, skHasRemoved)
+      if (skOutcome.kind === "drop") {
+        removes.push(index.sk.field)
+      } else if (skOutcome.kind === "set") {
+        sets[index.sk.field] =
+          skOutcome.length === skComposites.length
+            ? composeSk(schema, entityType, entityVersion, index, merged)
+            : composeSkPrefixUpTo(schema, entityType, entityVersion, index, merged, skOutcome.length)
+      }
+      // noop — emit nothing for this half.
     }
   }
 

--- a/packages/effect-dynamodb/test/Entity.test.ts
+++ b/packages/effect-dynamodb/test/Entity.test.ts
@@ -3831,8 +3831,7 @@ describe("Entity", () => {
           const eanEntries = Object.entries(call.ExpressionAttributeNames) as Array<
             [string, string]
           >
-          const aliasOf = (physical: string) =>
-            eanEntries.find(([_, v]) => v === physical)?.[0]
+          const aliasOf = (physical: string) => eanEntries.find(([_, v]) => v === physical)?.[0]
           const gsi1pkAlias = aliasOf("gsi1pk")
           const gsi1skAlias = aliasOf("gsi1sk")
           expect(gsi1pkAlias).toBeDefined()

--- a/packages/effect-dynamodb/test/Entity.test.ts
+++ b/packages/effect-dynamodb/test/Entity.test.ts
@@ -3780,57 +3780,74 @@ describe("Entity", () => {
         }).pipe(Effect.provide(TestLayer)),
     )
 
-    it.effect("update with indexPolicy sparse drops item out of the GSI on partial", () =>
-      Effect.gen(function* () {
-        const SparseDropEntity = withConfig(
-          Entity.make({
-            model: TenantUser,
-            entityType: "TenantUser",
-            primaryKey: {
-              pk: { field: "pk", composite: ["userId"] },
-              sk: { field: "sk", composite: [] },
-            },
-            indexes: {
-              byTenant: {
-                name: "gsi1",
-                pk: { field: "gsi1pk", composite: ["tenantId"] },
-                sk: { field: "gsi1sk", composite: ["region"] },
-                // v3 per-half: SK is sparse; whole-SK-empty triggers drop.
-                indexPolicy: { pk: "preserve", sk: "sparse" },
+    it.effect(
+      "update with indexPolicy sparse + touched-but-can't-compose drops only that half (v1.7.1)",
+      () =>
+        Effect.gen(function* () {
+          const SparseDropEntity = withConfig(
+            Entity.make({
+              model: TenantUser,
+              entityType: "TenantUser",
+              primaryKey: {
+                pk: { field: "pk", composite: ["userId"] },
+                sk: { field: "sk", composite: [] },
               },
-            },
-          }),
-        )
+              indexes: {
+                byTenant: {
+                  name: "gsi1",
+                  pk: { field: "gsi1pk", composite: ["tenantId"] },
+                  sk: { field: "gsi1sk", composite: ["region"] },
+                  // v1.7.1: per-half SK is sparse. SK touched (via undefined)
+                  // and can't compose → REMOVE gsi1sk only. pk is independent.
+                  indexPolicy: { pk: "preserve", sk: "sparse" },
+                },
+              },
+            }),
+          )
 
-        mockUpdateItem.mockResolvedValueOnce({
-          Attributes: toAttributeMap({
-            userId: "u-1",
-            name: "Test",
-            tenantId: "t-2",
-            region: "us-east-1",
-            email: "a@b.com",
-            pk: "$myapp#v1#tenantuser#userid_u-1",
-            sk: "$myapp#v1#tenantuser",
-            __edd_e__: "TenantUser",
-          }),
-        })
+          mockUpdateItem.mockResolvedValueOnce({
+            Attributes: toAttributeMap({
+              userId: "u-1",
+              name: "Test",
+              tenantId: "t-2",
+              region: "us-east-1",
+              email: "a@b.com",
+              pk: "$myapp#v1#tenantuser#userid_u-1",
+              sk: "$myapp#v1#tenantuser",
+              __edd_e__: "TenantUser",
+            }),
+          })
 
-        // region is 'sparse' and missing → REMOVE both gsi1 key fields.
-        yield* SparseDropEntity.update({ userId: "u-1" }).pipe(
-          Entity.set({ tenantId: "t-2" }),
-          Entity.asModel,
-        )
+          // Touch sk's region with undefined → sk evaluated. Empty leading
+          // prefix → sparse → REMOVE sk only. pk touched (tenantId in
+          // payload) → SET. v1.7.1 critical: pk is NOT removed.
+          yield* SparseDropEntity.update({ userId: "u-1" }).pipe(
+            Entity.set({ tenantId: "t-2", region: undefined }),
+            Entity.asModel,
+          )
 
-        const call = mockUpdateItem.mock.calls[0]![0]
-        const names = Object.values(call.ExpressionAttributeNames) as string[]
-        expect(names).toContain("gsi1pk")
-        expect(names).toContain("gsi1sk")
-        const expr = call.UpdateExpression as string
-        // REMOVE clause should cover both GSI key fields (the item drops out)
-        expect(expr).toContain("REMOVE")
-        // gsi1pk and gsi1sk appear only in REMOVE, not SET
-        expect(expr).not.toMatch(/SET[^R]*gsi1pk/)
-      }).pipe(Effect.provide(TestLayer)),
+          const call = mockUpdateItem.mock.calls[0]![0]
+          const expr = call.UpdateExpression as string
+          const eanEntries = Object.entries(call.ExpressionAttributeNames) as Array<
+            [string, string]
+          >
+          const aliasOf = (physical: string) =>
+            eanEntries.find(([_, v]) => v === physical)?.[0]
+          const gsi1pkAlias = aliasOf("gsi1pk")
+          const gsi1skAlias = aliasOf("gsi1sk")
+          expect(gsi1pkAlias).toBeDefined()
+          expect(gsi1skAlias).toBeDefined()
+          // Determine which clause each alias appears in.
+          const removeIdx = expr.indexOf("REMOVE")
+          const setExpr = removeIdx === -1 ? expr : expr.slice(0, removeIdx)
+          const remExpr = removeIdx === -1 ? "" : expr.slice(removeIdx)
+          // v1.7.1 critical: gsi1pk is SET (not REMOVE'd).
+          expect(setExpr.includes(gsi1pkAlias!)).toBe(true)
+          expect(remExpr.includes(gsi1pkAlias!)).toBe(false)
+          // gsi1sk is REMOVE'd (not SET).
+          expect(remExpr.includes(gsi1skAlias!)).toBe(true)
+          expect(setExpr.includes(gsi1skAlias!)).toBe(false)
+        }).pipe(Effect.provide(TestLayer)),
     )
 
     it.effect("update with indexPolicy preserve (explicit) leaves GSI untouched on partial", () =>
@@ -3880,103 +3897,119 @@ describe("Entity", () => {
       }).pipe(Effect.provide(TestLayer)),
     )
 
-    it.effect("remove of GSI composite cascades to GSI key field removal", () =>
-      Effect.gen(function* () {
-        mockUpdateItem.mockResolvedValueOnce({
-          Attributes: toAttributeMap({
-            userId: "u-1",
-            name: "Test",
-            tenantId: "t-1",
-            region: "us-east-1",
-            email: "a@b.com",
-            pk: "$myapp#v1#tenantuser#u-1",
-            sk: "$myapp#v1#tenantuser",
-            __edd_e__: "TenantUser",
-          }),
-        })
+    it.effect(
+      "remove of GSI composite cascades to that half's GSI key only (per-half — v1.7.1)",
+      () =>
+        Effect.gen(function* () {
+          // v1.7.1: cascade is per-half. tenantId is in pk composites of
+          // byTenant (pk=[tenantId], sk=[region]). PK touched via removedSet,
+          // can't compose → preserve + cascade override → REMOVE gsi1pk.
+          // SK untouched (region not in payload, not in removedSet) → noop.
+          //
+          // (v1.7.0 would have REMOVE'd both halves via the GSI-wide cascade.
+          // This test asserts the v1.7.1 behavior change.)
+          mockUpdateItem.mockResolvedValueOnce({
+            Attributes: toAttributeMap({
+              userId: "u-1",
+              name: "Test",
+              tenantId: "t-1",
+              region: "us-east-1",
+              email: "a@b.com",
+              pk: "$myapp#v1#tenantuser#u-1",
+              sk: "$myapp#v1#tenantuser",
+              __edd_e__: "TenantUser",
+            }),
+          })
 
-        yield* SparseUpdateEntity.update({ userId: "u-1" }).pipe(
-          Entity.remove(["tenantId"]),
-          Entity.asModel,
-        )
+          yield* SparseUpdateEntity.update({ userId: "u-1" }).pipe(
+            Entity.remove(["tenantId"]),
+            Entity.asModel,
+          )
 
-        const call = mockUpdateItem.mock.calls[0]![0]
-        const names = call.ExpressionAttributeNames as Record<string, string>
-        const nameValues = Object.values(names)
-        // The removed attribute itself
-        expect(nameValues).toContain("tenantId")
-        // GSI key fields should also be removed
-        expect(nameValues).toContain("gsi1pk")
-        expect(nameValues).toContain("gsi1sk")
-        // All should appear in REMOVE clause
-        const expr = call.UpdateExpression as string
-        expect(expr).toContain("REMOVE")
-      }).pipe(Effect.provide(TestLayer)),
+          const call = mockUpdateItem.mock.calls[0]![0]
+          const names = call.ExpressionAttributeNames as Record<string, string>
+          const nameValues = Object.values(names)
+          // The removed attribute itself.
+          expect(nameValues).toContain("tenantId")
+          // pk's GSI key REMOVE'd via per-half cascade override.
+          expect(nameValues).toContain("gsi1pk")
+          // sk's GSI key NOT addressed (region untouched per the per-half gate).
+          expect(nameValues).not.toContain("gsi1sk")
+          const expr = call.UpdateExpression as string
+          expect(expr).toContain("REMOVE")
+        }).pipe(Effect.provide(TestLayer)),
     )
 
-    it.effect("remove of one GSI composite doesn't affect other GSIs", () =>
-      Effect.gen(function* () {
-        // Entity with two GSIs
-        class MultiGsiUser extends Schema.Class<MultiGsiUser>("MultiGsiUser")({
-          userId: Schema.String,
-          name: Schema.String,
-          tenantId: Schema.String,
-          region: Schema.String,
-          department: Schema.String,
-        }) {}
+    it.effect(
+      "remove of one GSI composite doesn't affect other GSIs (and only the touched half — v1.7.1)",
+      () =>
+        Effect.gen(function* () {
+          // Entity with two GSIs.
+          class MultiGsiUser extends Schema.Class<MultiGsiUser>("MultiGsiUser")({
+            userId: Schema.String,
+            name: Schema.String,
+            tenantId: Schema.String,
+            region: Schema.String,
+            department: Schema.String,
+          }) {}
 
-        const MultiGsiEntity = withConfig(
-          Entity.make({
-            model: MultiGsiUser,
-            entityType: "MultiGsiUser",
-            primaryKey: {
-              pk: { field: "pk", composite: ["userId"] },
-              sk: { field: "sk", composite: [] },
-            },
-            indexes: {
-              byTenant: {
-                name: "gsi1",
-                pk: { field: "gsi1pk", composite: ["tenantId"] },
-                sk: { field: "gsi1sk", composite: ["region"] },
+          const MultiGsiEntity = withConfig(
+            Entity.make({
+              model: MultiGsiUser,
+              entityType: "MultiGsiUser",
+              primaryKey: {
+                pk: { field: "pk", composite: ["userId"] },
+                sk: { field: "sk", composite: [] },
               },
-              byDepartment: {
-                name: "gsi2",
-                pk: { field: "gsi2pk", composite: ["department"] },
-                sk: { field: "gsi2sk", composite: [] },
+              indexes: {
+                byTenant: {
+                  name: "gsi1",
+                  pk: { field: "gsi1pk", composite: ["tenantId"] },
+                  sk: { field: "gsi1sk", composite: ["region"] },
+                },
+                byDepartment: {
+                  name: "gsi2",
+                  pk: { field: "gsi2pk", composite: ["department"] },
+                  sk: { field: "gsi2sk", composite: [] },
+                },
               },
-            },
-          }),
-        )
+            }),
+          )
 
-        mockUpdateItem.mockResolvedValueOnce({
-          Attributes: toAttributeMap({
-            userId: "u-1",
-            name: "Test",
-            tenantId: "t-1",
-            region: "us-east-1",
-            department: "eng",
-            pk: "$myapp#v1#multigsiuser#u-1",
-            sk: "$myapp#v1#multigsiuser",
-            __edd_e__: "MultiGsiUser",
-          }),
-        })
+          mockUpdateItem.mockResolvedValueOnce({
+            Attributes: toAttributeMap({
+              userId: "u-1",
+              name: "Test",
+              tenantId: "t-1",
+              region: "us-east-1",
+              department: "eng",
+              pk: "$myapp#v1#multigsiuser#u-1",
+              sk: "$myapp#v1#multigsiuser",
+              __edd_e__: "MultiGsiUser",
+            }),
+          })
 
-        // Remove tenantId (affects byTenant GSI) but not department (byDepartment should be untouched)
-        yield* MultiGsiEntity.update({ userId: "u-1" }).pipe(
-          Entity.remove(["tenantId"]),
-          Entity.asModel,
-        )
+          // Remove tenantId. byTenant: pk's tenantId in removedSet → pk
+          // touched, can't compose → preserve + cascade override → REMOVE
+          // gsi1pk. sk untouched (region not in payload, not in removedSet)
+          // → noop. byDepartment: department not in removedSet, not in
+          // payload → both halves untouched → noop.
+          yield* MultiGsiEntity.update({ userId: "u-1" }).pipe(
+            Entity.remove(["tenantId"]),
+            Entity.asModel,
+          )
 
-        const call = mockUpdateItem.mock.calls[0]![0]
-        const names = call.ExpressionAttributeNames as Record<string, string>
-        const nameValues = Object.values(names)
-        // byTenant GSI keys removed
-        expect(nameValues).toContain("gsi1pk")
-        expect(nameValues).toContain("gsi1sk")
-        // byDepartment GSI keys NOT removed
-        expect(nameValues).not.toContain("gsi2pk")
-        expect(nameValues).not.toContain("gsi2sk")
-      }).pipe(Effect.provide(TestLayer)),
+          const call = mockUpdateItem.mock.calls[0]![0]
+          const names = call.ExpressionAttributeNames as Record<string, string>
+          const nameValues = Object.values(names)
+          // byTenant pk REMOVE'd via per-half cascade.
+          expect(nameValues).toContain("gsi1pk")
+          // v1.7.1 critical: sk's gsi1sk NOT removed (the half wasn't touched).
+          expect(nameValues).not.toContain("gsi1sk")
+          // byDepartment GSI keys completely untouched.
+          expect(nameValues).not.toContain("gsi2pk")
+          expect(nameValues).not.toContain("gsi2sk")
+        }).pipe(Effect.provide(TestLayer)),
     )
   })
 

--- a/packages/effect-dynamodb/test/IndexPolicyV3.test.ts
+++ b/packages/effect-dynamodb/test/IndexPolicyV3.test.ts
@@ -218,29 +218,26 @@ describe("Entity update — indexPolicy v1.7.1 wiring (retain path)", () => {
     },
   )
 
-  it.effect(
-    "Entity.remove(['region']) — per-half cascade on PK; SK preserved",
-    () => {
-      // region is in pk only. Per-half cascade hits PK; SK preserved.
-      const capture: Capture = {}
-      return Effect.gen(function* () {
-        const db = yield* DynamoClient.make({
-          entities: { Assets },
-          tables: { AppTable },
-        })
-        yield* db.entities.Assets.update({ assetId: "a-1" }).remove(["region"])
-        const tx = capture.transactWriteItems
-        const item = (
-          tx as { TransactItems: Array<{ Put: { Item: Record<string, AttributeValue> } }> }
-        ).TransactItems[0]!.Put.Item
-        // gsi1pk REMOVE'd via per-half cascade override (preserve + can't-
-        // compose + region in removedSet).
-        expect(item.gsi1pk).toBeUndefined()
-        // gsi1sk preserved (untouched). v1.7.1 critical assertion.
-        expect(item.gsi1sk).toBeDefined()
-      }).pipe(Effect.provide(Layer.mergeAll(makeLayer(capture), TableLayer)), Effect.scoped)
-    },
-  )
+  it.effect("Entity.remove(['region']) — per-half cascade on PK; SK preserved", () => {
+    // region is in pk only. Per-half cascade hits PK; SK preserved.
+    const capture: Capture = {}
+    return Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { Assets },
+        tables: { AppTable },
+      })
+      yield* db.entities.Assets.update({ assetId: "a-1" }).remove(["region"])
+      const tx = capture.transactWriteItems
+      const item = (
+        tx as { TransactItems: Array<{ Put: { Item: Record<string, AttributeValue> } }> }
+      ).TransactItems[0]!.Put.Item
+      // gsi1pk REMOVE'd via per-half cascade override (preserve + can't-
+      // compose + region in removedSet).
+      expect(item.gsi1pk).toBeUndefined()
+      // gsi1sk preserved (untouched). v1.7.1 critical assertion.
+      expect(item.gsi1sk).toBeDefined()
+    }).pipe(Effect.provide(Layer.mergeAll(makeLayer(capture), TableLayer)), Effect.scoped)
+  })
 
   it.effect(
     "Hierarchical demote — set surviving composites + remove leaf → SET sk truncated",

--- a/packages/effect-dynamodb/test/IndexPolicyV3.test.ts
+++ b/packages/effect-dynamodb/test/IndexPolicyV3.test.ts
@@ -1,14 +1,21 @@
 /**
- * Entity-level integration tests for indexPolicy v3 semantics (refs #39).
+ * Entity-level integration tests for indexPolicy v1.7.1 semantics (closes #41).
  *
  * Covers the wiring through `Entity.update` (standard updateItem path),
  * `Entity.update` retain path, and `.append()`. KeyComposer-level unit tests
- * live in `KeyComposer.test.ts`; this file proves the v3 semantics make it
+ * live in `KeyComposer.test.ts`; this file proves the v1.7.1 semantics make it
  * through the Entity layer to the wire (UpdateExpression / TransactItems).
  *
  * The tests are mock-based (no DynamoDB) — they capture the request payload
  * sent to `client.updateItem` / `client.transactWriteItems` and assert on
  * the SET / REMOVE clauses and key composition.
+ *
+ * Renamed scenarios from the v1.7.0 file:
+ *   - "GSI-wide cascade" → "per-half cascade" (v1.7.1 bug-1 fix)
+ *   - "EDD-9024 throw under preserve" → "noop or REMOVE depending on cascade
+ *     override" (v1.7.1 bug-2 fix)
+ *   - "always-evaluated under policy" → "per-half evaluation gate" (v1.7.1
+ *     bug-3 fix)
  */
 
 import type { AttributeValue } from "@aws-sdk/client-dynamodb"
@@ -17,7 +24,7 @@ import { Effect, Layer, Schema } from "effect"
 import { DynamoClient } from "../src/DynamoClient.js"
 import * as DynamoSchema from "../src/DynamoSchema.js"
 import * as Entity from "../src/Entity.js"
-import { CompositeKeyHoleError, CompositeNullableError } from "../src/Errors.js"
+import { CompositeNullableError } from "../src/Errors.js"
 import * as Table from "../src/Table.js"
 
 // ---------------------------------------------------------------------------
@@ -139,44 +146,130 @@ const TableLayer = AppTable.layer({ name: "app-table" })
 // The Asset fixture uses retain: true so retain-path semantics are exercised.
 // ---------------------------------------------------------------------------
 
-describe("Entity update — indexPolicy v3 wiring (retain path)", () => {
-  it.effect("Entity.remove(['site']) cascades — drops both GSI keys", () => {
-    const capture: Capture = {}
-    return Effect.gen(function* () {
-      const db = yield* DynamoClient.make({
-        entities: { Assets },
-        tables: { AppTable },
-      })
-      yield* db.entities.Assets.update({ assetId: "a-1" }).remove(["site"])
+describe("Entity update — indexPolicy v1.7.1 wiring (retain path)", () => {
+  it.effect(
+    "Entity.remove(['site']) — per-half cascade on SK; structural rule truncates from stored composites",
+    () => {
+      // v1.7.1: cascade is per-half. `site` is in the SK composite list only.
+      // SK touched via removedSet → on the RETAIN path the stored country/city
+      // are available in newItem (read-then-write), so the structural rule
+      // composes the leading prefix [country, city] → SET sk truncated. The
+      // cascade override fires only when the rule CAN'T compose; here it can.
+      //
+      // This is the retain-path-specific outcome — on the standard path
+      // without surviving composites in the same call, `Entity.remove(['site'])`
+      // alone REMOVEs sk (set/remove asymmetry — see KeyComposer tests).
+      //
+      // PK untouched (region not in removedSet, not in payload) → noop,
+      // keeps the stored value.
+      //
+      // (v1.7.0 would have REMOVE'd both gsi1pk AND gsi1sk via the GSI-wide
+      // cascade. This test asserts the v1.7.1 behavior change — pk preserved,
+      // sk truncates not drops.)
+      const capture: Capture = {}
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { Assets },
+          tables: { AppTable },
+        })
+        yield* db.entities.Assets.update({ assetId: "a-1" }).remove(["site"])
 
-      const tx = capture.transactWriteItems
-      expect(tx).toBeDefined()
-      const items = (tx as { TransactItems?: Array<unknown> }).TransactItems
-      expect(items?.length).toBeGreaterThan(0)
-      const mainPut = items?.[0] as { Put?: { Item?: Record<string, AttributeValue> } }
-      const item = mainPut.Put?.Item
-      expect(item).toBeDefined()
-      expect(item!.gsi1pk).toBeUndefined()
-      expect(item!.gsi1sk).toBeUndefined()
-    }).pipe(Effect.provide(Layer.mergeAll(makeLayer(capture), TableLayer)), Effect.scoped)
-  })
+        const tx = capture.transactWriteItems
+        expect(tx).toBeDefined()
+        const items = (tx as { TransactItems?: Array<unknown> }).TransactItems
+        expect(items?.length).toBeGreaterThan(0)
+        const mainPut = items?.[0] as { Put?: { Item?: Record<string, AttributeValue> } }
+        const item = mainPut.Put?.Item
+        expect(item).toBeDefined()
+        // gsi1pk preserved (region untouched). v1.7.1 critical assertion.
+        expect(item!.gsi1pk).toBeDefined()
+        expect(item!.gsi1pk).toEqual({ S: "$app#v1#asset#region_americas" })
+        // gsi1sk truncated to [country, city] via structural rule (the retain
+        // path supplies surviving composites from stored attrs).
+        expect(item!.gsi1sk).toBeDefined()
+        expect((item!.gsi1sk as { S: string }).S).toBe("$app#v1#asset#country_us#city_sf")
+      }).pipe(Effect.provide(Layer.mergeAll(makeLayer(capture), TableLayer)), Effect.scoped)
+    },
+  )
 
-  it.effect("Entity.remove(['country']) cascades the whole GSI", () => {
-    const capture: Capture = {}
-    return Effect.gen(function* () {
-      const db = yield* DynamoClient.make({
-        entities: { Assets },
-        tables: { AppTable },
-      })
-      yield* db.entities.Assets.update({ assetId: "a-1" }).remove(["country"])
-      const tx = capture.transactWriteItems
-      const item = (
-        tx as { TransactItems: Array<{ Put: { Item: Record<string, AttributeValue> } }> }
-      ).TransactItems[0]!.Put.Item
-      expect(item.gsi1pk).toBeUndefined()
-      expect(item.gsi1sk).toBeUndefined()
-    }).pipe(Effect.provide(Layer.mergeAll(makeLayer(capture), TableLayer)), Effect.scoped)
-  })
+  it.effect(
+    "Entity.remove(['country']) — per-half cascade on SK; can't compose (hole) → REMOVE sk; PK preserved",
+    () => {
+      // country is at sk[0]. Removing it leaves [_, city, site] — hole at
+      // sk[0]. Hole = can't compose. Preserve + cascade override (country in
+      // removedSet) → REMOVE sk. PK preserved (region untouched).
+      const capture: Capture = {}
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { Assets },
+          tables: { AppTable },
+        })
+        yield* db.entities.Assets.update({ assetId: "a-1" }).remove(["country"])
+        const tx = capture.transactWriteItems
+        const item = (
+          tx as { TransactItems: Array<{ Put: { Item: Record<string, AttributeValue> } }> }
+        ).TransactItems[0]!.Put.Item
+        // gsi1pk preserved (region untouched).
+        expect(item.gsi1pk).toBeDefined()
+        // gsi1sk REMOVE'd via per-half cascade override (preserve + can't-
+        // compose + country in removedSet).
+        expect(item.gsi1sk).toBeUndefined()
+      }).pipe(Effect.provide(Layer.mergeAll(makeLayer(capture), TableLayer)), Effect.scoped)
+    },
+  )
+
+  it.effect(
+    "Entity.remove(['region']) — per-half cascade on PK; SK preserved",
+    () => {
+      // region is in pk only. Per-half cascade hits PK; SK preserved.
+      const capture: Capture = {}
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { Assets },
+          tables: { AppTable },
+        })
+        yield* db.entities.Assets.update({ assetId: "a-1" }).remove(["region"])
+        const tx = capture.transactWriteItems
+        const item = (
+          tx as { TransactItems: Array<{ Put: { Item: Record<string, AttributeValue> } }> }
+        ).TransactItems[0]!.Put.Item
+        // gsi1pk REMOVE'd via per-half cascade override (preserve + can't-
+        // compose + region in removedSet).
+        expect(item.gsi1pk).toBeUndefined()
+        // gsi1sk preserved (untouched). v1.7.1 critical assertion.
+        expect(item.gsi1sk).toBeDefined()
+      }).pipe(Effect.provide(Layer.mergeAll(makeLayer(capture), TableLayer)), Effect.scoped)
+    },
+  )
+
+  it.effect(
+    "Hierarchical demote — set surviving composites + remove leaf → SET sk truncated",
+    () => {
+      // Set/remove asymmetry. Supply country+city via set, invalidate site via
+      // remove. SK touched (set + removedSet), structural rule succeeds with
+      // leading prefix [country, city] → SET sk truncated (no cascade — the
+      // rule composed something).
+      const capture: Capture = {}
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { Assets },
+          tables: { AppTable },
+        })
+        yield* db.entities.Assets.update({ assetId: "a-1" })
+          .set({ country: "us", city: "sf" })
+          .remove(["site"])
+        const tx = capture.transactWriteItems
+        const item = (
+          tx as { TransactItems: Array<{ Put: { Item: Record<string, AttributeValue> } }> }
+        ).TransactItems[0]!.Put.Item
+        // gsi1pk preserved (region untouched, not in payload, not in removedSet).
+        expect(item.gsi1pk).toBeDefined()
+        // gsi1sk SET to truncated leading prefix [country, city].
+        expect(item.gsi1sk).toBeDefined()
+        expect((item.gsi1sk as { S: string }).S).toBe("$app#v1#asset#country_us#city_sf")
+      }).pipe(Effect.provide(Layer.mergeAll(makeLayer(capture), TableLayer)), Effect.scoped)
+    },
+  )
 })
 
 // ---------------------------------------------------------------------------
@@ -229,9 +322,9 @@ const makePagesMock = (capture: Capture) => ({
   getItem: () => Effect.die("getItem not expected on standard path"),
 })
 
-describe("Entity update — standard path migration regression (issue #36 / #39)", () => {
+describe("Entity update — standard path migration regression (issue #36 / #41)", () => {
   it.effect(
-    "partial update that omits preserve-policied composites does NOT generate REMOVE",
+    "partial update that omits preserve-policied composites does NOT generate REMOVE for any GSI key",
     () => {
       const capture: Capture = {}
       const layer = Layer.mergeAll(
@@ -243,12 +336,10 @@ describe("Entity update — standard path migration regression (issue #36 / #39)
           entities: { Pages },
           tables: { PagesTable },
         })
-        // Update only `name` — never mentions X, Y, Z. Pre-1.6 with sparse on
-        // those composites generated REMOVE gsi1pk/sk + gsi2pk/sk + gsi3pk/sk
-        // (six unwanted REMOVEs). Under v3 with all halves preserve, a partial
-        // update that doesn't touch X/Y/Z is a no-op for those PK halves (the
-        // SK halves recompose because they share the primary key composite
-        // pageId).
+        // Update only `name` — never mentions X, Y, Z, or pageId. Under
+        // v1.7.1 the per-half evaluation gate skips ALL halves of all three
+        // GSIs (none has a composite touched). The footgun stays closed:
+        // zero gsi*pk / gsi*sk REMOVEs in the UpdateExpression.
         yield* db.entities.Pages.update({ pageId: "p-1" }).set({ name: "new-name" })
         const ui = capture.updateItem as {
           UpdateExpression?: string
@@ -263,6 +354,17 @@ describe("Entity update — standard path migration regression (issue #36 / #39)
           .filter((s) => s.length > 0)
           .map((alias) => ui.ExpressionAttributeNames?.[alias] ?? alias)
         for (const name of physicalRemoves) {
+          expect(name).not.toMatch(/^gsi\d(pk|sk)$/)
+        }
+        // v1.7.1 additional assertion: no SETs on gsi*pk / gsi*sk either —
+        // halves are untouched, so the composer emits nothing.
+        const setClause = expr.match(/SET\s+(.*?)(?:\s+REMOVE|$)/i)?.[1] ?? ""
+        const setNames = setClause
+          .split(",")
+          .map((s) => s.split("=")[0]?.trim() ?? "")
+          .filter((s) => s.startsWith("#"))
+          .map((alias) => ui.ExpressionAttributeNames?.[alias] ?? alias)
+        for (const name of setNames) {
           expect(name).not.toMatch(/^gsi\d(pk|sk)$/)
         }
       }).pipe(Effect.provide(layer), Effect.scoped)
@@ -323,35 +425,31 @@ const makeHolesMock = (capture: Capture) => ({
   getItem: () => Effect.die("getItem not expected (no retain)"),
 })
 
-describe("Entity update — hole detection (v3 policy-aware)", () => {
-  it.effect("preserve + hole pattern surfaces as CompositeKeyHoleError (EDD-9024)", () => {
-    const capture: Capture = {}
-    const layer = Layer.mergeAll(
-      Layer.succeed(DynamoClient, makeHolesMock(capture) as any),
-      HolesTableLayer,
-    )
-    return Effect.gen(function* () {
-      const db = yield* DynamoClient.make({
-        entities: { PreserveHoles, SparseHoles },
-        tables: { HolesTable },
-      })
-      // city absent (omitted), site present → hole on SK at position 0.
-      const error = yield* db.entities.PreserveHoles.update({ assetId: "a-1" })
-        .set({ country: "us", site: "datacenter-2" })
-        .asEffect()
-        .pipe(Effect.flip)
-      expect(error).toBeInstanceOf(CompositeKeyHoleError)
-      const e = error as CompositeKeyHoleError
-      expect(e.indexName).toBe("gsi1")
-      expect(e.clearedComposite).toBe("city")
-      expect(e.trailingComposite).toBe("site")
-      expect(e.key).toBe("sk")
-    }).pipe(Effect.provide(layer), Effect.scoped)
-  })
+// Helper for parsing the captured UpdateExpression's REMOVE clause into a
+// set of physical attribute names.
+const parseRemoves = (ui: {
+  UpdateExpression?: string
+  ExpressionAttributeNames?: Record<string, string>
+}): Set<string> => {
+  const expr = ui.UpdateExpression ?? ""
+  const removeIdx = expr.indexOf("REMOVE")
+  if (removeIdx === -1) return new Set()
+  const removeTail = expr.slice(removeIdx + "REMOVE".length).trim()
+  const removeAliases = removeTail
+    .split(/[,\s]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && s.startsWith("#"))
+  return new Set(removeAliases.map((a) => ui.ExpressionAttributeNames?.[a] ?? a))
+}
 
+describe("Entity update — hole pattern under v1.7.1 (no throw, unified can't-compose)", () => {
   it.effect(
-    "sparse + hole pattern with empty leading prefix → drops both halves (no error)",
+    "preserve + hole pattern (no removedSet) → noop sk (NOT a throw — EDD-9024 deprecated)",
     () => {
+      // city absent (omitted), site present → hole on SK at position 0.
+      // v1.7.0 threw EDD-9024 here. v1.7.1: hole collapses into can't-
+      // compose; preserve + no removedSet → noop sk. PK touched (country in
+      // payload) → SET pk. Critical assertion: no error AND no gsi1sk REMOVE.
       const capture: Capture = {}
       const layer = Layer.mergeAll(
         Layer.succeed(DynamoClient, makeHolesMock(capture) as any),
@@ -362,8 +460,79 @@ describe("Entity update — hole detection (v3 policy-aware)", () => {
           entities: { PreserveHoles, SparseHoles },
           tables: { HolesTable },
         })
-        // Same hole pattern (city absent, site present), but sk is sparse and
-        // the leading prefix is empty → collapses to whole-half-empty + drop.
+        yield* db.entities.PreserveHoles.update({ assetId: "a-1" }).set({
+          country: "us",
+          site: "datacenter-2",
+        })
+        const ui = capture.updateItem as {
+          UpdateExpression?: string
+          ExpressionAttributeNames?: Record<string, string>
+        }
+        const removed = parseRemoves(ui)
+        // No EDD-9024. No gsi1sk REMOVE (preserve + no cascade → noop).
+        expect(removed.has("gsi1sk")).toBe(false)
+        // gsi1pk is touched (country in payload, where country IS a pk
+        // composite for PreserveHoles? checking — yes, pk = [country]) →
+        // SET. No REMOVE on gsi1pk.
+        expect(removed.has("gsi1pk")).toBe(false)
+      }).pipe(Effect.provide(layer), Effect.scoped)
+    },
+  )
+
+  it.effect(
+    "preserve + hole pattern + Entity.remove(['city']) → REMOVE sk via cascade override",
+    () => {
+      // Same hole pattern, but now city is in removedSet. SK touched (set has
+      // site, removedSet has city), can't compose → preserve + cascade
+      // override → REMOVE sk only. (Per-half cascade — pk untouched per the
+      // gate on this fixture; country is the pk composite and IS in the
+      // payload, so pk is also touched and SETs.)
+      const capture: Capture = {}
+      const layer = Layer.mergeAll(
+        Layer.succeed(DynamoClient, makeHolesMock(capture) as any),
+        HolesTableLayer,
+      )
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { PreserveHoles, SparseHoles },
+          tables: { HolesTable },
+        })
+        yield* db.entities.PreserveHoles.update({ assetId: "a-1" })
+          .set({ country: "us", site: "datacenter-2" })
+          .remove(["city"])
+        const ui = capture.updateItem as {
+          UpdateExpression?: string
+          ExpressionAttributeNames?: Record<string, string>
+        }
+        const removed = parseRemoves(ui)
+        // gsi1sk REMOVE'd via cascade override (preserve + can't-compose +
+        // city in removedSet).
+        expect(removed.has("gsi1sk")).toBe(true)
+        // gsi1pk NOT removed — country is the pk composite, touched, SETs.
+        expect(removed.has("gsi1pk")).toBe(false)
+        // city itself is also REMOVE'd from the item (the standard remove
+        // clause).
+        expect(removed.has("city")).toBe(true)
+      }).pipe(Effect.provide(layer), Effect.scoped)
+    },
+  )
+
+  it.effect(
+    "sparse + hole pattern (empty leading prefix) → REMOVE sk only (per-half, NOT GSI-wide)",
+    () => {
+      // SparseHoles: pk preserve, sk sparse. city absent + site present →
+      // hole + sparse → REMOVE sk only. Critical v1.7.1 assertion: gsi1pk
+      // is NOT REMOVE'd (the v1.7.0 GSI-wide cascade is gone).
+      const capture: Capture = {}
+      const layer = Layer.mergeAll(
+        Layer.succeed(DynamoClient, makeHolesMock(capture) as any),
+        HolesTableLayer,
+      )
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { PreserveHoles, SparseHoles },
+          tables: { HolesTable },
+        })
         yield* db.entities.SparseHoles.update({ assetId: "a-1" }).set({
           country: "us",
           site: "datacenter-2",
@@ -372,20 +541,13 @@ describe("Entity update — hole detection (v3 policy-aware)", () => {
           UpdateExpression?: string
           ExpressionAttributeNames?: Record<string, string>
         }
-        // gsi1pk + gsi1sk should be REMOVE'd, not SET. Pull the REMOVE-clause
-        // tokens directly: they're the aliases whose names map back to gsi1pk
-        // and gsi1sk. The expression has shape "SET ... REMOVE #r0, #r1".
         expect(ui.UpdateExpression).toMatch(/\bREMOVE\b/)
-        const expr = ui.UpdateExpression!
-        const removeIdx = expr.indexOf("REMOVE")
-        const removeTail = expr.slice(removeIdx + "REMOVE".length).trim()
-        const removeAliases = removeTail
-          .split(/[,\s]+/)
-          .map((s) => s.trim())
-          .filter((s) => s.length > 0 && s.startsWith("#"))
-        const removed = removeAliases.map((a) => ui.ExpressionAttributeNames?.[a] ?? a)
-        expect(removed).toContain("gsi1pk")
-        expect(removed).toContain("gsi1sk")
+        const removed = parseRemoves(ui)
+        // sk REMOVE'd via sparse + can't-compose.
+        expect(removed.has("gsi1sk")).toBe(true)
+        // pk NOT REMOVE'd — preserve + the country composite of pk is in
+        // payload → pk touched, SETs. v1.7.1 critical: NOT GSI-wide cascade.
+        expect(removed.has("gsi1pk")).toBe(false)
       }).pipe(Effect.provide(layer), Effect.scoped)
     },
   )

--- a/packages/effect-dynamodb/test/KeyComposer.test.ts
+++ b/packages/effect-dynamodb/test/KeyComposer.test.ts
@@ -339,17 +339,26 @@ describe("KeyComposer", () => {
   })
 
   // ---------------------------------------------------------------------------
-  // composeGsiKeysForUpdatePolicyAware — v3 per-half structural composition
-  // (DESIGN.md §7, refs #39)
+  // composeGsiKeysForUpdatePolicyAware — v1.7.1 per-half model
+  // (DESIGN.md §7, closes #41)
   //
   // Canonical fixture: pk.composite = [A], sk.composite = [B, C]. Tests cover
-  // the structural rule (longest leading prefix), policy-aware hole detection
-  // (truncate under sparse, throw under preserve), whole-half-empty +
-  // policy-driven drop, two-way classification (null = undefined = absent),
-  // cascade override, and PK/SK symmetry.
+  // the four pillars of the unified per-half model:
+  //   1. Per-half evaluation gate — untouched halves are skipped entirely.
+  //   2. Structural rule — longest leading prefix; trailing-absent truncates.
+  //   3. Per-half outcome — SET / noop (preserve+can't-compose+no-cascade) /
+  //      REMOVE (sparse OR preserve+cascade-override).
+  //   4. Per-half cascade — Entity.remove([attr]) affects only the half(s)
+  //      whose composite list contains the attr; other halves follow the gate.
+  //
+  // Key v1.7.1 deltas vs v1.7.0 (asserted explicitly throughout):
+  //   - Untouched-half scenarios noop instead of firing the policy.
+  //   - Per-half cascade replaces GSI-wide REMOVE on cascade.
+  //   - Per-half cascade replaces GSI-wide REMOVE on can't-compose under sparse.
+  //   - No EDD-9024 throw — hole patterns collapse into can't-compose.
   // ---------------------------------------------------------------------------
 
-  describe("composeGsiKeysForUpdatePolicyAware — v3 per-half model", () => {
+  describe("composeGsiKeysForUpdatePolicyAware — v1.7.1 per-half model", () => {
     const makeIndexes = (
       indexPolicy?: KeyComposer.IndexPolicy,
     ): Record<string, KeyComposer.IndexDefinition> => ({
@@ -365,10 +374,122 @@ describe("KeyComposer", () => {
       },
     })
 
-    // --- Default policy (no indexPolicy) — both halves preserve ---
+    // ----------------------------------------------------------------------
+    // Per-half evaluation gate (NEW in v1.7.1)
+    // ----------------------------------------------------------------------
 
-    describe("default policy (no indexPolicy → preserve, preserve)", () => {
-      it("all composites present → SET both halves", () => {
+    describe("per-half evaluation gate", () => {
+      it("payload doesn't mention any composite of either half → both halves noop", () => {
+        // No index policy, no composite in payload, no removedSet → composer
+        // returns nothing for this GSI. (The standard update path will then
+        // simply not emit any GSI-key SET/REMOVE clauses.)
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "sparse", sk: "sparse" }),
+          { unrelated: "x" },
+          { id: "i-1", A: "a", B: "b", C: "c" },
+        )
+        // v1.7.1 critical assertion: even with sparse on both halves, an
+        // untouched payload doesn't fire policy. (v1.7.0 would have REMOVE'd
+        // both halves here.)
+        expect(result.sets).toEqual({})
+        expect(result.removes).toEqual([])
+      })
+
+      it("payload touches PK composite only → PK evaluated, SK noop", () => {
+        // PK touched (A present in payload) → SET pk.
+        // SK untouched (neither B nor C in payload, and no removedSet) → noop.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "sparse" }),
+          { A: "a-new" }, // only PK touched
+          { id: "i-1", B: "b", C: "c" },
+        )
+        expect(result.sets.gsi1pk).toBeDefined()
+        // SK untouched — the v1.7.1 per-half gate shields it from sparse.
+        // (v1.7.0 would have REMOVE'd gsi1sk because sk is sparse and the
+        // policy was always-evaluated.)
+        expect(result.sets).not.toHaveProperty("gsi1sk")
+        expect(result.removes).toEqual([])
+      })
+
+      it("payload touches SK composite only → SK evaluated, PK noop", () => {
+        // Mirror image of the above. SK touched → SET sk. PK untouched → noop
+        // even under sparse policy.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "sparse", sk: "preserve" }),
+          { B: "b-new", C: "c-new" }, // only SK touched
+          { id: "i-1", A: "a" },
+        )
+        expect(result.sets.gsi1sk).toBeDefined()
+        expect(result.sets).not.toHaveProperty("gsi1pk")
+        expect(result.removes).toEqual([])
+      })
+
+      it("touched via undefined-payload still evaluates the half", () => {
+        // `B: undefined` makes B "in" the payload (in operator true) — the
+        // half is touched. But the value classifies as absent under the
+        // two-way rule. Empty leading prefix on SK + sparse → REMOVE sk.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "sparse" }),
+          { B: undefined },
+          { id: "i-1", A: "a" },
+        )
+        expect(result.removes).toContain("gsi1sk")
+        // PK untouched → noop.
+        expect(result.removes).not.toContain("gsi1pk")
+        expect(result.sets).not.toHaveProperty("gsi1pk")
+      })
+
+      it("touched via removedSet still evaluates the half", () => {
+        // removeSet contains "B" (an SK composite) → SK touched. SK can't
+        // compose without B (and C alone would be a hole anyway) → preserve +
+        // cascade override → REMOVE sk. PK untouched → noop.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "preserve" }),
+          {},
+          { id: "i-1", A: "a", B: "b", C: "c" },
+          { removedSet: new Set(["B"]) },
+        )
+        expect(result.removes).toContain("gsi1sk")
+        expect(result.removes).not.toContain("gsi1pk")
+      })
+
+      it("GSI without indexPolicy + no composites in payload → skipped (gate is the same)", () => {
+        // Same gate logic regardless of policy declaration; the policy only
+        // affects the OUTCOME for touched halves.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes(),
+          { unrelated: "x" },
+          { id: "i-1" },
+        )
+        expect(result.sets).toEqual({})
+        expect(result.removes).toEqual([])
+      })
+    })
+
+    // ----------------------------------------------------------------------
+    // Per-half outcome — SET (full / truncated)
+    // ----------------------------------------------------------------------
+
+    describe("structural rule — SET (full / truncated)", () => {
+      it("all composites present (touched via payload) → SET both halves full", () => {
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
@@ -377,371 +498,25 @@ describe("KeyComposer", () => {
           { A: "a", B: "b", C: "c" },
           { id: "i-1" },
         )
-        expect(result.sets).toHaveProperty("gsi1pk")
-        expect(result.sets).toHaveProperty("gsi1sk")
-        expect(result.removes).toEqual([])
-      })
-
-      it("only A in payload → SET pk; sk no-op (preserve + empty SK)", () => {
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes(),
-          { A: "a" },
-          { id: "i-1" },
-        )
-        expect(result.sets).toHaveProperty("gsi1pk")
-        expect(result.sets).not.toHaveProperty("gsi1sk")
-        expect(result.removes).toEqual([])
-      })
-
-      it("only B in payload → no SET on either half (PK empty + SK trailing-absent C)", () => {
-        // PK half: A absent → empty leading prefix → preserve no-op.
-        // SK half: B present + C trailing-absent → truncate to [B] (SET).
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes(),
-          { B: "b" },
-          { id: "i-1" },
-        )
-        expect(result.sets).not.toHaveProperty("gsi1pk")
-        expect(result.sets.gsi1sk).toBe("$myapp#v1#e#b_b")
-        expect(result.removes).toEqual([])
-      })
-
-      it("{A, B} → SET pk; SET sk truncated to [B] (C trailing-absent)", () => {
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes(),
-          { A: "a", B: "b" },
-          { id: "i-1" },
-        )
         expect(result.sets.gsi1pk).toBe("$myapp#v1#e#a_a")
-        expect(result.sets.gsi1sk).toBe("$myapp#v1#e#b_b")
-      })
-
-      it("{B, C} (A absent, no policy) → SET sk; pk no-op (preserve + empty PK)", () => {
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes(),
-          { B: "b", C: "c" },
-          { id: "i-1" },
-        )
-        expect(result.sets).not.toHaveProperty("gsi1pk")
-        expect(result.sets).toHaveProperty("gsi1sk")
-        expect(result.removes).toEqual([])
-      })
-
-      it("hole pattern under preserve → throws EDD-9024", () => {
-        // {A, C} present, B absent. Default policy is preserve, so the SK hole
-        // throws.
-        expect(() =>
-          KeyComposer.composeGsiKeysForUpdatePolicyAware(
-            schema,
-            "E",
-            1,
-            makeIndexes(),
-            { A: "a", C: "c" },
-            { id: "i-1" },
-          ),
-        ).toThrow(/EDD-9024/)
-      })
-    })
-
-    // --- Two-way payload classification: null = undefined = absent ---
-
-    describe("two-way payload classification (null = undefined = absent)", () => {
-      it("`{ B: null, ... }` and `{ ... }` (B omitted) produce identical outcomes", () => {
-        // Choose a non-hole, non-throwing scenario so we can directly compare.
-        // PK = [A], SK = [B, C]. Stored attrs supply A only. Payload has B
-        // either null or omitted; C is also absent. SK whole-half-empty +
-        // preserve → no-op on SK; PK has A → SET pk.
-        const r1 = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "preserve", sk: "preserve" }),
-          { B: null }, // B absent via null
-          { id: "i-1", A: "a" },
-        )
-        const r2 = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "preserve", sk: "preserve" }),
-          {}, // B absent via omission
-          { id: "i-1", A: "a" },
-        )
-        expect(r1.sets).toEqual(r2.sets)
-        expect(r1.removes).toEqual(r2.removes)
-        expect(r1.sets.gsi1pk).toBe("$myapp#v1#e#a_a")
-        expect(r1.sets).not.toHaveProperty("gsi1sk")
-      })
-
-      it("`{ B: null, C: 'c' }` is a hole pattern just like `{ C: 'c' }`", () => {
-        // Without keyRecord supplying values for A/B, only C is reachable.
-        // SK composites = [B, C], B absent (null), C present → hole.
-        expect(() =>
-          KeyComposer.composeGsiKeysForUpdatePolicyAware(
-            schema,
-            "E",
-            1,
-            makeIndexes(),
-            { B: null, C: "c" },
-            { id: "i-1", A: "a" },
-          ),
-        ).toThrow(/EDD-9024/)
-        expect(() =>
-          KeyComposer.composeGsiKeysForUpdatePolicyAware(
-            schema,
-            "E",
-            1,
-            makeIndexes(),
-            { C: "c" },
-            { id: "i-1", A: "a" },
-          ),
-        ).toThrow(/EDD-9024/)
-      })
-
-      it("`{ A: undefined }` is treated as absent (no preserve no-op for A's slot)", () => {
-        // PK half: A absent → empty leading prefix → preserve no-op (no SET, no
-        // REMOVE). SK half: both B and C present in stored attrs → SET.
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes(),
-          { A: undefined },
-          { id: "i-1", B: "b", C: "c" },
-        )
-        expect(result.sets).not.toHaveProperty("gsi1pk")
         expect(result.sets.gsi1sk).toBe("$myapp#v1#e#b_b#c_c")
-      })
-    })
-
-    // --- Whole-half-empty: policy decides ---
-
-    describe("whole-half-empty under sparse → REMOVE both halves", () => {
-      it("{ pk: 'sparse', sk: 'preserve' } + payload omits A entirely → drop", () => {
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "sparse", sk: "preserve" }),
-          { B: "b", C: "c" }, // A absent, no stored value either
-          { id: "i-1" },
-        )
-        expect(result.sets).toEqual({})
-        expect(result.removes).toEqual(["gsi1pk", "gsi1sk"])
+        expect(result.removes).toEqual([])
       })
 
-      it("{ pk: 'preserve', sk: 'sparse' } + only A in payload → drop", () => {
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "preserve", sk: "sparse" }),
-          { A: "a" },
-          { id: "i-1" }, // B, C absent — SK whole-half empty
-        )
-        expect(result.sets).toEqual({})
-        expect(result.removes).toEqual(["gsi1pk", "gsi1sk"])
-      })
-
-      it("{ pk: 'sparse', sk: 'sparse' } + nothing in payload (policy still always-evaluated) → drop", () => {
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "sparse", sk: "sparse" }),
-          { unrelated: "x" },
-          { id: "i-1" },
-        )
-        expect(result.sets).toEqual({})
-        expect(result.removes).toEqual(["gsi1pk", "gsi1sk"])
-      })
-    })
-
-    describe("whole-half-empty under preserve → no-op (leave stored values)", () => {
-      it("default policy + payload doesn't touch GSI composites → skipped (no eval)", () => {
+      it("trailing-absent on SK (B touched, C absent) → SET sk truncated to [B]", () => {
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           makeIndexes(),
-          { unrelated: "x" },
-          { id: "i-1" },
-        )
-        expect(result.sets).toEqual({})
-        expect(result.removes).toEqual([])
-      })
-
-      it("explicit { pk: 'preserve', sk: 'preserve' } + nothing in payload → no-op (eval, but no writes)", () => {
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "preserve", sk: "preserve" }),
-          { unrelated: "x" },
-          { id: "i-1" },
-        )
-        expect(result.sets).toEqual({})
-        expect(result.removes).toEqual([])
-      })
-    })
-
-    // --- Hole detection: policy-aware ---
-
-    describe("hole detection — policy-aware (sparse truncates, preserve throws)", () => {
-      it("hole on SK + preserve → throws EDD-9024 with location info", () => {
-        try {
-          KeyComposer.composeGsiKeysForUpdatePolicyAware(
-            schema,
-            "E",
-            1,
-            makeIndexes({ pk: "preserve", sk: "preserve" }),
-            { A: "a", C: "c" }, // B absent at sk[0], C present at sk[1]
-            { id: "i-1" },
-          )
-        } catch (e) {
-          expect(e).toMatchObject({
-            _tag: "CompositeKeyHoleError",
-            indexName: "gsi1",
-            clearedComposite: "B",
-            trailingComposite: "C",
-            key: "sk",
-            clearedPosition: 0,
-            trailingPosition: 1,
-          })
-          const msg = (e as { message: string }).message
-          expect(msg).toContain("EDD-9024")
-          expect(msg).toContain("'preserve'")
-          return
-        }
-        throw new Error("expected throw")
-      })
-
-      it("hole on SK + sparse with non-empty leading prefix → silently truncates", () => {
-        // SK = [B, C, D]: B present at sk[0], C absent at sk[1], D present at
-        // sk[2] → hole. Under sparse, truncate to the leading prefix [B].
-        const indexes: Record<string, KeyComposer.IndexDefinition> = {
-          primary: { pk: { field: "pk", composite: ["id"] }, sk: { field: "sk", composite: [] } },
-          g1: {
-            index: "gsi1",
-            pk: { field: "gsi1pk", composite: ["A"] },
-            sk: { field: "gsi1sk", composite: ["B", "C", "D"] },
-            indexPolicy: { pk: "preserve", sk: "sparse" },
-          },
-        }
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          indexes,
-          { A: "a", B: "b", D: "d" }, // C absent → hole
+          { A: "a", B: "b" }, // C trailing-absent
           { id: "i-1" },
         )
         expect(result.sets.gsi1pk).toBe("$myapp#v1#e#a_a")
         expect(result.sets.gsi1sk).toBe("$myapp#v1#e#b_b") // truncated to [B]
       })
 
-      it("hole on SK + sparse with empty leading prefix → drops both halves", () => {
-        // SK = [B, C], B absent, C present, leading prefix is empty → sparse
-        // collapses this to whole-half-empty + drop.
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "preserve", sk: "sparse" }),
-          { A: "a", C: "c" },
-          { id: "i-1" },
-        )
-        expect(result.sets).toEqual({})
-        expect(result.removes).toEqual(["gsi1pk", "gsi1sk"])
-      })
-
-      it("hole on PK + preserve → throws EDD-9024 (PK and SK symmetric in v3)", () => {
-        // PK = [A1, A2] now. Construct an index with multi-PK so a PK hole is
-        // expressible.
-        const indexes: Record<string, KeyComposer.IndexDefinition> = {
-          primary: { pk: { field: "pk", composite: ["id"] }, sk: { field: "sk", composite: [] } },
-          g1: {
-            index: "gsi1",
-            pk: { field: "gsi1pk", composite: ["A1", "A2"] },
-            sk: { field: "gsi1sk", composite: [] },
-            indexPolicy: { pk: "preserve", sk: "preserve" },
-          },
-        }
-        try {
-          KeyComposer.composeGsiKeysForUpdatePolicyAware(
-            schema,
-            "E",
-            1,
-            indexes,
-            { A2: "a2" }, // A1 absent at pk[0], A2 present at pk[1]
-            { id: "i-1" },
-          )
-        } catch (e) {
-          expect(e).toMatchObject({
-            _tag: "CompositeKeyHoleError",
-            indexName: "gsi1",
-            key: "pk",
-          })
-          return
-        }
-        throw new Error("expected throw")
-      })
-
-      it("hole on PK + sparse → truncates to empty PK + sparse-on-empty drops both halves", () => {
-        const indexes: Record<string, KeyComposer.IndexDefinition> = {
-          primary: { pk: { field: "pk", composite: ["id"] }, sk: { field: "sk", composite: [] } },
-          g1: {
-            index: "gsi1",
-            pk: { field: "gsi1pk", composite: ["A1", "A2"] },
-            sk: { field: "gsi1sk", composite: [] },
-            indexPolicy: { pk: "sparse", sk: "preserve" },
-          },
-        }
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          indexes,
-          { A2: "a2" }, // A1 absent → leading prefix empty → sparse drops both
-          { id: "i-1" },
-        )
-        expect(result.sets).toEqual({})
-        expect(result.removes).toEqual(["gsi1pk", "gsi1sk"])
-      })
-
-      it("multi-clear at consecutive trailing positions is OK (no hole)", () => {
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "preserve", sk: "preserve" }),
-          { B: null, C: null },
-          { id: "i-1", A: "a" },
-        )
-        expect(result.sets.gsi1pk).toBe("$myapp#v1#e#a_a")
-        // SK leading prefix is empty + preserve → no SET on SK. (Different from
-        // the v1.6 'truncate-to-empty-prefix' behavior under preserve.)
-        expect(result.sets).not.toHaveProperty("gsi1sk")
-        expect(result.removes).toEqual([])
-      })
-    })
-
-    // --- Hierarchical truncation (PK and SK symmetric) ---
-
-    describe("hierarchical truncation — symmetric PK and SK", () => {
-      it("PK truncation: { pk: 'preserve' } + multi-PK + trailing-absent", () => {
+      it("trailing-absent on multi-PK → SET pk truncated to leading prefix", () => {
         const indexes: Record<string, KeyComposer.IndexDefinition> = {
           primary: { pk: { field: "pk", composite: ["id"] }, sk: { field: "sk", composite: [] } },
           g1: {
@@ -759,119 +534,441 @@ describe("KeyComposer", () => {
           { accountId: "acct-1" }, // fleetId trailing-absent
           { id: "i-1" },
         )
-        // PK truncated to leading prefix [accountId].
         expect(result.sets.gsi1pk).toBe("$myapp#v1#vehicle#accountid_acct-1")
         expect(result.removes).toEqual([])
       })
 
-      it("SK truncation: { sk: 'preserve' } + multi-SK + trailing-absent", () => {
-        // Same structure on the SK side — { B, C absent } truncates SK to [B's prefix].
-        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "preserve", sk: "preserve" }),
-          { A: "a", B: "b" },
-          { id: "i-1" },
-        )
-        expect(result.sets.gsi1pk).toBe("$myapp#v1#e#a_a")
-        expect(result.sets.gsi1sk).toBe("$myapp#v1#e#b_b")
-      })
-
-      it("SK truncation under sparse: trailing-absent is the same as preserve (no policy diff)", () => {
+      it("trailing-absent under sparse (touched + leading prefix non-empty) → SET truncated", () => {
+        // Sparse only fires when the half can't compose at all. Trailing-
+        // absent with a non-empty leading prefix composes fine.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           makeIndexes({ pk: "preserve", sk: "sparse" }),
-          { A: "a", B: "b" },
+          { A: "a", B: "b" }, // C absent
           { id: "i-1" },
         )
         expect(result.sets.gsi1pk).toBe("$myapp#v1#e#a_a")
         expect(result.sets.gsi1sk).toBe("$myapp#v1#e#b_b")
       })
-    })
 
-    // --- Cascade override unchanged ---
-
-    describe("cascade — Entity.remove([attr]) overrides everything", () => {
-      it("cascade composite of GSI → REMOVE both halves regardless of policy", () => {
-        const r = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+      it("hierarchical truncation via set+remove (set/remove asymmetry)", () => {
+        // Demote: supply surviving composites via set, invalidate the leaf
+        // via remove. Per-half cascade fires on the half containing the
+        // removed leaf — but the leading prefix is non-empty, so the
+        // structural rule composes the truncated prefix.
+        //
+        // Wait — under v1.7.1 cascade only triggers REMOVE when the
+        // structural rule CAN'T compose. The leading prefix here is
+        // non-empty, so the structural rule SUCCEEDS and SETs. The set/
+        // remove asymmetry is honored automatically.
+        const indexes: Record<string, KeyComposer.IndexDefinition> = {
+          primary: { pk: { field: "pk", composite: ["id"] }, sk: { field: "sk", composite: [] } },
+          g1: {
+            index: "gsi1",
+            pk: { field: "gsi1pk", composite: ["region"] },
+            sk: { field: "gsi1sk", composite: ["country", "city", "site"] },
+            indexPolicy: { pk: "preserve", sk: "preserve" },
+          },
+        }
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
-          "E",
+          "Asset",
           1,
-          makeIndexes({ pk: "preserve", sk: "preserve" }),
-          {},
-          { id: "i-1", A: "a", B: "b", C: "c" },
-          { removedSet: new Set(["A"]) },
-        )
-        expect(r.sets).toEqual({})
-        expect(r.removes).toEqual(["gsi1pk", "gsi1sk"])
-      })
-
-      it("cascade fires even with empty payload (cascade is a touch signal)", () => {
-        const r = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes(),
-          {},
+          indexes,
+          { country: "us", city: "sf" }, // surviving composites supplied
           { id: "i-1" },
-          { removedSet: new Set(["B"]) },
+          { removedSet: new Set(["site"]) }, // leaf invalidated
         )
-        expect(r.removes).toEqual(["gsi1pk", "gsi1sk"])
-      })
-
-      it("cascade overrides preserve-truncate", () => {
-        const r = KeyComposer.composeGsiKeysForUpdatePolicyAware(
-          schema,
-          "E",
-          1,
-          makeIndexes({ pk: "preserve", sk: "preserve" }),
-          { B: null }, // would otherwise truncate SK to []
-          { id: "i-1", A: "a" },
-          { removedSet: new Set(["B"]) },
-        )
-        expect(r.sets).toEqual({})
-        expect(r.removes).toEqual(["gsi1pk", "gsi1sk"])
+        // SK: composite list [country, city, site]; site removed; leading
+        // prefix [country, city] composes. Per-half cascade is fine because
+        // the structural rule succeeded — the cascade override only fires
+        // when the rule CAN'T compose.
+        expect(result.sets.gsi1sk).toBe("$myapp#v1#asset#country_us#city_sf")
+        // PK untouched (region not in payload, no removedSet) → noop.
+        expect(result.sets).not.toHaveProperty("gsi1pk")
+        expect(result.removes).not.toContain("gsi1pk")
       })
     })
 
-    // --- Touched gate ---
+    // ----------------------------------------------------------------------
+    // Per-half outcome — sparse + can't-compose → REMOVE
+    // ----------------------------------------------------------------------
 
-    describe("touched gate", () => {
-      it("GSI without indexPolicy + no composites in payload → skipped (no eval)", () => {
+    describe("sparse + touched + can't-compose → REMOVE this half only (NOT GSI-wide)", () => {
+      it("sparse pk + payload touches A as undefined → REMOVE pk only", () => {
+        // PK touched (A in payload as undefined → in operator true). Empty
+        // leading prefix → can't compose → sparse → REMOVE pk only.
+        // SK untouched → noop. Critical: gsi1sk must NOT be in removes.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
-          makeIndexes(),
-          { unrelated: "x" },
+          makeIndexes({ pk: "sparse", sk: "preserve" }),
+          { A: undefined },
+          { id: "i-1", B: "b", C: "c" },
+        )
+        expect(result.removes).toEqual(["gsi1pk"])
+        expect(result.sets).toEqual({})
+      })
+
+      it("sparse sk + payload touches B as undefined → REMOVE sk only", () => {
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "sparse" }),
+          { B: undefined },
+          { id: "i-1", A: "a" }, // C absent too
+        )
+        // SK touched (B in payload as undefined). Empty leading prefix →
+        // sparse → REMOVE sk. PK untouched → noop. (v1.7.0 would have
+        // REMOVE'd gsi1pk too via the GSI-wide cascade.)
+        expect(result.removes).toEqual(["gsi1sk"])
+        expect(result.sets).toEqual({})
+      })
+
+      it("sparse sk + hole (B absent + C present in payload) → REMOVE sk only", () => {
+        // Hole pattern collapses into can't-compose under v1.7.1 (no more
+        // silent truncate-and-discard). SK touched (C in payload). Empty
+        // leading prefix (B absent) → can't compose → sparse → REMOVE sk.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "sparse" }),
+          { C: "c" }, // B absent → hole at sk[0]
+          { id: "i-1", A: "a" },
+        )
+        expect(result.removes).toEqual(["gsi1sk"])
+        expect(result.sets).not.toHaveProperty("gsi1pk")
+      })
+
+      it("sparse sk + hole with non-empty leading prefix (B present, C absent, D present) → REMOVE sk", () => {
+        // SK = [B, C, D]: B present, C absent, D present → hole at C. Under
+        // v1.7.1, holes are can't-compose regardless of leading prefix
+        // length. Sparse → REMOVE sk. (v1.7.0 would have silently truncated
+        // to [B] and discarded D — that's gone.)
+        const indexes: Record<string, KeyComposer.IndexDefinition> = {
+          primary: { pk: { field: "pk", composite: ["id"] }, sk: { field: "sk", composite: [] } },
+          g1: {
+            index: "gsi1",
+            pk: { field: "gsi1pk", composite: ["A"] },
+            sk: { field: "gsi1sk", composite: ["B", "C", "D"] },
+            indexPolicy: { pk: "preserve", sk: "sparse" },
+          },
+        }
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          indexes,
+          { A: "a", B: "b", D: "d" }, // C absent → hole
+          { id: "i-1" },
+        )
+        // PK touched (A in payload) → SET. SK touched (B, D in payload),
+        // hole → REMOVE sk.
+        expect(result.sets.gsi1pk).toBe("$myapp#v1#e#a_a")
+        expect(result.removes).toEqual(["gsi1sk"])
+      })
+    })
+
+    // ----------------------------------------------------------------------
+    // Per-half outcome — preserve + can't-compose + no cascade → noop
+    // ----------------------------------------------------------------------
+
+    describe("preserve + touched + can't-compose + no cascade → noop (stored key may be stale)", () => {
+      it("preserve sk + B undefined (no removedSet) → noop sk; pk noop too", () => {
+        // SK touched via undefined. Empty leading prefix (no stored B/C
+        // either) → can't compose. Preserve + no cascade → noop. The stored
+        // gsi1sk (whatever it was) stays. PK untouched → noop.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "preserve" }),
+          { B: undefined },
           { id: "i-1" },
         )
         expect(result.sets).toEqual({})
         expect(result.removes).toEqual([])
       })
 
-      it("GSI WITH indexPolicy is always evaluated, even when no composite in payload", () => {
-        // Policy declaration opts the GSI into event-style evaluation; a
-        // sparse half + whole-half-empty still drops.
+      it("preserve sk + hole (B absent, C present) + no removedSet → noop sk", () => {
+        // SK touched (C in payload). Hole pattern → can't compose. Preserve
+        // + no cascade → noop. PK touched (A in payload) → SET.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
-          makeIndexes({ pk: "sparse", sk: "preserve" }),
-          { unrelated: "x" }, // A, B, C all absent
+          makeIndexes({ pk: "preserve", sk: "preserve" }),
+          { A: "a", C: "c" }, // B absent
           { id: "i-1" },
         )
-        expect(result.removes).toEqual(["gsi1pk", "gsi1sk"])
+        // v1.7.1: no throw. Hole collapses into can't-compose.
+        expect(result.sets.gsi1pk).toBeDefined()
+        expect(result.sets).not.toHaveProperty("gsi1sk")
+        expect(result.removes).toEqual([])
       })
     })
 
-    // --- Multiple GSIs evaluated independently ---
+    // ----------------------------------------------------------------------
+    // Per-half outcome — preserve + can't-compose + cascade override → REMOVE
+    // ----------------------------------------------------------------------
+
+    describe("cascade override under preserve (NEW in v1.7.1)", () => {
+      it("preserve sk + Entity.remove(['B']) (no surviving composites) → REMOVE sk only", () => {
+        // SK touched via removedSet on B. Empty leading prefix (no B/C
+        // anywhere). Preserve + cascade override → REMOVE sk. PK untouched
+        // → noop.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "preserve" }),
+          {},
+          { id: "i-1", A: "a" }, // no B/C stored
+          { removedSet: new Set(["B"]) },
+        )
+        expect(result.removes).toEqual(["gsi1sk"])
+        expect(result.sets).not.toHaveProperty("gsi1pk")
+      })
+
+      it("preserve pk + Entity.remove(['A']) (no surviving composites) → REMOVE pk only", () => {
+        // Mirror image. PK touched via removedSet. Empty leading prefix
+        // (A absent). Preserve + cascade override → REMOVE pk. SK untouched
+        // → noop. (v1.7.0 would have REMOVE'd both halves.)
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "preserve" }),
+          {},
+          { id: "i-1", B: "b", C: "c" }, // no A stored
+          { removedSet: new Set(["A"]) },
+        )
+        expect(result.removes).toEqual(["gsi1pk"])
+        expect(result.removes).not.toContain("gsi1sk")
+      })
+
+      it("preserve sk + Entity.remove(['B']) WITH surviving stored A → cascade override fires only on sk", () => {
+        // PK has stored A but PK is untouched (no A in payload, no A in
+        // removedSet) → noop. SK touched via removedSet on B; can't compose
+        // → preserve + cascade override → REMOVE sk.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "preserve" }),
+          {},
+          { id: "i-1", A: "a" },
+          { removedSet: new Set(["B"]) },
+        )
+        expect(result.removes).toEqual(["gsi1sk"])
+        expect(result.sets).not.toHaveProperty("gsi1pk") // pk untouched, noop
+      })
+
+      it("preserve + cascade override is per-half — multi-half scenario", () => {
+        // Both halves preserve, single GSI with composites split between halves.
+        // Update touches PK only (via removedSet). PK can't compose →
+        // cascade override → REMOVE pk. SK untouched → noop.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "preserve" }),
+          {},
+          { id: "i-1", B: "b", C: "c" }, // SK still composable from stored
+          { removedSet: new Set(["A"]) },
+        )
+        expect(result.removes).toEqual(["gsi1pk"])
+        // SK untouched → not addressed at all (neither in sets nor removes).
+        expect(result.sets).not.toHaveProperty("gsi1sk")
+      })
+    })
+
+    // ----------------------------------------------------------------------
+    // Two-way payload classification: null = undefined = (omitted-but-touched)
+    // ----------------------------------------------------------------------
+
+    describe("two-way payload classification", () => {
+      it("payload `{ B: null }` and `{ B: undefined }` produce identical outcomes", () => {
+        const r1 = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "sparse" }),
+          { B: null },
+          { id: "i-1", A: "a" },
+        )
+        const r2 = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes({ pk: "preserve", sk: "sparse" }),
+          { B: undefined },
+          { id: "i-1", A: "a" },
+        )
+        expect(r1.sets).toEqual(r2.sets)
+        expect(r1.removes).toEqual(r2.removes)
+      })
+
+      it("`{ A: undefined }` is touched + absent (PK eval fires)", () => {
+        // PK touched (A in payload). A is absent (undefined). Empty leading
+        // prefix → preserve + no cascade → noop pk. SK untouched → noop.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          makeIndexes(),
+          { A: undefined },
+          { id: "i-1", B: "b", C: "c" },
+        )
+        expect(result.sets).toEqual({})
+        expect(result.removes).toEqual([])
+      })
+    })
+
+    // ----------------------------------------------------------------------
+    // Multi-writer round-trip via the gate — the v1.7.0 leak closure
+    // ----------------------------------------------------------------------
+
+    describe("multi-writer round-trip (per-half gate closes the v1.7.0 leak)", () => {
+      // Canonical hybrid GSI: pk owned by enrichment writer, sk owned by
+      // telemetry writer. Stored: A="acme", B="active", C=T1.
+      const hybrid = {
+        primary: {
+          pk: { field: "pk", composite: ["id"] },
+          sk: { field: "sk", composite: [] },
+        },
+        g1: {
+          index: "gsi1",
+          pk: { field: "gsi1pk", composite: ["A"] },
+          sk: { field: "gsi1sk", composite: ["B", "C"] },
+          indexPolicy: { pk: "preserve", sk: "sparse" } as KeyComposer.IndexPolicy,
+        },
+      }
+      const stored = { id: "i-1", A: "acme", B: "active", C: "t1" }
+
+      it("stamp scenario — `{ unrelated: 'x' }` → both halves untouched, no writes (closes v1.7.0 bug-3)", () => {
+        // The v1.7.0 leak: a stamp writer that doesn't touch the GSI's
+        // composites would still trigger sparse on sk and REMOVE gsi1sk.
+        // Under v1.7.1, the per-half gate skips both halves entirely.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          hybrid,
+          { unrelated: "x" },
+          stored,
+        )
+        expect(result.sets).toEqual({})
+        expect(result.removes).toEqual([])
+      })
+
+      it("enrichment writer — `{ A: 'newAcct' }` → SET pk; sk untouched", () => {
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          hybrid,
+          { A: "newAcct" },
+          stored,
+        )
+        expect(result.sets.gsi1pk).toBeDefined()
+        expect(result.sets).not.toHaveProperty("gsi1sk")
+        expect(result.removes).toEqual([])
+      })
+
+      it("telemetry writer (active alert) — `{ B: 'active', C: T2 }` → SET sk; pk untouched", () => {
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          hybrid,
+          { B: "active", C: "t2" },
+          stored,
+        )
+        expect(result.sets.gsi1sk).toBeDefined()
+        expect(result.sets).not.toHaveProperty("gsi1pk")
+        expect(result.removes).toEqual([])
+      })
+
+      it("telemetry writer (no alert) — `{ C: T2 }` → REMOVE sk only (sparse + hole); pk untouched", () => {
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          hybrid,
+          { C: "t2" }, // B not in payload — hole pattern relative to stored B
+          { ...stored, B: undefined }, // simulate stored B already absent
+        )
+        // SK touched (C in payload), structural rule sees no B → can't compose
+        // → sparse → REMOVE sk only. PK untouched → noop. (v1.7.0 would have
+        // REMOVE'd gsi1pk too.)
+        expect(result.removes).toEqual(["gsi1sk"])
+        expect(result.sets).not.toHaveProperty("gsi1pk")
+      })
+
+      it("rejoin — telemetry writes B+C after a drop, SET sk; pk preserved (no enrichment re-fire)", () => {
+        // Item state: gsi1pk = "acme" (preserved), gsi1sk REMOVE'd from a
+        // prior drop. Telemetry now sends both B and C → SET sk. Critical:
+        // the test confirms the composer doesn't disturb pk in either
+        // direction (no SET, no REMOVE) — meaning the stored gsi1pk persists
+        // in the database without enrichment having to re-fire.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          hybrid,
+          { B: "active", C: "t3" },
+          { id: "i-1", A: "acme" }, // sk dropped previously; pk still stored
+        )
+        expect(result.sets.gsi1sk).toBeDefined()
+        expect(result.sets).not.toHaveProperty("gsi1pk")
+        expect(result.removes).toEqual([])
+      })
+
+      it("explicit clear — `Entity.remove(['B'])` → REMOVE sk only via per-half cascade", () => {
+        // Per-half cascade: removedSet on B touches sk only. pk untouched →
+        // noop. (v1.7.0 would have REMOVE'd both halves.)
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          hybrid,
+          {},
+          stored,
+          { removedSet: new Set(["B"]) },
+        )
+        expect(result.removes).toEqual(["gsi1sk"])
+        expect(result.sets).not.toHaveProperty("gsi1pk")
+      })
+
+      it("explicit clear on PK — `Entity.remove(['A'])` → REMOVE pk only via per-half cascade", () => {
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "E",
+          1,
+          hybrid,
+          {},
+          stored,
+          { removedSet: new Set(["A"]) },
+        )
+        expect(result.removes).toEqual(["gsi1pk"])
+        // sk untouched → noop, NOT removed. (v1.7.0 would have REMOVE'd both.)
+        expect(result.removes).not.toContain("gsi1sk")
+        expect(result.sets).not.toHaveProperty("gsi1sk")
+      })
+    })
+
+    // ----------------------------------------------------------------------
+    // Multi-GSI independence
+    // ----------------------------------------------------------------------
 
     describe("multi-GSI independence", () => {
-      it("two GSIs with different policies evaluate independently", () => {
+      it("two GSIs with different policies evaluate independently per-half", () => {
         const indexes: Record<string, KeyComposer.IndexDefinition> = {
           primary: { pk: { field: "pk", composite: ["id"] }, sk: { field: "sk", composite: [] } },
           g1: {
@@ -887,25 +984,61 @@ describe("KeyComposer", () => {
             indexPolicy: { pk: "preserve", sk: "preserve" },
           },
         }
+        // Payload touches A (g1.pk), C (g2.pk). g1.sk untouched (B not
+        // present). g2.sk untouched (D not present).
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           indexes,
-          { A: "a", C: "c" }, // g1: B absent + sparse → drop; g2: D absent + preserve → SET pk only
+          { A: "a", C: "c" },
           { id: "i-1" },
         )
-        expect(result.removes).toContain("gsi1pk")
-        expect(result.removes).toContain("gsi1sk")
+        // g1.pk: touched, SET. g1.sk: untouched, noop (v1.7.0 would have
+        // REMOVE'd because sparse-on-untouched fired).
+        expect(result.sets.gsi1pk).toBeDefined()
+        expect(result.removes).not.toContain("gsi1sk")
+        // g2.pk: touched, SET. g2.sk: untouched, noop.
         expect(result.sets.gsi2pk).toBeDefined()
-        expect(result.sets).not.toHaveProperty("gsi2sk")
+        expect(result.removes).not.toContain("gsi2sk")
       })
     })
 
-    // --- keyRecord merging (GSI composites pulled from primary key) ---
+    // ----------------------------------------------------------------------
+    // keyRecord merging — composites pulled from primary key
+    // ----------------------------------------------------------------------
 
     describe("keyRecord merging", () => {
-      it("PK composites from keyRecord fill in for GSI composites", () => {
+      it("PK composites in keyRecord fill in for GSI composites + payload supplies the other half", () => {
+        const indexes: Record<string, KeyComposer.IndexDefinition> = {
+          primary: {
+            pk: { field: "pk", composite: ["userId"] },
+            sk: { field: "sk", composite: [] },
+          },
+          byUserRole: {
+            index: "gsi1",
+            pk: { field: "gsi1pk", composite: ["role"] },
+            sk: { field: "gsi1sk", composite: ["userId"] },
+          },
+        }
+        // Payload touches role (gsi1.pk). gsi1.sk has userId — userId is in
+        // keyRecord but NOT in payload → sk is untouched per the gate, noop.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "User",
+          1,
+          indexes,
+          { role: "admin" },
+          { userId: "u-1" },
+        )
+        // pk: role touched → SET pk full from role.
+        expect(result.sets.gsi1pk).toBeDefined()
+        // sk: userId NOT in payload (only in keyRecord) → untouched, noop.
+        expect(result.sets).not.toHaveProperty("gsi1sk")
+      })
+
+      it("payload supplies a key that's also a GSI composite → SK touched, recompose from keyRecord", () => {
+        // Same shape but payload touches userId too — sk becomes touched.
         const indexes: Record<string, KeyComposer.IndexDefinition> = {
           primary: {
             pk: { field: "pk", composite: ["userId"] },
@@ -922,7 +1055,7 @@ describe("KeyComposer", () => {
           "User",
           1,
           indexes,
-          { role: "admin" },
+          { role: "admin", userId: "u-1" }, // userId touched
           { userId: "u-1" },
         )
         expect(result.sets.gsi1pk).toBeDefined()
@@ -930,16 +1063,22 @@ describe("KeyComposer", () => {
       })
     })
 
-    // --- Migration regression (the consumer footgun reproducer) ---
+    // ----------------------------------------------------------------------
+    // Issue #36 / #41 migration regression
+    // ----------------------------------------------------------------------
 
-    describe("migration regression — issue #36 + #39 (sparse footgun closed)", () => {
-      it("partial update with omitted preserve-policied composites does NOT generate REMOVE", () => {
-        // Captured shape from consumer report: a 3-GSI entity where each GSI's
-        // PK is a single attr the consumer touches under a separate
-        // workflow. Under v3 declaring all halves preserve means a partial
-        // update that doesn't touch X/Y/Z is a no-op for those GSIs (the SK
-        // halves recompose because they share the primary key composite, the
-        // PK halves no-op).
+    describe("migration regression — issue #36 / #41 (sparse footgun stays closed)", () => {
+      it("partial update with omitted preserve-policied composites → no REMOVEs and no SETs", () => {
+        // Three GSIs with preserve on every half. Update touches a non-
+        // composite field (`name`). Per the v1.7.1 per-half gate, NO half
+        // is touched → no SETs, no REMOVEs.
+        //
+        // (Behavior change from the v1.7.0 expectation: the v1.7.0 test
+        // expected SK halves to recompose because they shared the primary-
+        // key composite `id`. Under v1.7.1's per-half gate, `id` not being
+        // in the payload means SK is untouched → noop. The stored sk values
+        // already match what would be recomposed, so this is semantically
+        // identical and avoids spurious SETs.)
         const indexes: Record<string, KeyComposer.IndexDefinition> = {
           primary: {
             pk: { field: "pk", composite: ["id"] },
@@ -969,19 +1108,13 @@ describe("KeyComposer", () => {
           "E",
           1,
           indexes,
-          { name: "new-name" },
+          { name: "new-name" }, // no GSI composite touched
           { id: "i-1" },
         )
-        // Zero REMOVEs.
+        // Zero REMOVEs (the original sparse footgun stays closed).
         expect(r.removes).toEqual([])
-        // Each id-bearing SK half recomposes (id is in keyRecord); PK halves
-        // no-op (X/Y/Z absent + preserve).
-        expect(r.sets.gsi1sk).toBeDefined()
-        expect(r.sets.gsi2sk).toBeDefined()
-        expect(r.sets.gsi3sk).toBeDefined()
-        expect(r.sets).not.toHaveProperty("gsi1pk")
-        expect(r.sets).not.toHaveProperty("gsi2pk")
-        expect(r.sets).not.toHaveProperty("gsi3pk")
+        // Zero SETs too — per-half gate skips untouched halves entirely.
+        expect(r.sets).toEqual({})
       })
     })
   })

--- a/packages/effect-dynamodb/test/TimeSeries.test.ts
+++ b/packages/effect-dynamodb/test/TimeSeries.test.ts
@@ -953,8 +953,7 @@ describe("TimeSeries — indexPolicy on append", () => {
         const eanEntries = Object.entries(update.ExpressionAttributeNames) as Array<
           [string, string]
         >
-        const aliasOf = (physical: string) =>
-          eanEntries.find(([_, v]) => v === physical)?.[0]
+        const aliasOf = (physical: string) => eanEntries.find(([_, v]) => v === physical)?.[0]
         const gsi2pkAlias = aliasOf("gsi2pk")
         const gsi2skAlias = aliasOf("gsi2sk")
         expect(gsi2pkAlias).toBeDefined()

--- a/packages/effect-dynamodb/test/TimeSeries.test.ts
+++ b/packages/effect-dynamodb/test/TimeSeries.test.ts
@@ -881,65 +881,94 @@ describe("TimeSeries — indexPolicy on append", () => {
     }).pipe(Effect.provide(layer))
   })
 
-  it.effect("appendInput-owned composite with sparse policy drops item from GSI", () => {
-    const entity = Entity.make({
-      model: Telemetry,
-      entityType: "Telemetry",
-      primaryKey: {
-        pk: { field: "pk", composite: ["channel", "deviceId"] },
-        sk: { field: "sk", composite: [] },
-      },
-      indexes: {
-        byAlert: {
-          name: "gsi2",
-          pk: { field: "gsi2pk", composite: ["alert"] },
-          sk: { field: "gsi2sk", composite: ["timestamp"] },
-          // v3 per-half: sparse on pk (alert is the membership key — when
-          // an event omits it, the GSI drops). sk has timestamp in appendInput
-          // so it's always present.
-          indexPolicy: { pk: "sparse", sk: "preserve" },
+  it.effect(
+    "appendInput-owned composite with sparse + touched-but-can't-compose drops only that half (v1.7.1)",
+    () => {
+      // v1.7.1 behavior change: sparse only fires when the writer touches the
+      // half (per-half evaluation gate). A bare omission of `alert` from the
+      // appendInput payload no longer fires sparse on the byAlert.pk half —
+      // the half is untouched. To force a drop, declare `alert` in
+      // appendInput so the writer's "no alert this event" intent is
+      // explicitly signalled (alert: undefined in the payload), or use
+      // Entity.remove(['alert']) on the next update.
+      //
+      // For a writer-owned sparse half that's actually IN appendInput,
+      // touching the half with undefined → can't-compose → REMOVE that half
+      // only. We exercise that here by adding `alert: undefined` to the
+      // append payload.
+      const entity = Entity.make({
+        model: Telemetry,
+        entityType: "Telemetry",
+        primaryKey: {
+          pk: { field: "pk", composite: ["channel", "deviceId"] },
+          sk: { field: "sk", composite: [] },
         },
-      },
-      timestamps: true,
-      timeSeries: {
-        orderBy: "timestamp",
-        appendInput: TelemetryAppendInput,
-      },
-    })
-    const { tableLayer } = makeEntityWithTag(entity)
-    const layer = Layer.merge(TestDynamoClient, tableLayer)
-
-    return Effect.gen(function* () {
-      mockTransactWriteItems.mockResolvedValueOnce({})
-      mockGetItem.mockResolvedValueOnce({
-        Item: {
-          pk: { S: "$tsapp#v1#telemetry#c-1#d-7" },
-          sk: { S: "$tsapp#v1#telemetry_1" },
-          channel: { S: "c-1" },
-          deviceId: { S: "d-7" },
-          timestamp: { S: "2026-04-22T10:00:00.000Z" },
-          __edd_e__: { S: "Telemetry" },
+        indexes: {
+          byAlert: {
+            name: "gsi2",
+            pk: { field: "gsi2pk", composite: ["alert"] },
+            sk: { field: "gsi2sk", composite: ["timestamp"] },
+            // v1.7.1: per-half SK preserve, PK sparse. PK touched (alert in
+            // appendInput, supplied as undefined) and can't compose → REMOVE
+            // gsi2pk only. SK touched (timestamp present) → SET sk.
+            indexPolicy: { pk: "sparse", sk: "preserve" },
+          },
+        },
+        timestamps: true,
+        timeSeries: {
+          orderBy: "timestamp",
+          appendInput: TelemetryAppendInput,
         },
       })
+      const { tableLayer } = makeEntityWithTag(entity)
+      const layer = Layer.merge(TestDynamoClient, tableLayer)
 
-      // Ingest event without `alert` — sparse policy forces drop-out.
-      yield* entity.append({
-        channel: "c-1",
-        deviceId: "d-7",
-        timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
-      })
+      return Effect.gen(function* () {
+        mockTransactWriteItems.mockResolvedValueOnce({})
+        mockGetItem.mockResolvedValueOnce({
+          Item: {
+            pk: { S: "$tsapp#v1#telemetry#c-1#d-7" },
+            sk: { S: "$tsapp#v1#telemetry_1" },
+            channel: { S: "c-1" },
+            deviceId: { S: "d-7" },
+            timestamp: { S: "2026-04-22T10:00:00.000Z" },
+            __edd_e__: { S: "Telemetry" },
+          },
+        })
 
-      const call = mockTransactWriteItems.mock.calls[0]![0]
-      const update = call.TransactItems[0].Update
-      const expr = update.UpdateExpression as string
-      const nameVals: Array<string> = Object.values(update.ExpressionAttributeNames)
+        // Ingest event with `alert: undefined` — the writer explicitly
+        // signals "no alert this event," sk's pk half is touched (in
+        // operator true on undefined), can't compose → sparse → REMOVE pk.
+        // sk is touched (timestamp present) → SET sk.
+        yield* entity.append({
+          channel: "c-1",
+          deviceId: "d-7",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+          alert: undefined,
+        })
 
-      // gsi2 keys must be REMOVEd.
-      expect(expr).toContain("REMOVE")
-      expect(nameVals).toContain("gsi2pk")
-      expect(nameVals).toContain("gsi2sk")
-      // And NOT SET.
-      expect(expr).not.toMatch(/SET[^R]*gsi2pk/)
-    }).pipe(Effect.provide(layer))
-  })
+        const call = mockTransactWriteItems.mock.calls[0]![0]
+        const update = call.TransactItems[0].Update
+        const expr = update.UpdateExpression as string
+        const eanEntries = Object.entries(update.ExpressionAttributeNames) as Array<
+          [string, string]
+        >
+        const aliasOf = (physical: string) =>
+          eanEntries.find(([_, v]) => v === physical)?.[0]
+        const gsi2pkAlias = aliasOf("gsi2pk")
+        const gsi2skAlias = aliasOf("gsi2sk")
+        expect(gsi2pkAlias).toBeDefined()
+        expect(gsi2skAlias).toBeDefined()
+        // gsi2pk REMOVE'd via sparse + can't-compose. gsi2sk SET (timestamp).
+        const removeIdx = expr.indexOf("REMOVE")
+        const setExpr = removeIdx === -1 ? expr : expr.slice(0, removeIdx)
+        const remExpr = removeIdx === -1 ? "" : expr.slice(removeIdx)
+        expect(remExpr.includes(gsi2pkAlias!)).toBe(true)
+        expect(setExpr.includes(gsi2pkAlias!)).toBe(false)
+        // v1.7.1 critical: per-half drop. gsi2sk SET (NOT removed).
+        expect(setExpr.includes(gsi2skAlias!)).toBe(true)
+        expect(remExpr.includes(gsi2skAlias!)).toBe(false)
+      }).pipe(Effect.provide(layer))
+    },
+  )
 })

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -2230,64 +2230,101 @@ describeConnected("Entity refs and Aggregate integration tests", () => {
 })
 
 // ---------------------------------------------------------------------------
-// indexPolicy integration tests — hybrid-writer GSI semantics against a
-// real DynamoDB Local. Mirrors the telemetry pipeline motivating example
-// from issue #11: one GSI is sparse on a per-event attr (alertState), a
-// second is preserved across writers (tenantId). Proves end-to-end that:
-//   - Sparse drop-out during update makes items disappear from GSI queries.
-//   - Preserve leaves stored GSI keys intact and items remain queryable.
-//   - Re-adding a sparse composite re-indexes the item.
-//   - Two writers with disjoint attrs don't clobber each other's GSI state.
+// indexPolicy v1.7.1 integration tests — comprehensive multi-writer
+// round-trip + per-half cascade + truncation coverage against DynamoDB Local.
+//
+// Asserts the v1.7.1 model end-to-end (closes #41):
+//   1. Per-half evaluation gate — untouched halves stay untouched.
+//   2. Per-half outcome — sparse drops the half; preserve noops or cascades.
+//   3. Per-half cascade — Entity.remove drops only the half(s) containing
+//      the named composite.
+//   4. Set/remove asymmetry — set+remove truncates; remove alone REMOVEs.
 // ---------------------------------------------------------------------------
 
-class Device extends Schema.Class<Device>("Device")({
+// Hybrid telemetry-style fixture mirroring the consolidated comment in
+// issue #41: byCurrentAlert has accountId on pk (preserve, enrichment-owned)
+// and [alertState, timestamp] on sk (sparse, telemetry-owned). Both halves
+// are touched independently by their respective writers.
+class HybridDevice extends Schema.Class<HybridDevice>("HybridDevice")({
   channel: Schema.String,
   deviceId: Schema.String,
-  tenantId: Schema.optional(Schema.String),
+  // Enrichment-owned (preserve on pk).
+  accountId: Schema.optional(Schema.String),
+  // Telemetry-owned (sparse on sk).
   alertState: Schema.optional(Schema.Literals(["active", "cleared"])),
-  region: Schema.optional(Schema.String),
+  timestamp: Schema.optional(Schema.String),
+  // Stamp-style attribute — not in any GSI; touched by neither writer above.
+  published: Schema.optional(Schema.String),
   label: Schema.optional(Schema.String),
 }) {}
 
 const ipSchema = DynamoSchema.make({ name: "ip-test", version: 1 })
 const ipTableName = `ip-test-${Date.now()}`
 
-const Devices = Entity.make({
-  model: Device,
-  entityType: "Device",
+const HybridDevices = Entity.make({
+  model: HybridDevice,
+  entityType: "HybridDevice",
   primaryKey: {
     pk: { field: "pk", composite: ["channel", "deviceId"] },
     sk: { field: "sk", composite: [] },
   },
   indexes: {
-    // Sparse pk: alertState is the only pk composite. When absent (caller
-    // omits or sets to null/undefined), pk is whole-half-empty and sparse
-    // drops the item from the GSI. sk = [deviceId] always present (deviceId
-    // is in the primary key) so sk's policy is moot.
-    byAlert: {
+    // The motivating multi-writer GSI from issue #41: pk preserve
+    // (enrichment-owned), sk sparse (telemetry-owned).
+    byCurrentAlert: {
       name: "gsi1",
-      pk: { field: "gsi1pk", composite: ["alertState"] },
-      sk: { field: "gsi1sk", composite: ["deviceId"] },
-      indexPolicy: { pk: "sparse" },
+      pk: { field: "gsi1pk", composite: ["accountId"] },
+      sk: { field: "gsi1sk", composite: ["alertState", "timestamp"] },
+      indexPolicy: { pk: "preserve", sk: "sparse" },
     },
-    // Preserve everywhere: tenantId is owned by an enrichment writer.
-    // Ingest-side updates that don't touch tenantId leave the pk half
-    // alone (whole-half-empty + preserve = no-op).
-    byTenant: {
+    // Both-preserve GSI for testing per-half cascade override.
+    byBothPreserve: {
       name: "gsi2",
-      pk: { field: "gsi2pk", composite: ["tenantId"] },
-      sk: { field: "gsi2sk", composite: ["deviceId"] },
+      pk: { field: "gsi2pk", composite: ["accountId"] },
+      sk: { field: "gsi2sk", composite: ["timestamp"] },
       indexPolicy: { pk: "preserve", sk: "preserve" },
     },
   },
   timestamps: true,
 })
 
-const IpTable = Table.make({ schema: ipSchema, entities: { Devices } })
+const IpTable = Table.make({ schema: ipSchema, entities: { HybridDevices } })
 const IpTestLayer = Layer.mergeAll(ClientLayer, IpTable.layer({ name: ipTableName }))
 const provideIp = Effect.provide(IpTestLayer)
 
-describeConnected("indexPolicy integration tests", () => {
+// Hierarchical asset fixture for set/remove asymmetry + truncation tests.
+class HierAsset extends Schema.Class<HierAsset>("HierAsset")({
+  assetId: Schema.String,
+  region: Schema.optional(Schema.String),
+  country: Schema.optional(Schema.String),
+  city: Schema.optional(Schema.String),
+  site: Schema.optional(Schema.String),
+}) {}
+
+const hierTableName = `ip-hier-${Date.now()}`
+
+const HierAssets = Entity.make({
+  model: HierAsset,
+  entityType: "HierAsset",
+  primaryKey: {
+    pk: { field: "pk", composite: ["assetId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  indexes: {
+    byLocation: {
+      name: "gsi1",
+      pk: { field: "gsi1pk", composite: ["region"] },
+      sk: { field: "gsi1sk", composite: ["country", "city", "site"] },
+      indexPolicy: { pk: "preserve", sk: "preserve" },
+    },
+  },
+  timestamps: true,
+})
+const HierTable = Table.make({ schema: ipSchema, entities: { HierAssets } })
+const HierTestLayer = Layer.mergeAll(ClientLayer, HierTable.layer({ name: hierTableName }))
+const provideHier = Effect.provide(HierTestLayer)
+
+describeConnected("indexPolicy v1.7.1 integration tests (closes #41)", () => {
   beforeAll(async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
@@ -2298,6 +2335,16 @@ describeConnected("indexPolicy integration tests", () => {
           ...Table.definition(IpTable),
         })
       }).pipe(provideIp, Effect.scoped),
+    )
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* DynamoClient
+        yield* client.createTable({
+          TableName: hierTableName,
+          BillingMode: "PAY_PER_REQUEST",
+          ...Table.definition(HierTable),
+        })
+      }).pipe(provideHier, Effect.scoped),
     )
   }, 15000)
 
@@ -2312,137 +2359,572 @@ describeConnected("indexPolicy integration tests", () => {
         Effect.catchTag("ResourceNotFoundError", () => Effect.void),
       ),
     )
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* DynamoClient
+        yield* client.deleteTable({ TableName: hierTableName })
+      }).pipe(
+        provideHier,
+        Effect.scoped,
+        Effect.catchTag("ResourceNotFoundError", () => Effect.void),
+      ),
+    )
   }, 15000)
 
-  it.effect("put with all composites → item queryable via both GSIs", () =>
+  // ----- Scenario 1: Stamp doesn't disturb GSI -----
+  it.effect("scenario 1 — stamp writer doesn't disturb either GSI half", () =>
     Effect.gen(function* () {
-      const db = yield* DynamoClient.make({ entities: { Devices }, tables: { IpTable } })
-
-      yield* db.entities.Devices.put({
-        channel: "c-1",
-        deviceId: "d-1",
-        tenantId: "acme",
-        alertState: "active",
-        region: "us-east-1",
-        label: "initial",
+      const db = yield* DynamoClient.make({
+        entities: { HybridDevices },
+        tables: { IpTable },
       })
 
-      const byAlert = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-      expect(byAlert).toHaveLength(1)
-      expect(byAlert[0]!.deviceId).toBe("d-1")
+      // Pre-seed item with all composites; both GSIs visible.
+      yield* db.entities.HybridDevices.put({
+        channel: "c-s1",
+        deviceId: "d-s1",
+        accountId: "acme",
+        alertState: "active",
+        timestamp: "2026-04-30T10:00:00Z",
+      })
+      const beforeAlert = yield* db.entities.HybridDevices.byCurrentAlert({
+        accountId: "acme",
+      }).collect()
+      expect(beforeAlert.some((d) => d.deviceId === "d-s1")).toBe(true)
 
-      const byTenant = yield* db.entities.Devices.byTenant({ tenantId: "acme" }).collect()
-      expect(byTenant).toHaveLength(1)
-      expect(byTenant[0]!.deviceId).toBe("d-1")
+      // Stamp writer touches only `published` — no GSI composite touched.
+      yield* db.entities.HybridDevices.update({ channel: "c-s1", deviceId: "d-s1" }).set({
+        published: "2026-04-30",
+      })
+
+      // v1.7.1 critical: BOTH GSIs unchanged. (v1.7.0 would have REMOVE'd
+      // gsi1sk because sparse fired on the untouched sk half.)
+      const afterAlert = yield* db.entities.HybridDevices.byCurrentAlert({
+        accountId: "acme",
+      }).collect()
+      expect(afterAlert.some((d) => d.deviceId === "d-s1")).toBe(true)
+
+      // Verify raw stored item — both GSI key attrs still present.
+      const item = yield* HybridDevices.get({
+        channel: "c-s1",
+        deviceId: "d-s1",
+      }).pipe(Entity.asItem)
+      expect(item.gsi1pk).toBeDefined()
+      expect(item.gsi1sk).toBeDefined()
     }).pipe(provideIp),
   )
 
-  it.effect("update with alertState null + sparse policy → item drops out of byAlert", () =>
+  // ----- Scenario 2: Enrichment writer SETs pk, leaves sk alone -----
+  it.effect("scenario 2 — enrichment writer SETs pk, sk untouched", () =>
     Effect.gen(function* () {
-      const db = yield* DynamoClient.make({ entities: { Devices }, tables: { IpTable } })
+      const db = yield* DynamoClient.make({
+        entities: { HybridDevices },
+        tables: { IpTable },
+      })
 
-      // Pre-seed an indexed item.
-      yield* db.entities.Devices.put({
-        channel: "c-2",
-        deviceId: "d-2",
-        tenantId: "acme",
+      yield* db.entities.HybridDevices.put({
+        channel: "c-s2",
+        deviceId: "d-s2",
+        accountId: "acme",
         alertState: "active",
-        region: "us-east-1",
-      })
-      const before = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-      expect(before.some((d) => d.deviceId === "d-2")).toBe(true)
-
-      // Update explicitly nulling alertState — sparse policy must drop the item.
-      yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
-        alertState: undefined,
-        label: "cleared",
+        timestamp: "2026-04-30T10:00:00Z",
       })
 
-      const afterDrop = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-      expect(afterDrop.some((d) => d.deviceId === "d-2")).toBe(false)
+      // Enrichment moves accountId. SK untouched.
+      yield* db.entities.HybridDevices.update({ channel: "c-s2", deviceId: "d-s2" }).set({
+        accountId: "newAcct",
+      })
 
-      // byTenant unaffected — preserve policy left its keys intact.
-      const tenant = yield* db.entities.Devices.byTenant({ tenantId: "acme" }).collect()
-      expect(tenant.some((d) => d.deviceId === "d-2")).toBe(true)
+      // Visible under newAcct (pk SET).
+      const newAcct = yield* db.entities.HybridDevices.byCurrentAlert({
+        accountId: "newAcct",
+      }).collect()
+      expect(newAcct.some((d) => d.deviceId === "d-s2")).toBe(true)
+      // No longer visible under acme.
+      const acme = yield* db.entities.HybridDevices.byCurrentAlert({
+        accountId: "acme",
+      }).collect()
+      expect(acme.some((d) => d.deviceId === "d-s2")).toBe(false)
+
+      // SK unchanged — verify stored gsi1sk hasn't moved.
+      const item = yield* HybridDevices.get({
+        channel: "c-s2",
+        deviceId: "d-s2",
+      }).pipe(Entity.asItem)
+      expect(item.gsi1sk).toBeDefined()
     }).pipe(provideIp),
   )
 
-  it.effect("re-adding alertState → item reappears in byAlert", () =>
+  // ----- Scenario 3: Telemetry writer SETs sk, leaves pk alone -----
+  it.effect("scenario 3 — telemetry writer SETs sk, pk untouched", () =>
     Effect.gen(function* () {
-      const db = yield* DynamoClient.make({ entities: { Devices }, tables: { IpTable } })
+      const db = yield* DynamoClient.make({
+        entities: { HybridDevices },
+        tables: { IpTable },
+      })
 
-      yield* db.entities.Devices.update({ channel: "c-2", deviceId: "d-2" }).set({
+      yield* db.entities.HybridDevices.put({
+        channel: "c-s3",
+        deviceId: "d-s3",
+        accountId: "acme",
+        alertState: "active",
+        timestamp: "2026-04-30T10:00:00Z",
+      })
+
+      // Telemetry tick: new alertState + timestamp. PK untouched.
+      yield* db.entities.HybridDevices.update({ channel: "c-s3", deviceId: "d-s3" }).set({
         alertState: "cleared",
+        timestamp: "2026-04-30T11:00:00Z",
       })
 
-      const byCleared = yield* db.entities.Devices.byAlert({ alertState: "cleared" }).collect()
-      expect(byCleared.some((d) => d.deviceId === "d-2")).toBe(true)
+      // Still visible under acme (pk preserved).
+      const acme = yield* db.entities.HybridDevices.byCurrentAlert({
+        accountId: "acme",
+      }).collect()
+      expect(acme.some((d) => d.deviceId === "d-s3")).toBe(true)
+
+      // Stored item reflects the new sk.
+      const item = yield* HybridDevices.get({
+        channel: "c-s3",
+        deviceId: "d-s3",
+      }).pipe(Entity.asItem)
+      expect((item.gsi1sk as string).includes("cleared")).toBe(true)
     }).pipe(provideIp),
   )
 
+  // ----- Scenario 4: Telemetry "no alert" event drops sk -----
   it.effect(
-    "update touching non-composite attr only: sparse GSI drops, preserve GSI untouched",
+    "scenario 4 — telemetry 'no alert' (timestamp only, alertState undefined) → REMOVE sk only",
     () =>
       Effect.gen(function* () {
-        const db = yield* DynamoClient.make({ entities: { Devices }, tables: { IpTable } })
+        const db = yield* DynamoClient.make({
+          entities: { HybridDevices },
+          tables: { IpTable },
+        })
 
-        yield* db.entities.Devices.put({
-          channel: "c-3",
-          deviceId: "d-3",
-          tenantId: "globex",
+        yield* db.entities.HybridDevices.put({
+          channel: "c-s4",
+          deviceId: "d-s4",
+          accountId: "acme",
           alertState: "active",
+          timestamp: "2026-04-30T10:00:00Z",
         })
 
-        // Sanity check: item initially indexed in both.
-        const initialAlert = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-        const initialTenant = yield* db.entities.Devices.byTenant({ tenantId: "globex" }).collect()
-        expect(initialAlert.some((d) => d.deviceId === "d-3")).toBe(true)
-        expect(initialTenant.some((d) => d.deviceId === "d-3")).toBe(true)
-
-        // Update sets only `label` — neither alertState nor tenantId in payload.
-        // byAlert declares sparse on alertState → always evaluated → alertState
-        // absent from payload → REMOVE (drops from sparse GSI).
-        // byTenant declares preserve on tenantId → always evaluated → tenantId
-        // absent + preserve → leave half alone (stays in GSI).
-        yield* db.entities.Devices.update({ channel: "c-3", deviceId: "d-3" }).set({
-          label: "labelled",
+        // Telemetry tick with alertState explicitly set to undefined →
+        // sk touched (alertState in payload), can't compose (hole at sk[0]) →
+        // sparse → REMOVE sk.
+        yield* db.entities.HybridDevices.update({ channel: "c-s4", deviceId: "d-s4" }).set({
+          alertState: undefined,
+          timestamp: "2026-04-30T11:00:00Z",
         })
 
-        const byAlert = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-        const byTenant = yield* db.entities.Devices.byTenant({ tenantId: "globex" }).collect()
-        expect(byAlert.some((d) => d.deviceId === "d-3")).toBe(false)
-        expect(byTenant.some((d) => d.deviceId === "d-3")).toBe(true)
+        // Item invisible in GSI (DDB projection rule needs both keys).
+        const acme = yield* db.entities.HybridDevices.byCurrentAlert({
+          accountId: "acme",
+        }).collect()
+        expect(acme.some((d) => d.deviceId === "d-s4")).toBe(false)
+
+        // But pk preserved on the underlying item — verify raw stored attrs.
+        const item = yield* HybridDevices.get({
+          channel: "c-s4",
+          deviceId: "d-s4",
+        }).pipe(Entity.asItem)
+        expect(item.gsi1pk).toBeDefined() // preserved
+        expect(item.gsi1sk).toBeUndefined() // REMOVE'd
       }).pipe(provideIp),
   )
 
-  it.effect("hybrid writers: ingest + enrichment updates preserve each other's GSI state", () =>
+  // ----- Scenario 5: Rejoin without enrichment re-fire (closes v1.7.0 bug-1) -----
+  it.effect(
+    "scenario 5 — rejoin: telemetry SETs sk after a drop; pk preserved → re-visible without enrichment re-fire",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { HybridDevices },
+          tables: { IpTable },
+        })
+
+        yield* db.entities.HybridDevices.put({
+          channel: "c-s5",
+          deviceId: "d-s5",
+          accountId: "acme",
+          alertState: "active",
+          timestamp: "2026-04-30T10:00:00Z",
+        })
+
+        // Drop sk first.
+        yield* db.entities.HybridDevices.update({ channel: "c-s5", deviceId: "d-s5" }).set({
+          alertState: undefined,
+          timestamp: "2026-04-30T11:00:00Z",
+        })
+        const dropped = yield* db.entities.HybridDevices.byCurrentAlert({
+          accountId: "acme",
+        }).collect()
+        expect(dropped.some((d) => d.deviceId === "d-s5")).toBe(false)
+
+        // Telemetry rejoins — sets new alertState + timestamp.
+        yield* db.entities.HybridDevices.update({ channel: "c-s5", deviceId: "d-s5" }).set({
+          alertState: "active",
+          timestamp: "2026-04-30T12:00:00Z",
+        })
+
+        // v1.7.1 critical assertion: item re-visible under PRESERVED pk
+        // (acme), with NEW sk. No enrichment writer had to re-fire.
+        // (v1.7.0 would have lost gsi1pk on the drop and the rejoin alone
+        // wouldn't have re-indexed the item until enrichment re-fired.)
+        const rejoined = yield* db.entities.HybridDevices.byCurrentAlert({
+          accountId: "acme",
+        }).collect()
+        expect(rejoined.some((d) => d.deviceId === "d-s5")).toBe(true)
+      }).pipe(provideIp),
+  )
+
+  // ----- Scenario 6: Explicit clear via undefined ----- (already exercised by 4)
+  it.effect("scenario 6 — explicit clear via undefined produces same outcome as omission", () =>
     Effect.gen(function* () {
-      const db = yield* DynamoClient.make({ entities: { Devices }, tables: { IpTable } })
-
-      // Initial state: neither tenantId nor alertState known — item not in either GSI.
-      yield* db.entities.Devices.put({ channel: "c-4", deviceId: "d-4" })
-
-      // Enrichment writer: sets tenantId.
-      yield* db.entities.Devices.update({ channel: "c-4", deviceId: "d-4" }).set({
-        tenantId: "initech",
+      const db = yield* DynamoClient.make({
+        entities: { HybridDevices },
+        tables: { IpTable },
       })
 
-      // Verify byTenant now has the item.
-      const afterEnrich = yield* db.entities.Devices.byTenant({ tenantId: "initech" }).collect()
-      expect(afterEnrich.some((d) => d.deviceId === "d-4")).toBe(true)
-
-      // Ingest writer: sets alertState without touching tenantId (not in payload).
-      // tenantId has preserve policy → byTenant remains intact.
-      yield* db.entities.Devices.update({ channel: "c-4", deviceId: "d-4" }).set({
+      yield* db.entities.HybridDevices.put({
+        channel: "c-s6",
+        deviceId: "d-s6",
+        accountId: "acme",
         alertState: "active",
+        timestamp: "2026-04-30T10:00:00Z",
       })
 
-      const byAlert = yield* db.entities.Devices.byAlert({ alertState: "active" }).collect()
-      const byTenant = yield* db.entities.Devices.byTenant({ tenantId: "initech" }).collect()
-
-      expect(byAlert.some((d) => d.deviceId === "d-4")).toBe(true)
-      // Critical: byTenant still populated — ingest didn't clobber the enrichment-owned half.
-      expect(byTenant.some((d) => d.deviceId === "d-4")).toBe(true)
+      // Explicit `alertState: undefined` — sk touched (in operator true on
+      // undefined), can't compose → sparse → REMOVE sk.
+      yield* db.entities.HybridDevices.update({ channel: "c-s6", deviceId: "d-s6" }).set({
+        alertState: undefined,
+        timestamp: "2026-04-30T11:00:00Z",
+      })
+      const item = yield* HybridDevices.get({
+        channel: "c-s6",
+        deviceId: "d-s6",
+      }).pipe(Entity.asItem)
+      expect(item.gsi1sk).toBeUndefined()
+      expect(item.gsi1pk).toBeDefined() // preserved
     }).pipe(provideIp),
+  )
+
+  // ----- Scenario 7: Entity.remove on sparse-half composite — per-half cascade -----
+  it.effect(
+    "scenario 7 — Entity.remove(['alertState']) drops sk only (per-half, NOT GSI-wide)",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { HybridDevices },
+          tables: { IpTable },
+        })
+
+        yield* db.entities.HybridDevices.put({
+          channel: "c-s7",
+          deviceId: "d-s7",
+          accountId: "acme",
+          alertState: "active",
+          timestamp: "2026-04-30T10:00:00Z",
+        })
+
+        // Per-half cascade: alertState in sk only → REMOVE gsi1sk only.
+        yield* db.entities.HybridDevices.update({ channel: "c-s7", deviceId: "d-s7" }).remove([
+          "alertState",
+        ])
+
+        const item = yield* HybridDevices.get({
+          channel: "c-s7",
+          deviceId: "d-s7",
+        }).pipe(Entity.asItem)
+        // v1.7.1 critical: gsi1pk preserved (per-half cascade — not GSI-wide).
+        expect(item.gsi1pk).toBeDefined()
+        // sk REMOVE'd via cascade override.
+        expect(item.gsi1sk).toBeUndefined()
+        // The byBothPreserve gsi2 has accountId on pk (untouched, no cascade
+        // — alertState not in gsi2's composites) → both halves untouched.
+        expect(item.gsi2pk).toBeDefined()
+        expect(item.gsi2sk).toBeDefined()
+      }).pipe(provideIp),
+  )
+
+  // ----- Scenario 8: Entity.remove on preserve-half composite — cascade override -----
+  it.effect(
+    "scenario 8 — Entity.remove(['accountId']) under preserve → REMOVE pk via cascade override (per-half)",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { HybridDevices },
+          tables: { IpTable },
+        })
+
+        yield* db.entities.HybridDevices.put({
+          channel: "c-s8",
+          deviceId: "d-s8",
+          accountId: "acme",
+          alertState: "active",
+          timestamp: "2026-04-30T10:00:00Z",
+        })
+
+        // accountId is the only pk composite for both byCurrentAlert and
+        // byBothPreserve. Per-half cascade fires on PK halves only — sk
+        // untouched (alertState/timestamp not in removedSet, not in payload).
+        yield* db.entities.HybridDevices.update({ channel: "c-s8", deviceId: "d-s8" }).remove([
+          "accountId",
+        ])
+
+        const item = yield* HybridDevices.get({
+          channel: "c-s8",
+          deviceId: "d-s8",
+        }).pipe(Entity.asItem)
+        // Both PK halves REMOVE'd (cascade override under preserve fires on
+        // both — accountId is in both PKs).
+        expect(item.gsi1pk).toBeUndefined()
+        expect(item.gsi2pk).toBeUndefined()
+        // v1.7.1 critical: SK halves preserved (they don't contain
+        // accountId; per-half gate skips them entirely).
+        expect(item.gsi1sk).toBeDefined()
+        expect(item.gsi2sk).toBeDefined()
+      }).pipe(provideIp),
+  )
+
+  // ----- Scenario 9: Hierarchical truncation via set+remove -----
+  it.effect("scenario 9 — hierarchical truncation: set surviving + remove leaf → SET sk truncated", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { HierAssets },
+        tables: { HierTable },
+      })
+
+      yield* db.entities.HierAssets.put({
+        assetId: "rack-9",
+        region: "americas",
+        country: "us",
+        city: "sf",
+        site: "datacenter-1",
+      })
+
+      // Demote — drop site, keep country+city via set; structural rule
+      // composes the leading prefix [country, city]. SET sk truncated.
+      // PK untouched (region not in payload, not in removedSet).
+      yield* db.entities.HierAssets.update({ assetId: "rack-9" })
+        .set({ country: "us", city: "sf" })
+        .remove(["site"])
+
+      const item = yield* HierAssets.get({ assetId: "rack-9" }).pipe(Entity.asItem)
+      // PK preserved (region untouched).
+      expect(item.gsi1pk).toBeDefined()
+      // SK SET to truncated leading prefix.
+      expect((item.gsi1sk as string)).toBe("$ip-test#v1#hierasset#country_us#city_sf")
+
+      // begins_with query at city level still finds the asset.
+      const atRegion = yield* db.entities.HierAssets.byLocation({
+        region: "americas",
+      }).collect()
+      expect(atRegion.some((a) => a.assetId === "rack-9")).toBe(true)
+    }).pipe(provideHier),
+  )
+
+  // ----- Scenario 10: Hole pattern + sparse → REMOVE sk -----
+  it.effect("scenario 10 — hole pattern under sparse → REMOVE sk only (NOT GSI-wide)", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { HybridDevices },
+        tables: { IpTable },
+      })
+
+      yield* db.entities.HybridDevices.put({
+        channel: "c-s10",
+        deviceId: "d-s10",
+        accountId: "acme",
+        alertState: "active",
+        timestamp: "2026-04-30T10:00:00Z",
+      })
+
+      // Hole on sk: pass timestamp only; alertState absent from payload.
+      // Wait — under v1.7.1, omitted means untouched per the gate. To
+      // exercise hole-under-sparse here we have to TOUCH sk by including
+      // alertState as undefined (or include another sk composite). We use
+      // `timestamp` as the touch signal; alertState is absent (stored value
+      // exists, but a fresh ingest `set({ timestamp: T })` only mentions
+      // timestamp). That makes sk touched (timestamp in payload), but
+      // alertState... is in stored attrs as "active" — so the merged record
+      // has alertState present.
+      //
+      // To exercise the actual hole-under-sparse semantic, the writer must
+      // touch sk AND signal alertState as absent. Use `alertState: undefined`
+      // explicitly to force the hole.
+      yield* db.entities.HybridDevices.update({ channel: "c-s10", deviceId: "d-s10" }).set({
+        alertState: undefined,
+        timestamp: "2026-04-30T11:00:00Z",
+      })
+
+      const item = yield* HybridDevices.get({
+        channel: "c-s10",
+        deviceId: "d-s10",
+      }).pipe(Entity.asItem)
+      // sk REMOVE'd via sparse + can't-compose (hole at sk[0]).
+      expect(item.gsi1sk).toBeUndefined()
+      // pk preserved (untouched).
+      expect(item.gsi1pk).toBeDefined()
+    }).pipe(provideIp),
+  )
+
+  // ----- Scenario 11: Hole pattern + preserve, no removedSet → noop -----
+  it.effect(
+    "scenario 11 — hole pattern under preserve (no removedSet) → noop sk (stored value retained)",
+    () =>
+      Effect.gen(function* () {
+        // Use HierAssets with byLocation sk = [country, city, site], both
+        // preserve. Hole = country present, city absent, site present.
+        const dbHier = yield* DynamoClient.make({
+          entities: { HierAssets },
+          tables: { HierTable },
+        })
+
+        yield* dbHier.entities.HierAssets.put({
+          assetId: "rack-11",
+          region: "americas",
+          country: "us",
+          city: "sf",
+          site: "datacenter-1",
+        })
+        const beforeStored = yield* HierAssets.get({ assetId: "rack-11" }).pipe(Entity.asItem)
+        const beforeSk = beforeStored.gsi1sk
+
+        // Touch sk with a hole pattern under preserve, no removedSet.
+        // city: undefined, site: 'datacenter-2' → hole at sk[1].
+        yield* dbHier.entities.HierAssets.update({ assetId: "rack-11" }).set({
+          country: "us",
+          city: undefined,
+          site: "datacenter-2",
+        })
+
+        const item = yield* HierAssets.get({ assetId: "rack-11" }).pipe(Entity.asItem)
+        // v1.7.1: preserve + can't-compose + no cascade → noop. The stored
+        // gsi1sk is left at its previous value (no SET, no REMOVE).
+        expect(item.gsi1sk).toBe(beforeSk)
+      }).pipe(provideHier),
+  )
+
+  // ----- Scenario 12: Hole pattern + preserve + removedSet → REMOVE via cascade override -----
+  it.effect(
+    "scenario 12 — hole pattern under preserve + removedSet → REMOVE sk via cascade override",
+    () =>
+      Effect.gen(function* () {
+        const dbHier = yield* DynamoClient.make({
+          entities: { HierAssets },
+          tables: { HierTable },
+        })
+
+        yield* dbHier.entities.HierAssets.put({
+          assetId: "rack-12",
+          region: "americas",
+          country: "us",
+          city: "sf",
+          site: "datacenter-1",
+        })
+
+        // Touch sk via removedSet on city, set site to a new value → hole
+        // pattern (country present, city absent via removedSet, site
+        // present). Preserve + cascade override → REMOVE sk.
+        yield* dbHier.entities.HierAssets.update({ assetId: "rack-12" })
+          .set({ site: "datacenter-2" })
+          .remove(["city"])
+
+        const item = yield* HierAssets.get({ assetId: "rack-12" }).pipe(Entity.asItem)
+        expect(item.gsi1sk).toBeUndefined()
+        // pk preserved.
+        expect(item.gsi1pk).toBeDefined()
+      }).pipe(provideHier),
+  )
+
+  // ----- Scenario 13: Multi-writer concurrent updates -----
+  it.effect("scenario 13 — multi-writer sequential updates produce expected combined GSI state", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { HybridDevices },
+        tables: { IpTable },
+      })
+
+      // Initial state — full composites set on put.
+      yield* db.entities.HybridDevices.put({
+        channel: "c-s13",
+        deviceId: "d-s13",
+        accountId: "acme",
+        alertState: "active",
+        timestamp: "2026-04-30T10:00:00Z",
+      })
+
+      // Enrichment writer fires.
+      yield* db.entities.HybridDevices.update({ channel: "c-s13", deviceId: "d-s13" }).set({
+        accountId: "newAcct",
+      })
+      // Telemetry writer fires.
+      yield* db.entities.HybridDevices.update({ channel: "c-s13", deviceId: "d-s13" }).set({
+        alertState: "cleared",
+        timestamp: "2026-04-30T11:00:00Z",
+      })
+
+      // Both writes preserved end-to-end. Final GSI state under newAcct +
+      // cleared.
+      const final = yield* db.entities.HybridDevices.byCurrentAlert({
+        accountId: "newAcct",
+      }).collect()
+      expect(final.some((d) => d.deviceId === "d-s13")).toBe(true)
+      // Stale account still empty.
+      const stale = yield* db.entities.HybridDevices.byCurrentAlert({
+        accountId: "acme",
+      }).collect()
+      expect(stale.some((d) => d.deviceId === "d-s13")).toBe(false)
+    }).pipe(provideIp),
+  )
+
+  // ----- Scenario 14: DDB projection invariant (documented, not library behavior) -----
+  it.effect(
+    "scenario 14 — DDB projection invariant: item with only one GSI key attr is invisible",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { HybridDevices },
+          tables: { IpTable },
+        })
+
+        // Put with full composites — visible.
+        yield* db.entities.HybridDevices.put({
+          channel: "c-s14",
+          deviceId: "d-s14",
+          accountId: "acme",
+          alertState: "active",
+          timestamp: "2026-04-30T10:00:00Z",
+        })
+        const visible = yield* db.entities.HybridDevices.byCurrentAlert({
+          accountId: "acme",
+        }).collect()
+        expect(visible.some((d) => d.deviceId === "d-s14")).toBe(true)
+
+        // Drop sk only — gsi1pk persists, gsi1sk REMOVE'd.
+        yield* db.entities.HybridDevices.update({ channel: "c-s14", deviceId: "d-s14" }).set({
+          alertState: undefined,
+          timestamp: "2026-04-30T11:00:00Z",
+        })
+
+        // DDB projection rule: GSI query returns nothing for items missing
+        // either of the GSI's key attrs. This is NOT library behavior — it's
+        // the DDB invariant the per-half cascade relies on. We document it
+        // here so readers see the round trip.
+        const invisible = yield* db.entities.HybridDevices.byCurrentAlert({
+          accountId: "acme",
+        }).collect()
+        expect(invisible.some((d) => d.deviceId === "d-s14")).toBe(false)
+
+        // Raw item still has gsi1pk — confirming the per-half persistence.
+        const item = yield* HybridDevices.get({
+          channel: "c-s14",
+          deviceId: "d-s14",
+        }).pipe(Entity.asItem)
+        expect(item.gsi1pk).toBeDefined()
+        expect(item.gsi1sk).toBeUndefined()
+      }).pipe(provideIp),
   )
 })

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -2689,40 +2689,42 @@ describeConnected("indexPolicy v1.7.1 integration tests (closes #41)", () => {
   )
 
   // ----- Scenario 9: Hierarchical truncation via set+remove -----
-  it.effect("scenario 9 — hierarchical truncation: set surviving + remove leaf → SET sk truncated", () =>
-    Effect.gen(function* () {
-      const db = yield* DynamoClient.make({
-        entities: { HierAssets },
-        tables: { HierTable },
-      })
+  it.effect(
+    "scenario 9 — hierarchical truncation: set surviving + remove leaf → SET sk truncated",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { HierAssets },
+          tables: { HierTable },
+        })
 
-      yield* db.entities.HierAssets.put({
-        assetId: "rack-9",
-        region: "americas",
-        country: "us",
-        city: "sf",
-        site: "datacenter-1",
-      })
+        yield* db.entities.HierAssets.put({
+          assetId: "rack-9",
+          region: "americas",
+          country: "us",
+          city: "sf",
+          site: "datacenter-1",
+        })
 
-      // Demote — drop site, keep country+city via set; structural rule
-      // composes the leading prefix [country, city]. SET sk truncated.
-      // PK untouched (region not in payload, not in removedSet).
-      yield* db.entities.HierAssets.update({ assetId: "rack-9" })
-        .set({ country: "us", city: "sf" })
-        .remove(["site"])
+        // Demote — drop site, keep country+city via set; structural rule
+        // composes the leading prefix [country, city]. SET sk truncated.
+        // PK untouched (region not in payload, not in removedSet).
+        yield* db.entities.HierAssets.update({ assetId: "rack-9" })
+          .set({ country: "us", city: "sf" })
+          .remove(["site"])
 
-      const item = yield* HierAssets.get({ assetId: "rack-9" }).pipe(Entity.asItem)
-      // PK preserved (region untouched).
-      expect(item.gsi1pk).toBeDefined()
-      // SK SET to truncated leading prefix.
-      expect((item.gsi1sk as string)).toBe("$ip-test#v1#hierasset#country_us#city_sf")
+        const item = yield* HierAssets.get({ assetId: "rack-9" }).pipe(Entity.asItem)
+        // PK preserved (region untouched).
+        expect(item.gsi1pk).toBeDefined()
+        // SK SET to truncated leading prefix.
+        expect(item.gsi1sk as string).toBe("$ip-test#v1#hierasset#country_us#city_sf")
 
-      // begins_with query at city level still finds the asset.
-      const atRegion = yield* db.entities.HierAssets.byLocation({
-        region: "americas",
-      }).collect()
-      expect(atRegion.some((a) => a.assetId === "rack-9")).toBe(true)
-    }).pipe(provideHier),
+        // begins_with query at city level still finds the asset.
+        const atRegion = yield* db.entities.HierAssets.byLocation({
+          region: "americas",
+        }).collect()
+        expect(atRegion.some((a) => a.assetId === "rack-9")).toBe(true)
+      }).pipe(provideHier),
   )
 
   // ----- Scenario 10: Hole pattern + sparse → REMOVE sk -----
@@ -2840,44 +2842,46 @@ describeConnected("indexPolicy v1.7.1 integration tests (closes #41)", () => {
   )
 
   // ----- Scenario 13: Multi-writer concurrent updates -----
-  it.effect("scenario 13 — multi-writer sequential updates produce expected combined GSI state", () =>
-    Effect.gen(function* () {
-      const db = yield* DynamoClient.make({
-        entities: { HybridDevices },
-        tables: { IpTable },
-      })
+  it.effect(
+    "scenario 13 — multi-writer sequential updates produce expected combined GSI state",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { HybridDevices },
+          tables: { IpTable },
+        })
 
-      // Initial state — full composites set on put.
-      yield* db.entities.HybridDevices.put({
-        channel: "c-s13",
-        deviceId: "d-s13",
-        accountId: "acme",
-        alertState: "active",
-        timestamp: "2026-04-30T10:00:00Z",
-      })
+        // Initial state — full composites set on put.
+        yield* db.entities.HybridDevices.put({
+          channel: "c-s13",
+          deviceId: "d-s13",
+          accountId: "acme",
+          alertState: "active",
+          timestamp: "2026-04-30T10:00:00Z",
+        })
 
-      // Enrichment writer fires.
-      yield* db.entities.HybridDevices.update({ channel: "c-s13", deviceId: "d-s13" }).set({
-        accountId: "newAcct",
-      })
-      // Telemetry writer fires.
-      yield* db.entities.HybridDevices.update({ channel: "c-s13", deviceId: "d-s13" }).set({
-        alertState: "cleared",
-        timestamp: "2026-04-30T11:00:00Z",
-      })
+        // Enrichment writer fires.
+        yield* db.entities.HybridDevices.update({ channel: "c-s13", deviceId: "d-s13" }).set({
+          accountId: "newAcct",
+        })
+        // Telemetry writer fires.
+        yield* db.entities.HybridDevices.update({ channel: "c-s13", deviceId: "d-s13" }).set({
+          alertState: "cleared",
+          timestamp: "2026-04-30T11:00:00Z",
+        })
 
-      // Both writes preserved end-to-end. Final GSI state under newAcct +
-      // cleared.
-      const final = yield* db.entities.HybridDevices.byCurrentAlert({
-        accountId: "newAcct",
-      }).collect()
-      expect(final.some((d) => d.deviceId === "d-s13")).toBe(true)
-      // Stale account still empty.
-      const stale = yield* db.entities.HybridDevices.byCurrentAlert({
-        accountId: "acme",
-      }).collect()
-      expect(stale.some((d) => d.deviceId === "d-s13")).toBe(false)
-    }).pipe(provideIp),
+        // Both writes preserved end-to-end. Final GSI state under newAcct +
+        // cleared.
+        const final = yield* db.entities.HybridDevices.byCurrentAlert({
+          accountId: "newAcct",
+        }).collect()
+        expect(final.some((d) => d.deviceId === "d-s13")).toBe(true)
+        // Stale account still empty.
+        const stale = yield* db.entities.HybridDevices.byCurrentAlert({
+          accountId: "acme",
+        }).collect()
+        expect(stale.some((d) => d.deviceId === "d-s13")).toBe(false)
+      }).pipe(provideIp),
   )
 
   // ----- Scenario 14: DDB projection invariant (documented, not library behavior) -----

--- a/packages/language-service/CHANGELOG.md
+++ b/packages/language-service/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @effect-dynamodb/language-service
 
+## 1.7.1
+
+### Patch Changes
+
+- **indexPolicy v1.7.1 — per-half roll-up corrections (closes [#41](https://github.com/jmenga/effect-dynamodb/issues/41)).**
+
+  v1.7.0 shipped the per-key declaration model (`indexPolicy: { pk, sk }`) but had three connected bugs in how outcomes were rolled up. All three were rooted in the same defect: the model was per-half on declaration but not on evaluation, outcome, or cascade. v1.7.1 makes all four uniformly per-half.
+
+  **Bug fixes** (strictly more correct than v1.7.0):
+  1. **GSI-wide cascade on can't-compose → per-key REMOVE.** v1.7.0 REMOVE'd both `gsiNpk` AND `gsiNsk` whenever either half couldn't compose. v1.7.1 REMOVEs only the half that couldn't compose; the other half's stored value persists. Closes the multi-writer enrichment-on-pk + telemetry-on-sk scenario that v1.7.0 was designed to enable but didn't actually enable correctly.
+  2. **`CompositeKeyHoleError` (EDD-9024) deprecated — no longer thrown.** The v1.7.0 throw under preserve+hole was a defensive runtime safety net for a case the type system already catches (required composites can't be omitted under `exactOptionalPropertyTypes` since v1.7.0 reverted the NullishOr widening). The class export is preserved for back-compat with consumers who type-imported it for `Effect.catchTag` handlers, but no code path raises it anymore. Hole patterns now collapse into the unified per-half can't-compose rule.
+  3. **Per-half evaluation gate (NEW in v1.7.1).** v1.7.0 fired the policy on every update of every GSI declaring `indexPolicy`, regardless of whether the writer touched the half. This made stamps and unrelated writers blow away sparse halves they didn't own. v1.7.1 skips untouched halves entirely — a half is touched iff at least one of its composite names appears in the update payload OR in `Entity.remove([...])`.
+
+  **Behavior change:**
+  - **`Entity.remove([attr])` is now per-half** (no longer GSI-wide). Removing a composite REMOVEs only the half(s) whose composite list contains it. Other halves follow the per-half evaluation gate (untouched → noop). Combined with the new "cascade override under preserve" rule, the consumer's explicit signal still gets honored — preserve + can't-compose + composite in `removedSet` → REMOVE that half.
+
+  **No API changes:**
+  - Same `indexPolicy: { pk, sk }` declaration shape.
+  - Same `Entity.remove([...])` API.
+  - Same EDD-9025 invariants (composite attributes can't be `Schema.NullOr`).
+  - Same `Schema.optional(...)` pattern for sparse composites.
+
+  **v3 model preserved:** the per-key declaration, two-way payload classification, and EDD-9025 footgun gate from v1.7.0 are all preserved unchanged. v1.7.1 only fixes the roll-up.
+
+  See `DESIGN.md §7` for the full v1.7.1 decision algorithm and the `guides/index-policy.mdx` rewrite for the concept-first walkthrough.
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/language-service",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "TypeScript Language Service Plugin for effect-dynamodb — shows DynamoDB operations on hover",
   "license": "MIT",
   "author": "Justin Menga",


### PR DESCRIPTION
Closes #41.

## Summary

v1.7.0 shipped per-key declaration (`indexPolicy: { pk, sk }`) but had three connected bugs in the roll-up. All three were rooted in the same defect: the model was per-half on declaration but not on evaluation, outcome, or cascade. v1.7.1 makes all four uniformly per-half across declaration, evaluation gate, outcome, and cascade.

- **Bug fix 1 (GSI-wide cascade on can't-compose).** v1.7.0 REMOVE'd both `gsiNpk` AND `gsiNsk` whenever either half couldn't compose, defeating the multi-writer enrichment-on-pk + telemetry-on-sk pattern v1.7.0 was designed to enable. v1.7.1 REMOVEs only the half that couldn't compose; the other half's stored value persists for rejoin without other writers re-firing.
- **Bug fix 2 (`CompositeKeyHoleError` deprecated).** The v1.7.0 throw under preserve+hole was a defensive runtime safety net for a case the type system already catches (required composites can't be omitted under `exactOptionalPropertyTypes` since v1.7.0 reverted the NullishOr widening). The class export is preserved for back-compat with consumers who type-imported it for `Effect.catchTag` handlers; the throw site is gone. Hole patterns now collapse into the unified per-half can't-compose rule.
- **Bug fix 3 (per-half evaluation gate, NEW in v1.7.1).** v1.7.0 fired the policy on every update of every GSI declaring `indexPolicy`, regardless of whether the writer touched the half. v1.7.1 skips untouched halves entirely. A half is touched iff at least one of its composite names appears in the update payload OR in `Entity.remove([...])`. Stamps no longer blow away sparse halves they don't own.
- **Behavior change: `Entity.remove([attr])` is now per-half** (no longer GSI-wide). Removing a composite REMOVEs only the half(s) whose composite list contains it. Other halves follow the per-half evaluation gate. The cascade override under preserve (preserve + can't-compose + composite in `removedSet` → REMOVE that half) honors the consumer's explicit signal.
- **Set/remove asymmetry documented prominently.** `set` provides values to compose with; `remove` invalidates a composite without providing a replacement. Truncation (`set({ surviving }).remove(['leaf'])`) requires surviving composites in the same call — the library has no read-before-write.
- **No API changes.** Same `indexPolicy: { pk, sk }` declaration shape; same `Entity.remove([...])` API; same EDD-9025 invariants; same `Schema.optional(...)` pattern for sparse composites. The v3 model (per-key declaration, two-way payload classification, EDD-9025 footgun gate) is preserved unchanged from v1.7.0.

## Documentation

- DESIGN.md §7 — Policy-Aware GSI Composition rewritten for v1.7.1 (per-half eval gate, unified per-half outcome rule, set/remove asymmetry, decision table from issue #41 consolidated comment).
- guides/index-policy.mdx — full rewrite per the 10-section concept-first spec (mental model + three contracts + per-half evaluation gate before any API surface).
- examples/guide-index-policy.ts — three runnable scenarios (single-writer sparse, multi-writer preserve+sparse with rejoin, hierarchical truncation via set+remove).
- Migration table in the guide covers v1.7.0 → v1.7.1 (4 behavior changes, all bug fixes) and v1.6 → v1.7.x (preserved).

## Test plan

- [x] `pnpm lint` — zero issues.
- [x] `pnpm check` — zero type errors across all 5 packages.
- [x] `pnpm test` — all unit tests pass (1046 effect-dynamodb, 56 geo, 47 doctest, 67 language-service).
- [x] **`pnpm --filter effect-dynamodb test:connected` — all 99 connected tests pass against DynamoDB Local** (gate 4, mandatory per CLAUDE.md).
- [x] `pnpm --filter @effect-dynamodb/doctest test` — sync verification passes.
- [x] `npx tsx packages/effect-dynamodb/examples/guide-index-policy.ts` — three scenarios run end-to-end against DDB Local without errors.

### Test coverage matrix

**Unit (KeyComposer.test.ts)** — 67 tests organized by the four pillars of the v1.7.1 model:
- [x] Per-half evaluation gate — untouched halves are skipped (multiple variants: no gate fire, undefined-touched, removedSet-touched, multi-writer round-trip).
- [x] Structural rule — SET full / SET truncated on PK and SK / hierarchical truncation via set+remove.
- [x] Per-half outcome — sparse + can't-compose → REMOVE this half only (NOT GSI-wide); preserve + can't-compose + no removedSet → noop; preserve + can't-compose + removedSet → REMOVE via cascade override.
- [x] Multi-writer round-trip — all 8 scenarios from the issue #41 consolidated decision table (stamp / enrichment / telemetry-active / no-alert / explicit-clear / rejoin / hierarchical / explicit-drop on each half).
- [x] Two-way payload classification — null = undefined = touched-but-absent.
- [x] Multi-GSI independence — different policies evaluate independently per-half.
- [x] keyRecord merging — payload-touched composites and key-only composites.
- [x] Issue #36/#41 migration regression — partial update without GSI composites → zero SETs and zero REMOVEs.

**Unit (IndexPolicyV3.test.ts)** — Entity-level wiring through the standard updateItem and retain (transactWriteItems) paths. Hole-throw assertions replaced with REMOVE/noop assertions per the unified rule.

**Connected (connected.test.ts)** — 14 scenarios from the Phase 6 spec, each as a separate `it.effect` against DDB Local:
- [x] Scenario 1 — stamp doesn't disturb GSI (closes v1.7.0 bug-3).
- [x] Scenario 2 — enrichment writer SETs pk, sk untouched.
- [x] Scenario 3 — telemetry writer SETs sk, pk untouched.
- [x] Scenario 4 — telemetry "no alert" event → REMOVE sk only.
- [x] Scenario 5 — rejoin without enrichment re-fire (closes v1.7.0 bug-1).
- [x] Scenario 6 — explicit clear via undefined matches omission.
- [x] Scenario 7 — Entity.remove on sparse-half composite → REMOVE that half only.
- [x] Scenario 8 — Entity.remove on preserve-half composite → REMOVE via cascade override (per-half).
- [x] Scenario 9 — hierarchical truncation via set+remove → SET sk truncated.
- [x] Scenario 10 — hole pattern + sparse → REMOVE sk only.
- [x] Scenario 11 — hole pattern + preserve, no removedSet → noop sk (stored retained).
- [x] Scenario 12 — hole pattern + preserve + removedSet → REMOVE sk via cascade.
- [x] Scenario 13 — multi-writer sequential updates produce expected combined state.
- [x] Scenario 14 — DDB projection invariant documented (item with one GSI key attr is invisible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)