### PR TITLE
indexPolicy v1.7.2 — fix PK-composites-only GSI regression (closes #43)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,18 @@ Before committing:
 
 > **For agents:** all of the above gates must run successfully before reporting a task complete. The single most common gap is skipping gate 4 — `pnpm test:connected` requires DDB Local Docker running and is genuinely time-consuming, but it is mandatory for the modules listed there. Reporting "examples ran end-to-end against DDB Local ✓" does NOT satisfy gate 4. CI will catch the gap, but it costs a CI cycle, a stale PR review, and the agent's credibility. Run it before pushing.
 
+### Canonical GSI-composite test-fixture shapes
+
+When changing **`KeyComposer.composeGsiKeysForUpdatePolicyAware`** or any policy-aware composition path (`Entity.update`, `Entity.append`, retain path, BoundUpdate combinators), test coverage MUST span the canonical GSI-composite shapes below. Missing one shape leads directly to consumer-facing regressions — the v1.7.1 fixture matrix missed shape #2 (PK-composites-only) and shipped a regression that left items invisible to channel-scoped queries (#43). Verify each shape in the unit suite (`KeyComposer.test.ts`), at the entity wiring layer (`IndexPolicyV3.test.ts`), AND in the connected suite (`connected.test.ts`).
+
+1. **Multi-writer GSI** — composites split across writers (e.g. enrichment-owned PK composite + telemetry-owned SK composites). The per-half gate must skip halves the current writer doesn't touch. Anchor scenario for the `'preserve'` contract.
+2. **PK-composites-only GSI** — composites entirely subset of the entity primary key (e.g. `byChannel: { pk: [channel], sk: [deviceId] }` on `primaryKey: [channel, deviceId]`). The per-half gate must fire via `keyRecord` membership and SET on every write (idempotent — values are immutable). **This is the #43 regression scenario** — must be present in unit, entity-level, AND connected suites for any composer change.
+3. **Hierarchical GSI** — composites form a parent → child hierarchy (e.g. `[region, country, city, site]`). The structural rule must truncate via `set({ parents }).remove(["leaf"])`.
+4. **Hole pattern GSI** — optional leading composite + present trailing composite. Must collapse into the unified can't-compose rule (drop under `'sparse'`, noop or cascade-override under `'preserve'`).
+5. **All composites mutable** — every composite is a non-PK model field, and `appendInput` / update payloads carry them all. The standard case; the gate fires through the payload.
+
+`DESIGN.md §7` documents the same canonical shapes alongside the policy semantics. Cross-reference both whenever editing the composer.
+
 ## PR Conventions
 
 Every PR that resolves a tracked issue **MUST** reference the issue(s) it closes using a GitHub closing keyword (`Closes #N`, `Fixes #N`, or `Resolves #N`) in the PR body. This is non-negotiable — without a closing keyword, the issue stays open after merge and drifts out of sync with reality. A bare `#N` mention (e.g. "relates to #N") does **not** auto-close; use one of the keywords above, one per issue. If a PR only partially addresses an issue, reference it without a closing keyword and say so explicitly in the PR body.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -642,16 +642,19 @@ indexes: {
 
 `set({ attr: null })` is no longer a separate "drop signal" — it still REMOVEs the attribute from the item (the data-attribute REMOVE clause), but it does not separately cascade-drop the GSI keys. Drop-via-cascade goes through `Entity.remove([attr])` instead.
 
-**Per-half evaluation gate (NEW in v1.7.1 — closes the multi-writer leak).** Before the structural rule even runs, each half is checked for whether the writer touched it. **If a half is untouched, it is skipped entirely — no SET, no REMOVE, no policy fires.** A half is "touched" iff at least one of its composite names appears in the update payload (regardless of value, including `undefined`) OR appears in `Entity.remove([...])`:
+**Per-half evaluation gate (v1.7.1, broadened in v1.7.2 — closes the multi-writer leak AND the PK-composites-only regression).** Before the structural rule even runs, each half is checked for whether the writer touched it. **If a half is untouched, it is skipped entirely — no SET, no REMOVE, no policy fires.** A half is "touched" iff at least one of its composite names appears in the update payload (regardless of value, including `undefined`) OR appears in `keyRecord` (the entity primary-key attributes carried into the composer alongside the payload) OR appears in `Entity.remove([...])`:
 
 ```ts
 const halfTouched =
   halfComposites.some((c) => c in updatePayload) ||
+  halfComposites.some((c) => c in keyRecord) ||   // v1.7.2 (closes #43)
   halfComposites.some((c) => removedSet?.has(c))
 if (!halfTouched) continue  // leave this half's key attribute alone
 ```
 
-Why: `'sparse'`'s contract is *with the half's owner*. If the writer doesn't touch any of the half's composites, they aren't claiming ownership of this half on this call — sparse shouldn't fire. The writer-scope concept #38 was reaching for falls out of payload contents naturally.
+Why two input sources, not one: composites that are *also* entity primary-key composites (e.g. `byChannel: { pk: [channel], sk: [deviceId] }` on an entity with `primaryKey: [channel, deviceId]`) arrive through `keyRecord`, never through `updatePayload` — the writer addresses the row by key, doesn't restate those values in `.set({...})`, and `.append()` deliberately separates structural fields from the SET clause. The v1.7.1 gate looked only at `updatePayload` and so classified such halves as "untouched" on every call, skipping evaluation entirely; the half's `gsiNpk` / `gsiNsk` were never composed and the item was invisible to the GSI. v1.7.2 broadens "touched" to also count `keyRecord` membership: any GSI half whose composites are entity-PK composites is now evaluated on every write that has a `keyRecord`, and the structural rule composes the half from the always-present PK values. The behavior is idempotent — re-SETting the same composed value from immutable PK composites produces the same key — so there is no multi-writer regression from broadening the gate (see issue #43 for the full analysis and the multi-writer preservation argument).
+
+Why: `'sparse'`'s contract is *with the half's owner*. If the writer doesn't touch any of the half's composites — neither in payload, nor through the key-addressed structural inputs — they aren't claiming ownership of this half on this call. The writer-scope concept #38 was reaching for falls out of payload-plus-keyRecord contents naturally.
 
 End-to-end consequences for the canonical multi-writer scenarios:
 
@@ -722,7 +725,7 @@ Naming any one composite of a half is enough — `Entity.remove` doesn't require
 
 For each half (PK then SK), independently:
 
-1. **Evaluation gate.** If no composite of this half is in `payload` AND no composite of this half is in `removedSet` → `noop` (skip — leave the stored key untouched). Otherwise the half is **touched**, continue.
+1. **Evaluation gate.** If no composite of this half is in `payload` AND no composite of this half is in `keyRecord` AND no composite of this half is in `removedSet` → `noop` (skip — leave the stored key untouched). Otherwise the half is **touched**, continue. (`keyRecord` membership is the v1.7.2 broadening — see #43; entity-PK composites are always present in `keyRecord` and so any GSI half whose composites are entity-PK composites is touched on every write.)
 2. **Structural rule.** Walk the half's composite list left-to-right. Find the longest leading prefix of present values in `M`.
 3. **Classify the outcome:**
    - **Compose succeeded** (leading prefix is non-empty AND no hole — i.e. all absent composites are at trailing positions): SET this half's key from the leading prefix. Done.
@@ -735,9 +738,11 @@ The two halves' outcomes are emitted independently — each affects only its own
 
 **`put()` semantics (unchanged).** `put()` does not consult `indexPolicy`. It writes a complete item from scratch — any missing composite means "this item is not in that GSI." The existing `tryComposeIndexKeys` path (omit GSI keys when any composite is absent) is preserved as-is. `indexPolicy` exists specifically to resolve the update/append ambiguity, not the put case.
 
-**`.append()` semantics (time-series) — same composer.** v1.7.x unifies append with update. `.append(input)` calls the same composer as `.update(...).set(...)`, with `appendInput` as the payload. Composites outside `appendInput` are simply absent under the structural rule, and the per-half evaluation gate applies — halves whose composites are entirely outside `appendInput` are untouched and follow the noop branch.
+**`.append()` semantics (time-series) — same composer.** v1.7.x unifies append with update. `.append(input)` calls the same composer as `.update(...).set(...)`, with the encoded append input passed as both `updatePayload` and `keyRecord` (v1.7.2 — see #43; the v1.7.1 path filtered PK composites out of the payload, which combined with the gate-only-checks-payload bug to skip GSI evaluation for any half whose composites are entirely entity-PK composites). Composites outside `appendInput` are simply absent under the structural rule, and the per-half evaluation gate applies — halves whose composites are entirely outside `appendInput` AND outside the entity primary key are untouched and follow the noop branch.
 
-For sparse GSIs whose composites are entirely outside `appendInput`, the half is untouched → noop (under v1.7.1). Sparse only fires when the writer touches the half but can't compose it. This matches the consumer-side multi-writer recommendation: sparse GSIs should be single-writer-per-half by design.
+For sparse GSIs whose composites are entirely outside `appendInput` *and* outside the entity primary key, the half is untouched → noop. Sparse only fires when the writer touches the half but can't compose it. This matches the consumer-side multi-writer recommendation: sparse GSIs should be single-writer-per-half by design.
+
+For GSIs whose composites are entirely entity-PK composites (e.g. `byChannel: { pk: [channel], sk: [deviceId] }` on a Telemetry entity with `primaryKey: [channel, deviceId]`), the half is always touched (PK composites are always in `keyRecord`), the structural rule always composes from the immutable PK values, and the resulting SET is idempotent — every write re-emits the same composed key. This is the correct behavior; v1.7.0 / v1.7.1 silently skipped these GSIs, leaving items invisible to channel-scoped queries.
 
 **EDD-9024 (`CompositeKeyHoleError`) deprecation — runtime-irrelevant in v1.7.1.** The class is kept exported for back-compat but no longer thrown at runtime. The original v1.7.0 throw protected against an `[A, _, C]` shape under preserve — but the type system already catches the only "wrong" case the throw was guarding (required composites can't be omitted under `exactOptionalPropertyTypes` since v1.7.0 reverted the NullishOr widening; the only legitimate runtime hole is "optional leading composite absent + present trailing composite," which is a normal write the consumer expressly chose). Under v1.7.1 the hole pattern collapses into the unified can't-compose rule (drop under sparse, noop-or-cascade-override under preserve). See `Errors.ts` for the deprecation note on the class.
 
@@ -786,6 +791,18 @@ entity.update(key).remove(['alertState']).asEffect()
 | Cascade override under preserve | `{ pk: "preserve" }`, `update(key).remove(["accountId"])` (no surviving pk composites) | touched (cascade), can't compose + preserve + cascade override → REMOVE gsi1pk | untouched, **noop** | gsi1pk REMOVE'd via cascade override |
 
 **Multi-writer entity design rule.** Each GSI half should be entirely owned by a single writer's domain. The library does not paper over cross-writer composite ownership — that's a consumer-side modeling discipline. With v1.7.1's per-half evaluation gate and the per-half outcome rule, a writer that doesn't touch a GSI's composites simply doesn't supply them, and the half no-ops regardless of policy. There is no per-composite leakage across writers like in v1.6, and no GSI-wide blast radius like in v1.7.0.
+
+**v1.7.0 / v1.7.1 → v1.7.2 PK-composites-only regression callout (closes #43).** The v1.7.1 per-half gate consulted only `updatePayload`. For GSI halves whose composites are entity-PK composites (a common pattern: tenant-scoped queries, entity-key-projected GSIs), `updatePayload` never carried those composites — the writer addresses the row by key, never restates them in `.set({...})`, and `.append()` further filtered PK composites out of its payload before passing to the composer. The gate saw both halves as untouched, skipped GSI evaluation entirely, and never wrote `gsiNpk` / `gsiNsk`. Items written under v1.7.0 / v1.7.1 against such GSIs were invisible to GSI queries. v1.7.2 fixes this in two places: the gate now also counts `keyRecord` membership (so PK composites carried alongside the payload count as "touched"), AND `Entity.append()` no longer filters PK composites out of the payload it passes to the composer (the filter never solved a real problem and silently broke this pattern). Affected items repair on the next `Entity.update()` against them — the gate now fires, the structural rule composes the immutable PK values, and the missing GSI keys are SET. No data migration needed; reads via the GSI start returning these items as their next update lands.
+
+#### Canonical GSI-composite test-fixture shapes
+
+Test coverage for the policy-aware composer must span the canonical GSI-composite shapes. Missing one shape (as the v1.7.1 fixture matrix did with PK-composites-only) leads to consumer-facing regressions. Future work in this area must verify each shape:
+
+1. **Multi-writer GSI** — composites split across writers (e.g. enrichment-owned PK composite + telemetry-owned SK composites). The per-half gate must skip halves the current writer doesn't touch. Anchor scenario for the `'preserve'` contract.
+2. **PK-composites-only GSI** — composites entirely subset of the entity primary key (e.g. `byChannel: { pk: [channel], sk: [deviceId] }` on `primaryKey: [channel, deviceId]`). The per-half gate must fire via `keyRecord` membership and SET on every write. Regression scenario for #43 — must be present in unit, entity-level integration, and connected suites.
+3. **Hierarchical GSI** — composites form a parent → child hierarchy (e.g. `[region, country, city, site]`). The structural rule must truncate via `set({ parents }).remove(["leaf"])`.
+4. **Hole pattern GSI** — optional leading composite + present trailing composite. Must collapse into the unified can't-compose rule (drop under `'sparse'`, noop or cascade-override under `'preserve'`).
+5. **All composites mutable** — every composite is a non-PK model field, and `appendInput` / update payloads carry them all. The standard case; the gate fires through the payload.
 
 ### Sparse Map Storage (`storedAs: DynamoModel.SparseMap()`)
 

--- a/packages/docs/src/content/docs/guides/index-policy.mdx
+++ b/packages/docs/src/content/docs/guides/index-policy.mdx
@@ -79,19 +79,24 @@ For each *touched* half (PK and SK independently), the library walks the composi
 
 Truncation on PK is the same hierarchical demotion as truncation on SK. An item with `pk.composite = ['accountId', 'fleetId']` and `fleetId` absent composes a partition key of `account#A` and stays queryable at the account scope.
 
-### Per-half evaluation gate (NEW in v1.7.1)
+### Per-half evaluation gate (v1.7.1, broadened in v1.7.2)
 
 Before the structural rule even runs, each half is checked for whether the writer touched it. **If a half is untouched, it is skipped entirely — no SET, no REMOVE, no policy fires.**
 
-A half is *touched* iff at least one of its composite names appears in the update payload (regardless of value, including `undefined`) OR appears in `Entity.remove([...])`.
+A half is *touched* iff at least one of its composite names appears in:
+- the update payload (regardless of value, including `undefined`), OR
+- the `keyRecord` carried alongside the payload — i.e. the entity primary-key composites used to address the row (added in **v1.7.2** to close [#43](https://github.com/jmenga/effect-dynamodb/issues/43); see the *byChannel* pitfall below), OR
+- `Entity.remove([...])`.
 
 This is what makes the multi-writer story work end-to-end:
 
 | Writer | Payload | byCurrentAlert eval |
 |---|---|---|
-| Stamp | `{ published: "2026-04-30" }` | Both halves untouched → noop, both halves preserved |
+| Stamp | `{ published: "2026-04-30" }` | Both halves untouched (composites are not in payload, not in keyRecord, not in `Entity.remove`) → noop, both halves preserved |
 | Enrichment | `{ accountId: "newAcct" }` | pk touched (SET); sk untouched (noop) |
 | Telemetry | `{ alertState: "active", timestamp: T }` | pk untouched (noop); sk touched (SET) |
+
+Why `keyRecord` is in the gate (v1.7.2): GSI halves whose composites are entity primary-key composites — for example `byChannel: { pk: [channel], sk: [deviceId] }` on an entity with `primaryKey: [channel, deviceId]` — never receive those composites via the update payload. The writer addresses the row by key, never restates the values in `.set({...})`, and `.append()` separates structural fields from the SET clause. The v1.7.1 gate looked only at the payload and so silently classified such halves as untouched on every write — `gsi*pk` / `gsi*sk` were never composed and the item was invisible to the GSI. v1.7.2 broadens the check to also count `keyRecord` membership; the resulting SET is idempotent for entity-PK composites because they're immutable.
 
 ## 6. Per-key outcome rolls up to per-key storage
 
@@ -281,6 +286,18 @@ In v1.7.0, a stamp writer that touched only a non-composite attribute (e.g. `set
 
 v1.7.1's per-half evaluation gate fixes this: untouched halves are skipped entirely. The stamp writer above leaves both halves alone.
 
+### `byChannel` GSI returns 0 items in v1.7.0 / v1.7.1 (PK-composites-only regression, fixed in v1.7.2)
+
+In v1.7.0 and v1.7.1, GSIs whose composites are entirely entity primary-key composites — e.g. `byChannel: { pk: [channel], sk: [deviceId] }` on a Telemetry entity with `primaryKey: [channel, deviceId]` — were silently skipped on every write. The per-half evaluation gate consulted only the update payload, but PK composites never appear there: the writer addresses the row by key, never restates them in `.set({...})`, and `.append()` separates structural fields from the SET clause. The composer ran but the gate classified both halves as untouched → `gsi*pk` / `gsi*sk` were never written → channel-scoped GSI queries returned nothing.
+
+v1.7.2 fixes this in two places:
+1. The per-half evaluation gate now also counts `keyRecord` membership, so PK-composite-only halves are touched on every write that has a `keyRecord`.
+2. `Entity.append()` no longer filters PK composites out of the payload it passes to the composer (the filter never solved a real problem and combined with #1 to silently break this pattern).
+
+**Affected items:** items written to PK-composites-only GSIs under v1.7.0 or v1.7.1 will repair themselves on the next `Entity.update()` against them. The gate now fires correctly, the structural rule composes the immutable PK values, and the missing GSI keys are SET. No data migration is needed; reads via the GSI start returning these items as their next update lands. If you have items that aren't naturally updated, a one-shot bulk `set({ otherField: ... })` or `Entity.update(key).set({})` (touching no fields, just bumping `updatedAt` + version) is enough to repair them.
+
+This pattern is common — tenant-scoped queries (`byTenant: { pk: [tenantId] }`), entity-key-projected GSIs, channel-scoped time-series. Test coverage for the policy-aware composer must always include the PK-composites-only shape; missing it (as the v1.7.1 fixture matrix did) is what produced this regression.
+
 ## 10. Make-time guarantees
 
 ### EDD-9025 — composite attributes can't be nullable
@@ -326,9 +343,14 @@ The error class is still exported for back-compat with consumers who type-import
 
 ## When is a GSI evaluated?
 
-Per the [per-half evaluation gate](#per-half-evaluation-gate-new-in-v171), each *half* is evaluated only when at least one of its composites is in the update payload, or when `Entity.remove([attr])` names one of its composites. Halves whose composites are entirely outside the payload are skipped — no SET, no REMOVE, no policy fires.
+Per the [per-half evaluation gate](#per-half-evaluation-gate-v171-broadened-in-v172), each *half* is evaluated when at least one of its composites is:
+- in the update payload, OR
+- in `keyRecord` (the entity primary-key attributes used to address the row — added in **v1.7.2**, [#43](https://github.com/jmenga/effect-dynamodb/issues/43)), OR
+- in `Entity.remove([attr])`.
 
-The presence of an `indexPolicy` declaration does **not** force evaluation of every update under v1.7.1 (this is a behavior change from v1.7.0). The per-half gate is the same regardless of whether `indexPolicy` is declared.
+Halves whose composites satisfy none of those conditions are skipped — no SET, no REMOVE, no policy fires.
+
+The presence of an `indexPolicy` declaration does **not** force evaluation of every update under v1.7.1+ (this is a behavior change from v1.7.0). The per-half gate is the same regardless of whether `indexPolicy` is declared.
 
 ## Interaction with `put()`
 
@@ -336,7 +358,9 @@ The presence of an `indexPolicy` declaration does **not** force evaluation of ev
 
 ## Interaction with time-series `.append()`
 
-v1.7.x unifies `.append()` with `.update()` — both call the same composer with the same per-half evaluation gate. Composites outside `appendInput` are absent under the structural rule, AND the half is untouched per the gate (composite name is not in payload, not in removedSet). Halves whose composites are entirely outside `appendInput` are skipped.
+v1.7.x unifies `.append()` with `.update()` — both call the same composer with the same per-half evaluation gate. Composites outside `appendInput` are absent under the structural rule, AND the half is untouched per the gate (composite name is not in payload, not in keyRecord, not in removedSet). Halves whose composites are entirely outside `appendInput` *and* entirely outside the entity primary key are skipped.
+
+For GSIs whose composites are entirely entity-PK composites (e.g. `byChannel: { pk: [channel], sk: [deviceId] }` on `primaryKey: [channel, deviceId]`), the half is always touched via keyRecord membership and the structural rule composes from the immutable PK values on every append. The resulting SET is idempotent. (v1.7.0 / v1.7.1 silently skipped these GSIs — see the *byChannel* pitfall above; closes [#43](https://github.com/jmenga/effect-dynamodb/issues/43).)
 
 A multi-writer entity should declare its GSI shape so each half is owned by a single writer's domain — that's the design rule and the natural fit with per-half policy.
 
@@ -348,9 +372,19 @@ With per-half policy, the per-half evaluation gate, and the structural compositi
 
 Concretely: if you have a hybrid GSI with `pk = [accountId, alertState]` where `accountId` is enrichment-owned and `alertState` is ingest-owned, restructure to put each writer's composites on its own half — `pk = [accountId]`, `sk = [alertState, ...]` — so each half has a single owner. The per-half policy then expresses each writer's intent cleanly, and the per-half gate ensures one writer never disturbs the other's key.
 
+## Migrating from 1.7.1 (or 1.7.0)
+
+v1.7.2 is a patch release fixing the PK-composites-only GSI regression introduced by v1.7.1's per-half evaluation gate (closes [#43](https://github.com/jmenga/effect-dynamodb/issues/43)). **No API changes** — same `indexPolicy: { pk, sk }` declaration, same `Entity.remove([...])` API, same EDD-9025 invariants.
+
+**Behavior change** (strictly more correct than v1.7.1):
+
+- **Per-half evaluation gate now also counts `keyRecord` membership.** GSI halves whose composites are entirely entity primary-key composites are now correctly classified as touched on every write, and the structural rule composes their keys from the immutable PK values. The resulting SET is idempotent. Items written under v1.7.0 / v1.7.1 against such GSIs (where the gate silently skipped them) repair themselves on the next `Entity.update()` against them — no data migration needed; reads via the GSI start returning these items as their next update lands.
+
+If you used the `byChannel`-style pattern (GSI composites = subset of entity PK) under v1.7.0 or v1.7.1 and noticed channel-scoped queries returning no items, this is the fix. Re-run any item that should be in the GSI through any update touching any field, and the GSI key composition will land.
+
 ## Migrating from 1.7.0
 
-v1.7.1 is a patch release fixing three connected bugs in the v1.7.0 roll-up. **No API changes** — same `indexPolicy: { pk, sk }` declaration, same `Entity.remove([...])` API, same EDD-9025 invariants.
+v1.7.1 was a patch release fixing three connected bugs in the v1.7.0 roll-up. **No API changes** — same `indexPolicy: { pk, sk }` declaration, same `Entity.remove([...])` API, same EDD-9025 invariants.
 
 **Behavior changes** (all bug fixes — strictly more correct than v1.7.0):
 

--- a/packages/effect-dynamodb-geo/CHANGELOG.md
+++ b/packages/effect-dynamodb-geo/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @effect-dynamodb/geo
 
+## 1.7.2
+
+### Patch Changes
+
+- **indexPolicy v1.7.2 — fix PK-composites-only GSI regression (closes [#43](https://github.com/jmenga/effect-dynamodb/issues/43)).**
+
+  v1.7.1 introduced a per-half evaluation gate that — by design — skipped GSI evaluation on halves the writer didn't touch. Unfortunately the gate consulted only `updatePayload` and so silently classified entire GSIs as untouched whenever their composites were entirely entity primary-key composites. Those PK composites never appear in `updatePayload` (writers address the row by key, never restate them in `.set({...})`, and `.append()` filtered them out before passing to the composer). The composer never ran, `gsiNpk` and `gsiNsk` were never written, and items were invisible to the GSI for their lifetime.
+
+  Concretely: an entity with `primaryKey: [channel, deviceId]` and a `byChannel: { pk: [channel], sk: [deviceId] }` GSI saw zero items returned from any channel-scoped query under v1.7.0 / v1.7.1, regardless of whether the writes used `.put()`, `.update()`, or `.append()` — the latter two never composed the keys, and `.update()` only re-composed them on calls that explicitly restated `channel` / `deviceId` in the payload (which no realistic writer does).
+
+  **The fix** (two minimal patches working together):
+  1. **`KeyComposer.composeGsiKeysForUpdatePolicyAware`** — the per-half gate now also counts `keyRecord` membership (the entity primary-key attributes carried into the composer alongside the payload). PK-composite-only GSI halves are now correctly classified as touched on every write that has a `keyRecord`.
+  2. **`Entity.append()`** — no longer filters PK composites out of the payload it passes to the composer. The filter never solved a real problem (the composer doesn't emit redundant SETs for the underlying composite fields, and idempotent recomposition from immutable PK composites is benign) and combined with the v1.7.1 gate to silently break this pattern.
+
+  The change is idempotent for entity-PK composites (re-composing the same value from immutable PK composites produces the same key) and preserves the v1.7.1 multi-writer fix: stamps' GSI composites are not in `updatePayload` AND not in `keyRecord` either (they're enrichment-owned model attrs), so their halves remain untouched as designed.
+
+  **Affected items:** items written to PK-composites-only GSIs under v1.7.0 or v1.7.1 will repair themselves on the next `Entity.update()` against them. The gate now fires correctly, the structural rule composes the immutable PK values, and the missing GSI keys are SET. **No data migration required** — reads via the GSI start returning these items as their next update lands. If you have items that aren't naturally updated, a one-shot bulk `Entity.update(key).set({ otherField: value })` (or even an empty-payload update touching only `updatedAt` + version) is enough to repair them.
+
+  **No API changes** — same `indexPolicy: { pk, sk }` declaration shape, same `Entity.update` / `Entity.append` signatures, same EDD-9025 invariants. Behavior change is strictly more correct than v1.7.1.
+
+  See `DESIGN.md §7` for the updated decision algorithm and `guides/index-policy.mdx` for the updated walkthrough plus the _byChannel GSI returns 0 items_ pitfall.
+
 ## 1.7.1
 
 ### Patch Changes

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/geo",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Geospatial index and search for effect-dynamodb using H3 hexagonal grid",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/CHANGELOG.md
+++ b/packages/effect-dynamodb/CHANGELOG.md
@@ -1,5 +1,27 @@
 # effect-dynamodb
 
+## 1.7.2
+
+### Patch Changes
+
+- **indexPolicy v1.7.2 — fix PK-composites-only GSI regression (closes [#43](https://github.com/jmenga/effect-dynamodb/issues/43)).**
+
+  v1.7.1 introduced a per-half evaluation gate that — by design — skipped GSI evaluation on halves the writer didn't touch. Unfortunately the gate consulted only `updatePayload` and so silently classified entire GSIs as untouched whenever their composites were entirely entity primary-key composites. Those PK composites never appear in `updatePayload` (writers address the row by key, never restate them in `.set({...})`, and `.append()` filtered them out before passing to the composer). The composer never ran, `gsiNpk` and `gsiNsk` were never written, and items were invisible to the GSI for their lifetime.
+
+  Concretely: an entity with `primaryKey: [channel, deviceId]` and a `byChannel: { pk: [channel], sk: [deviceId] }` GSI saw zero items returned from any channel-scoped query under v1.7.0 / v1.7.1, regardless of whether the writes used `.put()`, `.update()`, or `.append()` — the latter two never composed the keys, and `.update()` only re-composed them on calls that explicitly restated `channel` / `deviceId` in the payload (which no realistic writer does).
+
+  **The fix** (two minimal patches working together):
+  1. **`KeyComposer.composeGsiKeysForUpdatePolicyAware`** — the per-half gate now also counts `keyRecord` membership (the entity primary-key attributes carried into the composer alongside the payload). PK-composite-only GSI halves are now correctly classified as touched on every write that has a `keyRecord`.
+  2. **`Entity.append()`** — no longer filters PK composites out of the payload it passes to the composer. The filter never solved a real problem (the composer doesn't emit redundant SETs for the underlying composite fields, and idempotent recomposition from immutable PK composites is benign) and combined with the v1.7.1 gate to silently break this pattern.
+
+  The change is idempotent for entity-PK composites (re-composing the same value from immutable PK composites produces the same key) and preserves the v1.7.1 multi-writer fix: stamps' GSI composites are not in `updatePayload` AND not in `keyRecord` either (they're enrichment-owned model attrs), so their halves remain untouched as designed.
+
+  **Affected items:** items written to PK-composites-only GSIs under v1.7.0 or v1.7.1 will repair themselves on the next `Entity.update()` against them. The gate now fires correctly, the structural rule composes the immutable PK values, and the missing GSI keys are SET. **No data migration required** — reads via the GSI start returning these items as their next update lands. If you have items that aren't naturally updated, a one-shot bulk `Entity.update(key).set({ otherField: value })` (or even an empty-payload update touching only `updatedAt` + version) is enough to repair them.
+
+  **No API changes** — same `indexPolicy: { pk, sk }` declaration shape, same `Entity.update` / `Entity.append` signatures, same EDD-9025 invariants. Behavior change is strictly more correct than v1.7.1.
+
+  See `DESIGN.md §7` for the updated decision algorithm and `guides/index-policy.mdx` for the updated walkthrough plus the _byChannel GSI returns 0 items_ pitfall.
+
 ## 1.7.1
 
 ### Patch Changes

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-dynamodb",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Effect TS ORM for DynamoDB — schema-driven entity modeling, single-table design, composite keys, transactions, and Stream-based pagination",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/src/Entity.ts
+++ b/packages/effect-dynamodb/src/Entity.ts
@@ -4248,7 +4248,6 @@ const makeImpl = <
       // attributes on the item (mirrors `.put()`), and though their values
       // never change, writing them on every append makes the first append
       // (where the row doesn't yet exist) materialise the row correctly.
-      const pkCompositeSet = new Set(primaryKeyComposites(config.indexes))
       for (const [attr, val] of Object.entries(serialisedInput)) {
         if (val === undefined) continue
         const nameKey = `#a${counter}`
@@ -4260,30 +4259,28 @@ const makeImpl = <
       }
 
       // GSI key recomposition. v3 unifies append with update — both call
-      // the same composer. PK composites are excluded from the update
-      // payload — they're already in the key and never change during an
-      // append. The composer treats composites outside `appendInput` as
-      // absent under the structural rule (per-half policy decides whether
-      // a half empties to drop or no-op). See DESIGN.md §7 — "append uses
-      // the same composer."
-      const nonPkAppendFields: globalThis.Record<string, unknown> = {}
-      for (const [attr, val] of Object.entries(encoded)) {
-        if (!pkCompositeSet.has(attr)) {
-          nonPkAppendFields[attr] = val
-        }
-      }
-
+      // the same composer. v1.7.2 (closes #43): the full encoded record is
+      // passed as both `updatePayload` and `keyRecord`. The previous
+      // v1.7.0 / v1.7.1 path filtered PK composites out of the payload on
+      // the rationale that they "never change during an append" — but
+      // combined with v1.7.1's per-half evaluation gate (which only looked
+      // at `updatePayload`), that filter caused any GSI half whose
+      // composites are entirely entity-PK composites to be classified as
+      // untouched on every append, silently skipping GSI evaluation. The
+      // PK exclusion never solved a real problem (the composer doesn't
+      // emit redundant SETs for the underlying composite fields, and
+      // idempotent recomposition from immutable PK composites is fine), so
+      // it's removed. The gate now broadens its "touched" check to also
+      // count `keyRecord` membership, so PK-composite-only halves are
+      // touched on every write and the structural rule composes them.
       // No try/catch — EDD-9024 was deprecated in v1.7.1 and the composer
-      // no longer throws. Per-half evaluation gate skips halves whose
-      // composites are entirely outside `appendInput`; touched halves
-      // follow the unified per-half outcome rule (sparse drops; preserve
-      // noops or cascades).
+      // no longer throws.
       const gsiUpdate = KeyComposer.composeGsiKeysForUpdatePolicyAware(
         schema,
         entityType,
         entityVersion,
         allIndexes,
-        nonPkAppendFields,
+        encoded,
         encoded,
       )
       for (const [field, value] of Object.entries(gsiUpdate.sets)) {

--- a/packages/effect-dynamodb/src/KeyComposer.ts
+++ b/packages/effect-dynamodb/src/KeyComposer.ts
@@ -515,14 +515,18 @@ const resolveIndexPolicy = (
  * `.append` — v1.7.1 per-half structural composition with per-half evaluation
  * gate and per-half cascade.
  *
- * **Per-half evaluation gate (v1.7.1).** Each half (PK and SK) is independently
- * checked for whether the writer touched it. A half is "touched" iff at least
- * one of its composite names appears in `updatePayload` (regardless of value,
- * including `undefined`) OR appears in `removedSet`. **Untouched halves are
+ * **Per-half evaluation gate (v1.7.1; broadened in v1.7.2).** Each half (PK
+ * and SK) is independently checked for whether the writer touched it. A half
+ * is "touched" iff at least one of its composite names appears in
+ * `updatePayload` (regardless of value, including `undefined`) OR appears in
+ * `keyRecord` (the entity primary-key attributes carried into the composer
+ * alongside the payload) OR appears in `removedSet`. **Untouched halves are
  * skipped entirely — no SET, no REMOVE, no policy fires.** This closes the
  * v1.7.0 multi-writer leak where a "stamp" writer that doesn't touch a GSI's
  * composites would still trigger the policy and blow away another writer's
- * key.
+ * key, AND the v1.7.1 PK-composites-only regression (#43) where GSI halves
+ * whose composites are entity-PK composites were silently skipped because
+ * those composites arrive via `keyRecord`, not `updatePayload`.
  *
  * **Two-way payload classification.**
  * - **present** (`attr: <value>` in payload, or inherited from `keyRecord`)
@@ -579,16 +583,42 @@ export const composeGsiKeysForUpdatePolicyAware = (
     const pkComposites = index.pk.composite
     const skComposites = index.sk.composite
 
-    // Per-half evaluation gate (v1.7.1). A half is touched iff at least one
-    // of its composite names appears in `updatePayload` (regardless of value)
-    // OR in `removedSet`. Untouched halves are skipped — leave the stored
-    // key attribute alone.
+    // Per-half evaluation gate (v1.7.1; broadened in v1.7.2 — closes #43).
+    // A half is touched iff at least one of its composite names appears in
+    // `updatePayload` (regardless of value) OR in `keyRecord` OR in
+    // `removedSet`. Untouched halves are skipped — leave the stored key
+    // attribute alone.
+    //
+    // Why `keyRecord` is part of the gate (v1.7.2): GSI halves whose
+    // composites are entity primary-key composites (e.g.
+    // `byChannel: { pk: [channel], sk: [deviceId] }` on an entity with
+    // `primaryKey: [channel, deviceId]`) never receive those composites via
+    // `updatePayload` — the writer addresses the row by key, never restates
+    // the values in `.set({...})`, and `.append()` similarly delivers them
+    // through the structural-keyRecord channel rather than the SET clause.
+    // The v1.7.1 gate looked only at `updatePayload` and so classified such
+    // halves as "untouched" on every call, skipping evaluation entirely.
+    // The half's `gsiNpk` / `gsiNsk` were never composed → items invisible
+    // to the GSI. v1.7.2 also counts `keyRecord` membership so any half
+    // whose composites are entity-PK composites is touched on every write
+    // that has a `keyRecord`. This is idempotent (re-SETting the same
+    // composed value from immutable PK composites produces the same key)
+    // and preserves the v1.7.1 multi-writer fix: stamps still don't have
+    // those composites in EITHER `updatePayload` OR `keyRecord` (those
+    // composites are enrichment-owned model attrs), so their halves
+    // remain untouched. See `DESIGN.md §7` and issue #43.
     const pkHasRemoved =
       removedSet !== undefined && pkComposites.some((attr) => removedSet.has(attr))
     const skHasRemoved =
       removedSet !== undefined && skComposites.some((attr) => removedSet.has(attr))
-    const pkTouched = pkHasRemoved || pkComposites.some((attr) => attr in updatePayload)
-    const skTouched = skHasRemoved || skComposites.some((attr) => attr in updatePayload)
+    const pkTouched =
+      pkHasRemoved ||
+      pkComposites.some((attr) => attr in updatePayload) ||
+      pkComposites.some((attr) => attr in keyRecord)
+    const skTouched =
+      skHasRemoved ||
+      skComposites.some((attr) => attr in updatePayload) ||
+      skComposites.some((attr) => attr in keyRecord)
 
     if (!pkTouched && !skTouched) continue
 

--- a/packages/effect-dynamodb/test/IndexPolicyV3.test.ts
+++ b/packages/effect-dynamodb/test/IndexPolicyV3.test.ts
@@ -20,7 +20,7 @@
 
 import type { AttributeValue } from "@aws-sdk/client-dynamodb"
 import { describe, expect, it } from "@effect/vitest"
-import { Effect, Layer, Schema } from "effect"
+import { DateTime, Duration, Effect, Layer, Schema } from "effect"
 import { DynamoClient } from "../src/DynamoClient.js"
 import * as DynamoSchema from "../src/DynamoSchema.js"
 import * as Entity from "../src/Entity.js"
@@ -319,9 +319,9 @@ const makePagesMock = (capture: Capture) => ({
   getItem: () => Effect.die("getItem not expected on standard path"),
 })
 
-describe("Entity update — standard path migration regression (issue #36 / #41)", () => {
+describe("Entity update — standard path migration regression (issue #36 / #41 / #43)", () => {
   it.effect(
-    "partial update that omits preserve-policied composites does NOT generate REMOVE for any GSI key",
+    "partial update that omits preserve-policied composites does NOT generate REMOVE for any GSI key (footgun stays closed); SK halves SET via keyRecord membership (v1.7.2 — closes #43)",
     () => {
       const capture: Capture = {}
       const layer = Layer.mergeAll(
@@ -333,10 +333,15 @@ describe("Entity update — standard path migration regression (issue #36 / #41)
           entities: { Pages },
           tables: { PagesTable },
         })
-        // Update only `name` — never mentions X, Y, Z, or pageId. Under
-        // v1.7.1 the per-half evaluation gate skips ALL halves of all three
-        // GSIs (none has a composite touched). The footgun stays closed:
-        // zero gsi*pk / gsi*sk REMOVEs in the UpdateExpression.
+        // Update only `name` — never mentions X, Y, Z, or pageId in the
+        // payload. Under v1.7.1 the per-half evaluation gate skipped ALL
+        // halves of all three GSIs because the gate only consulted
+        // `updatePayload`. Under v1.7.2 (closes #43) the gate also counts
+        // `keyRecord` membership: `pageId` is in keyRecord (it's the
+        // entity-PK composite), so all three SK halves are touched →
+        // structural rule composes from `pageId` → SET. The PK halves
+        // (X/Y/Z) are non-PK composites — not in payload, not in keyRecord
+        // → noop. The original footgun stays closed: zero gsi*pk REMOVEs.
         yield* db.entities.Pages.update({ pageId: "p-1" }).set({ name: "new-name" })
         const ui = capture.updateItem as {
           UpdateExpression?: string
@@ -350,20 +355,28 @@ describe("Entity update — standard path migration regression (issue #36 / #41)
           .map((s) => s.trim())
           .filter((s) => s.length > 0)
           .map((alias) => ui.ExpressionAttributeNames?.[alias] ?? alias)
+        // Footgun assertion: no GSI key REMOVE'd. Stays closed under v1.7.2.
         for (const name of physicalRemoves) {
           expect(name).not.toMatch(/^gsi\d(pk|sk)$/)
         }
-        // v1.7.1 additional assertion: no SETs on gsi*pk / gsi*sk either —
-        // halves are untouched, so the composer emits nothing.
+        // Per-half partition (v1.7.2): PK halves (X/Y/Z — non-PK composites,
+        // not in keyRecord, not in payload) → noop. SK halves (pageId — the
+        // entity-PK composite, in keyRecord) → touched → SET.
         const setClause = expr.match(/SET\s+(.*?)(?:\s+REMOVE|$)/i)?.[1] ?? ""
         const setNames = setClause
           .split(",")
           .map((s) => s.split("=")[0]?.trim() ?? "")
           .filter((s) => s.startsWith("#"))
           .map((alias) => ui.ExpressionAttributeNames?.[alias] ?? alias)
-        for (const name of setNames) {
-          expect(name).not.toMatch(/^gsi\d(pk|sk)$/)
-        }
+        const setSet = new Set(setNames)
+        // No SET on PK halves of any GSI.
+        expect(setSet.has("gsi1pk")).toBe(false)
+        expect(setSet.has("gsi2pk")).toBe(false)
+        expect(setSet.has("gsi3pk")).toBe(false)
+        // SET on every GSI's SK half via keyRecord membership.
+        expect(setSet.has("gsi1sk")).toBe(true)
+        expect(setSet.has("gsi2sk")).toBe(true)
+        expect(setSet.has("gsi3sk")).toBe(true)
       }).pipe(Effect.provide(layer), Effect.scoped)
     },
   )
@@ -708,7 +721,7 @@ describe("Entity.make() — EDD-9025 composite null check", () => {
     ).not.toThrow()
   })
 
-  it("allows plain non-nullable schemas on composites", () => {
+  it("allows plain non-nullable schemas on composites (sanity)", () => {
     class OkModel extends Schema.Class<OkModel>("OkModel")({
       id: Schema.String,
       tenantId: Schema.String,
@@ -750,4 +763,242 @@ describe("Entity.make() — EDD-9025 composite null check", () => {
       }),
     ).not.toThrow()
   })
+})
+
+// ---------------------------------------------------------------------------
+// Issue #43 — PK-composites-only GSI shape (entity-level wiring)
+// ---------------------------------------------------------------------------
+//
+// The bug: GSIs whose composites are entirely entity-PK composites (e.g.
+// `byChannel: { pk: [channel], sk: [deviceId] }` on an entity with
+// `primaryKey: [channel, deviceId]`) had their `gsi*pk` / `gsi*sk` keys
+// silently skipped under v1.7.0 / v1.7.1 — the per-half evaluation gate
+// only consulted `updatePayload`, and PK composites never appear there.
+// v1.7.2 broadens the gate to also count `keyRecord` membership AND
+// removes the PK-composite filter from `Entity.append()`'s payload.
+//
+// These tests prove the wiring through both Entity.update (standard path)
+// and Entity.append (time-series path) — verifying the resulting wire-form
+// expressions carry SETs for the PK-composite-only GSI keys.
+// ---------------------------------------------------------------------------
+
+class Sensor extends Schema.Class<Sensor>("Sensor")({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  // A non-composite payload field used to trigger updates without restating
+  // the PK composites. Modeled as Schema.optional so updates can include it
+  // selectively.
+  otherField: Schema.optional(Schema.String),
+}) {}
+
+const SensorSchema = DynamoSchema.make({ name: "sensor-test", version: 1 })
+
+const Sensors = Entity.make({
+  model: Sensor,
+  entityType: "Sensor",
+  primaryKey: {
+    pk: { field: "pk", composite: ["channel", "deviceId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  indexes: {
+    // PK-composites-only GSI shape — the #43 repro.
+    byChannel: {
+      name: "gsi1",
+      pk: { field: "gsi1pk", composite: ["channel"] },
+      sk: { field: "gsi1sk", composite: ["deviceId"] },
+      indexPolicy: { pk: "preserve", sk: "preserve" },
+    },
+  },
+})
+
+const SensorTable = Table.make({ schema: SensorSchema, entities: { Sensors } })
+const SensorTableLayer = SensorTable.layer({ name: "sensor-table" })
+
+// Mock client that pretends a stored Sensor exists with no GSI keys (mirrors
+// items written under v1.7.0 / v1.7.1 — the bug state). Returns
+// Sensor-shaped Attributes from updateItem so the Schema decode succeeds.
+const makeSensorMock = (capture: Capture) => ({
+  ...makeMockClient(capture),
+  getItem: () =>
+    Effect.succeed({
+      Item: {
+        pk: { S: "$sensor-test#v1#sensor#channel_c-1#deviceid_d-1" } as AttributeValue,
+        sk: { S: "$sensor-test#v1#sensor" } as AttributeValue,
+        channel: { S: "c-1" } as AttributeValue,
+        deviceId: { S: "d-1" } as AttributeValue,
+        __edd_e__: { S: "Sensor" } as AttributeValue,
+      },
+    }),
+  updateItem: (input: Record<string, unknown>) => {
+    capture.updateItem = input
+    return Effect.succeed({
+      Attributes: {
+        pk: { S: "$sensor-test#v1#sensor#channel_c-1#deviceid_d-1" } as AttributeValue,
+        sk: { S: "$sensor-test#v1#sensor" } as AttributeValue,
+        channel: { S: "c-1" } as AttributeValue,
+        deviceId: { S: "d-1" } as AttributeValue,
+        otherField: { S: "X" } as AttributeValue,
+        __edd_e__: { S: "Sensor" } as AttributeValue,
+      },
+    })
+  },
+})
+
+describe("Entity update — PK-composites-only GSI shape (closes #43)", () => {
+  it.effect(
+    "Entity.update().set({ otherField }) on entity with byChannel: {pk:[channel], sk:[deviceId]} produces SET clauses for gsi1pk AND gsi1sk",
+    () => {
+      // Standard update path. `set({ otherField: ... })` doesn't mention
+      // channel or deviceId in the payload — they live in keyRecord. Pre-
+      // v1.7.2 the per-half gate skipped both halves of byChannel and the
+      // UpdateExpression had no SET for gsi1pk / gsi1sk. v1.7.2 fixes this.
+      const capture: Capture = {}
+      const layer = Layer.mergeAll(
+        Layer.succeed(DynamoClient, makeSensorMock(capture) as any),
+        SensorTableLayer,
+      )
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { Sensors },
+          tables: { SensorTable },
+        })
+        yield* db.entities.Sensors.update({ channel: "c-1", deviceId: "d-1" }).set({
+          otherField: "X",
+        })
+        const ui = capture.updateItem as {
+          UpdateExpression?: string
+          ExpressionAttributeNames?: Record<string, string>
+          ExpressionAttributeValues?: Record<string, AttributeValue>
+        }
+        expect(ui.UpdateExpression).toBeDefined()
+        const expr = ui.UpdateExpression!
+        // Parse the SET clause and resolve aliases to physical names.
+        const setClause = expr.match(/SET\s+(.*?)(?:\s+REMOVE|$)/i)?.[1] ?? ""
+        const setAssignments = setClause.split(",").map((s) => s.trim())
+        const setNames = setAssignments
+          .map((s) => s.split("=")[0]?.trim() ?? "")
+          .filter((s) => s.startsWith("#"))
+          .map((alias) => ui.ExpressionAttributeNames?.[alias] ?? alias)
+        const setSet = new Set(setNames)
+        // v1.7.2 critical assertions: both halves of byChannel SET via the
+        // per-half gate's keyRecord branch.
+        expect(setSet.has("gsi1pk")).toBe(true)
+        expect(setSet.has("gsi1sk")).toBe(true)
+        // No REMOVE on either half.
+        const removed = parseRemoves(ui)
+        expect(removed.has("gsi1pk")).toBe(false)
+        expect(removed.has("gsi1sk")).toBe(false)
+      }).pipe(Effect.provide(layer), Effect.scoped)
+    },
+  )
+})
+
+// Time-series append path uses transactWriteItems. Same entity shape but
+// with `timeSeries` configuration. The SET clauses live in the
+// TransactItems[0].Update.UpdateExpression.
+
+class TelemetryFixture extends Schema.Class<TelemetryFixture>("TelemetryFixture")({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  timestamp: Schema.DateTimeUtc,
+  reading: Schema.optional(Schema.Number),
+}) {}
+
+const TelemetryFixtureAppendInput = Schema.Struct({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  timestamp: Schema.DateTimeUtc,
+  reading: Schema.optional(Schema.Number),
+})
+
+const TelemetryFixtureSchema = DynamoSchema.make({ name: "telemetry-fixture", version: 1 })
+
+const TelemetryFixtureEntity = Entity.make({
+  model: TelemetryFixture,
+  entityType: "TelemetryFixture",
+  primaryKey: {
+    pk: { field: "pk", composite: ["channel", "deviceId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  indexes: {
+    byChannel: {
+      name: "gsi1",
+      pk: { field: "gsi1pk", composite: ["channel"] },
+      sk: { field: "gsi1sk", composite: ["deviceId"] },
+      indexPolicy: { pk: "preserve", sk: "preserve" },
+    },
+  },
+  timestamps: true,
+  timeSeries: {
+    orderBy: "timestamp",
+    ttl: Duration.days(7),
+    appendInput: TelemetryFixtureAppendInput,
+  },
+})
+
+const TelemetryFixtureTable = Table.make({
+  schema: TelemetryFixtureSchema,
+  entities: { TelemetryFixtureEntity },
+})
+const TelemetryFixtureTableLayer = TelemetryFixtureTable.layer({ name: "telemetry-fixture-table" })
+
+const makeTelemetryFixtureMock = (capture: Capture) => ({
+  ...makeMockClient(capture),
+  getItem: () => Effect.die("getItem not used on append path"),
+  // The append path's follow-up GET (when not skipFollowUp) needs a stored
+  // record. Provide a minimally complete one — the test only inspects the
+  // captured TransactWriteItems.
+  // The follow-up uses getItem too, but we can return the same shape.
+})
+
+describe("Entity append — PK-composites-only GSI shape (closes #43)", () => {
+  it.effect(
+    "Entity.append() on time-series entity with byChannel: {pk:[channel], sk:[deviceId]} produces SET clauses for gsi1pk AND gsi1sk in the current-row UpdateItem",
+    () => {
+      const capture: Capture = {}
+      const layer = Layer.mergeAll(
+        Layer.succeed(DynamoClient, makeTelemetryFixtureMock(capture) as any),
+        TelemetryFixtureTableLayer,
+      )
+      return Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { TelemetryFixtureEntity },
+          tables: { TelemetryFixtureTable },
+        })
+        // Use skipFollowUp so the test doesn't need to mock the follow-up
+        // GetItem. We're only inspecting the TransactWriteItems wire form.
+        yield* db.entities.TelemetryFixtureEntity.append({
+          channel: "c-1",
+          deviceId: "d-1",
+          timestamp: DateTime.makeUnsafe("2026-04-30T10:00:00.000Z"),
+          reading: 42,
+        }).skipFollowUp()
+
+        const tx = capture.transactWriteItems
+        expect(tx).toBeDefined()
+        const items = (tx as { TransactItems?: Array<unknown> }).TransactItems
+        expect(items?.length).toBe(2) // Update current + Put event
+        const update = (items?.[0] as { Update?: Record<string, unknown> }).Update
+        expect(update).toBeDefined()
+        const expr = (update as { UpdateExpression?: string }).UpdateExpression!
+        const names = (update as { ExpressionAttributeNames?: Record<string, string> })
+          .ExpressionAttributeNames!
+        // Parse SET clause and resolve aliases.
+        const setClause = expr.match(/SET\s+(.*?)(?:\s+REMOVE|$)/i)?.[1] ?? ""
+        const setNames = setClause
+          .split(",")
+          .map((s) => s.trim())
+          .map((s) => s.split("=")[0]?.trim() ?? "")
+          .filter((s) => s.startsWith("#"))
+          .map((alias) => names[alias] ?? alias)
+        const setSet = new Set(setNames)
+        // v1.7.2 critical assertions for #43: both halves of byChannel SET
+        // via the per-half gate's keyRecord branch (Option B) AND because
+        // append no longer filters PK composites out of its payload (Option
+        // A). v1.7.0 / v1.7.1 had neither SET — items invisible to GSI.
+        expect(setSet.has("gsi1pk")).toBe(true)
+        expect(setSet.has("gsi1sk")).toBe(true)
+      }).pipe(Effect.provide(layer), Effect.scoped)
+    },
+  )
 })

--- a/packages/effect-dynamodb/test/KeyComposer.test.ts
+++ b/packages/effect-dynamodb/test/KeyComposer.test.ts
@@ -380,16 +380,24 @@ describe("KeyComposer", () => {
 
     describe("per-half evaluation gate", () => {
       it("payload doesn't mention any composite of either half → both halves noop", () => {
-        // No index policy, no composite in payload, no removedSet → composer
-        // returns nothing for this GSI. (The standard update path will then
-        // simply not emit any GSI-key SET/REMOVE clauses.)
+        // No index policy, no composite in payload, no removedSet, and the
+        // GSI's composites (A/B/C) are not entity-PK composites (so they're
+        // not in keyRecord either) → composer returns nothing for this GSI.
+        // (The standard update path will then simply not emit any GSI-key
+        // SET/REMOVE clauses.)
+        //
+        // keyRecord here mirrors the production standard-update path:
+        // entity-PK composites only. Putting non-PK composites in keyRecord
+        // would simulate the retain path / the merged-row reality, where
+        // v1.7.2's broadened gate (#43) would correctly classify those
+        // halves as touched.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           makeIndexes({ pk: "sparse", sk: "sparse" }),
           { unrelated: "x" },
-          { id: "i-1", A: "a", B: "b", C: "c" },
+          { id: "i-1" },
         )
         // v1.7.1 critical assertion: even with sparse on both halves, an
         // untouched payload doesn't fire policy. (v1.7.0 would have REMOVE'd
@@ -400,14 +408,15 @@ describe("KeyComposer", () => {
 
       it("payload touches PK composite only → PK evaluated, SK noop", () => {
         // PK touched (A present in payload) → SET pk.
-        // SK untouched (neither B nor C in payload, and no removedSet) → noop.
+        // SK untouched (neither B nor C in payload or keyRecord, and no
+        // removedSet) → noop. keyRecord = entity-PK composites only.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           makeIndexes({ pk: "preserve", sk: "sparse" }),
           { A: "a-new" }, // only PK touched
-          { id: "i-1", B: "b", C: "c" },
+          { id: "i-1" },
         )
         expect(result.sets.gsi1pk).toBeDefined()
         // SK untouched — the v1.7.1 per-half gate shields it from sparse.
@@ -426,7 +435,7 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "sparse", sk: "preserve" }),
           { B: "b-new", C: "c-new" }, // only SK touched
-          { id: "i-1", A: "a" },
+          { id: "i-1" },
         )
         expect(result.sets.gsi1sk).toBeDefined()
         expect(result.sets).not.toHaveProperty("gsi1pk")
@@ -443,7 +452,7 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "preserve", sk: "sparse" }),
           { B: undefined },
-          { id: "i-1", A: "a" },
+          { id: "i-1" },
         )
         expect(result.removes).toContain("gsi1sk")
         // PK untouched → noop.
@@ -461,7 +470,7 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "preserve", sk: "preserve" }),
           {},
-          { id: "i-1", A: "a", B: "b", C: "c" },
+          { id: "i-1" },
           { removedSet: new Set(["B"]) },
         )
         expect(result.removes).toContain("gsi1sk")
@@ -600,14 +609,15 @@ describe("KeyComposer", () => {
       it("sparse pk + payload touches A as undefined → REMOVE pk only", () => {
         // PK touched (A in payload as undefined → in operator true). Empty
         // leading prefix → can't compose → sparse → REMOVE pk only.
-        // SK untouched → noop. Critical: gsi1sk must NOT be in removes.
+        // SK untouched (B/C not in payload, not in keyRecord) → noop.
+        // Critical: gsi1sk must NOT be in removes.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           makeIndexes({ pk: "sparse", sk: "preserve" }),
           { A: undefined },
-          { id: "i-1", B: "b", C: "c" },
+          { id: "i-1" },
         )
         expect(result.removes).toEqual(["gsi1pk"])
         expect(result.sets).toEqual({})
@@ -620,7 +630,7 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "preserve", sk: "sparse" }),
           { B: undefined },
-          { id: "i-1", A: "a" }, // C absent too
+          { id: "i-1" }, // A/C not in keyRecord either
         )
         // SK touched (B in payload as undefined). Empty leading prefix →
         // sparse → REMOVE sk. PK untouched → noop. (v1.7.0 would have
@@ -639,7 +649,7 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "preserve", sk: "sparse" }),
           { C: "c" }, // B absent → hole at sk[0]
-          { id: "i-1", A: "a" },
+          { id: "i-1" },
         )
         expect(result.removes).toEqual(["gsi1sk"])
         expect(result.sets).not.toHaveProperty("gsi1pk")
@@ -721,14 +731,14 @@ describe("KeyComposer", () => {
       it("preserve sk + Entity.remove(['B']) (no surviving composites) → REMOVE sk only", () => {
         // SK touched via removedSet on B. Empty leading prefix (no B/C
         // anywhere). Preserve + cascade override → REMOVE sk. PK untouched
-        // → noop.
+        // (A not in payload, not in keyRecord, not in removedSet) → noop.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           makeIndexes({ pk: "preserve", sk: "preserve" }),
           {},
-          { id: "i-1", A: "a" }, // no B/C stored
+          { id: "i-1" },
           { removedSet: new Set(["B"]) },
         )
         expect(result.removes).toEqual(["gsi1sk"])
@@ -745,15 +755,15 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "preserve", sk: "preserve" }),
           {},
-          { id: "i-1", B: "b", C: "c" }, // no A stored
+          { id: "i-1" },
           { removedSet: new Set(["A"]) },
         )
         expect(result.removes).toEqual(["gsi1pk"])
         expect(result.removes).not.toContain("gsi1sk")
       })
 
-      it("preserve sk + Entity.remove(['B']) WITH surviving stored A → cascade override fires only on sk", () => {
-        // PK has stored A but PK is untouched (no A in payload, no A in
+      it("preserve sk + Entity.remove(['B']) — pk untouched, sk cascade fires", () => {
+        // PK is untouched (A not in payload, not in keyRecord, not in
         // removedSet) → noop. SK touched via removedSet on B; can't compose
         // → preserve + cascade override → REMOVE sk.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
@@ -762,7 +772,7 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "preserve", sk: "preserve" }),
           {},
-          { id: "i-1", A: "a" },
+          { id: "i-1" },
           { removedSet: new Set(["B"]) },
         )
         expect(result.removes).toEqual(["gsi1sk"])
@@ -779,7 +789,7 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "preserve", sk: "preserve" }),
           {},
-          { id: "i-1", B: "b", C: "c" }, // SK still composable from stored
+          { id: "i-1" },
           { removedSet: new Set(["A"]) },
         )
         expect(result.removes).toEqual(["gsi1pk"])
@@ -800,7 +810,7 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "preserve", sk: "sparse" }),
           { B: null },
-          { id: "i-1", A: "a" },
+          { id: "i-1" },
         )
         const r2 = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
@@ -808,7 +818,7 @@ describe("KeyComposer", () => {
           1,
           makeIndexes({ pk: "preserve", sk: "sparse" }),
           { B: undefined },
-          { id: "i-1", A: "a" },
+          { id: "i-1" },
         )
         expect(r1.sets).toEqual(r2.sets)
         expect(r1.removes).toEqual(r2.removes)
@@ -816,14 +826,15 @@ describe("KeyComposer", () => {
 
       it("`{ A: undefined }` is touched + absent (PK eval fires)", () => {
         // PK touched (A in payload). A is absent (undefined). Empty leading
-        // prefix → preserve + no cascade → noop pk. SK untouched → noop.
+        // prefix → preserve + no cascade → noop pk. SK untouched (B/C not
+        // in payload, not in keyRecord) → noop.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           makeIndexes(),
           { A: undefined },
-          { id: "i-1", B: "b", C: "c" },
+          { id: "i-1" },
         )
         expect(result.sets).toEqual({})
         expect(result.removes).toEqual([])
@@ -836,7 +847,12 @@ describe("KeyComposer", () => {
 
     describe("multi-writer round-trip (per-half gate closes the v1.7.0 leak)", () => {
       // Canonical hybrid GSI: pk owned by enrichment writer, sk owned by
-      // telemetry writer. Stored: A="acme", B="active", C=T1.
+      // telemetry writer. Note: the GSI composites (A/B/C) are non-PK model
+      // attrs — they are not in `keyRecord` (which carries only entity-PK
+      // composites in the production standard-update path; that's `id`
+      // here). The "stored" values shown in comments live on disk but are
+      // not seen by the composer; they represent what was last SET by
+      // earlier writers.
       const hybrid = {
         primary: {
           pk: { field: "pk", composite: ["id"] },
@@ -849,19 +865,22 @@ describe("KeyComposer", () => {
           indexPolicy: { pk: "preserve", sk: "sparse" } as KeyComposer.IndexPolicy,
         },
       }
-      const stored = { id: "i-1", A: "acme", B: "active", C: "t1" }
+      // keyRecord under the standard update path: entity-PK composites only.
+      const keyOnly = { id: "i-1" }
 
       it("stamp scenario — `{ unrelated: 'x' }` → both halves untouched, no writes (closes v1.7.0 bug-3)", () => {
         // The v1.7.0 leak: a stamp writer that doesn't touch the GSI's
         // composites would still trigger sparse on sk and REMOVE gsi1sk.
         // Under v1.7.1, the per-half gate skips both halves entirely.
+        // Under v1.7.2, the broadened gate still skips them — A/B/C are
+        // non-PK composites so they're not in keyRecord either.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           hybrid,
           { unrelated: "x" },
-          stored,
+          keyOnly,
         )
         expect(result.sets).toEqual({})
         expect(result.removes).toEqual([])
@@ -874,7 +893,7 @@ describe("KeyComposer", () => {
           1,
           hybrid,
           { A: "newAcct" },
-          stored,
+          keyOnly,
         )
         expect(result.sets.gsi1pk).toBeDefined()
         expect(result.sets).not.toHaveProperty("gsi1sk")
@@ -888,7 +907,7 @@ describe("KeyComposer", () => {
           1,
           hybrid,
           { B: "active", C: "t2" },
-          stored,
+          keyOnly,
         )
         expect(result.sets.gsi1sk).toBeDefined()
         expect(result.sets).not.toHaveProperty("gsi1pk")
@@ -901,8 +920,8 @@ describe("KeyComposer", () => {
           "E",
           1,
           hybrid,
-          { C: "t2" }, // B not in payload — hole pattern relative to stored B
-          { ...stored, B: undefined }, // simulate stored B already absent
+          { C: "t2" }, // B absent → hole at sk[0]
+          keyOnly,
         )
         // SK touched (C in payload), structural rule sees no B → can't compose
         // → sparse → REMOVE sk only. PK untouched → noop. (v1.7.0 would have
@@ -911,19 +930,19 @@ describe("KeyComposer", () => {
         expect(result.sets).not.toHaveProperty("gsi1pk")
       })
 
-      it("rejoin — telemetry writes B+C after a drop, SET sk; pk preserved (no enrichment re-fire)", () => {
-        // Item state: gsi1pk = "acme" (preserved), gsi1sk REMOVE'd from a
-        // prior drop. Telemetry now sends both B and C → SET sk. Critical:
-        // the test confirms the composer doesn't disturb pk in either
-        // direction (no SET, no REMOVE) — meaning the stored gsi1pk persists
-        // in the database without enrichment having to re-fire.
+      it("rejoin — telemetry writes B+C after a drop, SET sk; pk untouched (no enrichment re-fire)", () => {
+        // Item state on disk: gsi1pk = "acme" (preserved from earlier
+        // enrichment), gsi1sk REMOVE'd from a prior drop. Telemetry now
+        // sends both B and C → SET sk. Critical: the composer leaves pk
+        // untouched (no SET, no REMOVE) → the stored gsi1pk persists in
+        // the database without enrichment having to re-fire.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "E",
           1,
           hybrid,
           { B: "active", C: "t3" },
-          { id: "i-1", A: "acme" }, // sk dropped previously; pk still stored
+          keyOnly,
         )
         expect(result.sets.gsi1sk).toBeDefined()
         expect(result.sets).not.toHaveProperty("gsi1pk")
@@ -939,7 +958,7 @@ describe("KeyComposer", () => {
           1,
           hybrid,
           {},
-          stored,
+          keyOnly,
           { removedSet: new Set(["B"]) },
         )
         expect(result.removes).toEqual(["gsi1sk"])
@@ -953,7 +972,7 @@ describe("KeyComposer", () => {
           1,
           hybrid,
           {},
-          stored,
+          keyOnly,
           { removedSet: new Set(["A"]) },
         )
         expect(result.removes).toEqual(["gsi1pk"])
@@ -1009,7 +1028,7 @@ describe("KeyComposer", () => {
     // ----------------------------------------------------------------------
 
     describe("keyRecord merging", () => {
-      it("PK composites in keyRecord fill in for GSI composites + payload supplies the other half", () => {
+      it("PK composites in keyRecord fill in for GSI composites + payload supplies the other half (v1.7.2 — both halves SET, closes #43)", () => {
         const indexes: Record<string, KeyComposer.IndexDefinition> = {
           primary: {
             pk: { field: "pk", composite: ["userId"] },
@@ -1022,7 +1041,11 @@ describe("KeyComposer", () => {
           },
         }
         // Payload touches role (gsi1.pk). gsi1.sk has userId — userId is in
-        // keyRecord but NOT in payload → sk is untouched per the gate, noop.
+        // keyRecord (it's the entity-PK composite). v1.7.2 (#43) broadens
+        // the per-half gate to also count keyRecord membership → sk touched
+        // → structural rule composes from userId → SET sk. v1.7.0 / v1.7.1
+        // skipped this — items written under those versions had no gsi1sk
+        // and were invisible to byUserRole queries.
         const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
           schema,
           "User",
@@ -1031,14 +1054,15 @@ describe("KeyComposer", () => {
           { role: "admin" },
           { userId: "u-1" },
         )
-        // pk: role touched → SET pk full from role.
+        // pk: role touched (payload) → SET.
         expect(result.sets.gsi1pk).toBeDefined()
-        // sk: userId NOT in payload (only in keyRecord) → untouched, noop.
-        expect(result.sets).not.toHaveProperty("gsi1sk")
+        // sk: userId touched via keyRecord (v1.7.2) → SET.
+        expect(result.sets.gsi1sk).toBe("$myapp#v1#user#userid_u-1")
       })
 
       it("payload supplies a key that's also a GSI composite → SK touched, recompose from keyRecord", () => {
-        // Same shape but payload touches userId too — sk becomes touched.
+        // Same shape but payload also restates userId — same outcome
+        // (idempotent).
         const indexes: Record<string, KeyComposer.IndexDefinition> = {
           primary: {
             pk: { field: "pk", composite: ["userId"] },
@@ -1055,8 +1079,8 @@ describe("KeyComposer", () => {
           "User",
           1,
           indexes,
-          { role: "admin", userId: "u-1" }, // userId touched
-          { userId: "u-1" },
+          { role: "admin", userId: "u-1" }, // userId touched (payload)
+          { userId: "u-1" }, // also in keyRecord
         )
         expect(result.sets.gsi1pk).toBeDefined()
         expect(result.sets.gsi1sk).toBeDefined()
@@ -1068,17 +1092,20 @@ describe("KeyComposer", () => {
     // ----------------------------------------------------------------------
 
     describe("migration regression — issue #36 / #41 (sparse footgun stays closed)", () => {
-      it("partial update with omitted preserve-policied composites → no REMOVEs and no SETs", () => {
+      it("partial update with omitted preserve-policied composites → no REMOVEs and no SETs on the enrichment-owned PK halves", () => {
         // Three GSIs with preserve on every half. Update touches a non-
-        // composite field (`name`). Per the v1.7.1 per-half gate, NO half
-        // is touched → no SETs, no REMOVEs.
+        // composite field (`name`). The PK halves' composites (X/Y/Z) are
+        // enrichment-owned model attrs — not in payload, not in keyRecord
+        // → per-half gate skips them → no SETs, no REMOVEs on gsi*pk.
         //
-        // (Behavior change from the v1.7.0 expectation: the v1.7.0 test
-        // expected SK halves to recompose because they shared the primary-
-        // key composite `id`. Under v1.7.1's per-half gate, `id` not being
-        // in the payload means SK is untouched → noop. The stored sk values
-        // already match what would be recomposed, so this is semantically
-        // identical and avoids spurious SETs.)
+        // The SK halves' composites are `id` (the entity-PK composite). v1.7.2
+        // (closes #43) broadens the per-half gate to also count `keyRecord`
+        // membership — `id` IS in keyRecord, so the SK halves are touched
+        // and the structural rule SETs them. This is correct, idempotent
+        // behavior: SETting `gsi*sk` with the same composed value the row
+        // already has is a noop on disk and ensures items written under
+        // v1.7.0 / v1.7.1 (where the gate skipped these halves) repair on
+        // their next update.
         const indexes: Record<string, KeyComposer.IndexDefinition> = {
           primary: {
             pk: { field: "pk", composite: ["id"] },
@@ -1108,13 +1135,170 @@ describe("KeyComposer", () => {
           "E",
           1,
           indexes,
-          { name: "new-name" }, // no GSI composite touched
-          { id: "i-1" },
+          { name: "new-name" }, // no payload-owned GSI composite touched
+          { id: "i-1" }, // entity PK in keyRecord
         )
         // Zero REMOVEs (the original sparse footgun stays closed).
         expect(r.removes).toEqual([])
-        // Zero SETs too — per-half gate skips untouched halves entirely.
-        expect(r.sets).toEqual({})
+        // PK halves untouched (X/Y/Z not in payload, not in keyRecord) → noop.
+        expect(r.sets).not.toHaveProperty("gsi1pk")
+        expect(r.sets).not.toHaveProperty("gsi2pk")
+        expect(r.sets).not.toHaveProperty("gsi3pk")
+        // SK halves touched via keyRecord (#43) → structural rule composes
+        // from `id` → SET. v1.7.0 / v1.7.1 silently skipped these.
+        expect(r.sets.gsi1sk).toBeDefined()
+        expect(r.sets.gsi2sk).toBeDefined()
+        expect(r.sets.gsi3sk).toBeDefined()
+      })
+    })
+
+    // ----------------------------------------------------------------------
+    // PK-composites-only GSI shape (issue #43)
+    // ----------------------------------------------------------------------
+
+    describe("keyRecord membership counts as touched (issue #43 — PK-composites-only GSIs)", () => {
+      // Canonical fixture for #43: the GSI's composites are entirely entity
+      // PK composites. They never appear in `updatePayload` (writers
+      // address the row by key, not by restating the PK in `.set({...})`,
+      // and `.append()` separates structural fields from the SET clause).
+      // Pre-v1.7.2 the per-half gate looked only at `updatePayload` and so
+      // classified both halves as untouched on every write — `gsi1pk` /
+      // `gsi1sk` were never composed and items were invisible to the GSI.
+      //
+      // v1.7.2 fix: the gate now also counts `keyRecord` membership. The
+      // structural rule composes from the always-present PK values; the
+      // SET is idempotent for entity-PK composites because they're
+      // immutable.
+      const pkOnlyIndexes = (
+        indexPolicy?: KeyComposer.IndexPolicy,
+      ): Record<string, KeyComposer.IndexDefinition> => ({
+        primary: {
+          pk: { field: "pk", composite: ["channel", "deviceId"] },
+          sk: { field: "sk", composite: [] },
+        },
+        byChannel: {
+          index: "gsi1",
+          pk: { field: "gsi1pk", composite: ["channel"] },
+          sk: { field: "gsi1sk", composite: ["deviceId"] },
+          ...(indexPolicy ? { indexPolicy } : {}),
+        },
+      })
+
+      it("payload empty + keyRecord supplies all composites → both halves SET (default preserve)", () => {
+        // No indexPolicy → defaults to preserve on both halves. Payload is
+        // empty (mirrors `Entity.update(key).set({ unrelated: "x" })` minus
+        // the unrelated field, or an `Entity.append({...})` whose appendInput
+        // contains only structural composites). Pre-v1.7.2 → noop on both
+        // halves (the bug). Post-v1.7.2 → both halves touched via keyRecord,
+        // structural rule composes, SET both.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "Telemetry",
+          1,
+          pkOnlyIndexes(),
+          {}, // empty payload — no composite in payload
+          { channel: "c-1", deviceId: "d-1" }, // composites only in keyRecord
+        )
+        expect(result.sets.gsi1pk).toBe("$myapp#v1#telemetry#channel_c-1")
+        expect(result.sets.gsi1sk).toBe("$myapp#v1#telemetry#deviceid_d-1")
+        expect(result.removes).toEqual([])
+      })
+
+      it("payload empty + keyRecord supplies all composites → both halves SET under sparse policy", () => {
+        // Sparse on both halves should not change behavior here — the
+        // structural rule succeeds (both composites available via keyRecord),
+        // so sparse never gets to fire its "drop" branch. Critical: SET
+        // happens, NOT REMOVE.
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "Telemetry",
+          1,
+          pkOnlyIndexes({ pk: "sparse", sk: "sparse" }),
+          {},
+          { channel: "c-1", deviceId: "d-1" },
+        )
+        expect(result.sets.gsi1pk).toBe("$myapp#v1#telemetry#channel_c-1")
+        expect(result.sets.gsi1sk).toBe("$myapp#v1#telemetry#deviceid_d-1")
+        expect(result.removes).toEqual([])
+      })
+
+      it("payload empty + keyRecord supplies all composites → both halves SET under preserve policy", () => {
+        // Explicit preserve → same outcome. SET (idempotent re-compose).
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "Telemetry",
+          1,
+          pkOnlyIndexes({ pk: "preserve", sk: "preserve" }),
+          {},
+          { channel: "c-1", deviceId: "d-1" },
+        )
+        expect(result.sets.gsi1pk).toBeDefined()
+        expect(result.sets.gsi1sk).toBeDefined()
+        expect(result.removes).toEqual([])
+      })
+
+      it("mixed GSI: PK from keyRecord + SK from payload → both halves evaluate independently and SET", () => {
+        // PK composite is an entity-PK composite (in keyRecord), SK composite
+        // is an enrichment-owned model attr (in payload). Both halves
+        // touched independently — pre-v1.7.2 the SK half would fire (payload-
+        // membership), but the PK half would silently skip; post-v1.7.2
+        // both fire correctly.
+        const indexes: Record<string, KeyComposer.IndexDefinition> = {
+          primary: {
+            pk: { field: "pk", composite: ["channel", "deviceId"] },
+            sk: { field: "sk", composite: [] },
+          },
+          byChannelAlert: {
+            index: "gsi1",
+            pk: { field: "gsi1pk", composite: ["channel"] }, // entity-PK composite
+            sk: { field: "gsi1sk", composite: ["alertState"] }, // model attr
+            indexPolicy: { pk: "preserve", sk: "preserve" },
+          },
+        }
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "Telemetry",
+          1,
+          indexes,
+          { alertState: "active" }, // SK composite via payload
+          { channel: "c-1", deviceId: "d-1" }, // PK composite via keyRecord
+        )
+        expect(result.sets.gsi1pk).toBe("$myapp#v1#telemetry#channel_c-1")
+        expect(result.sets.gsi1sk).toBe("$myapp#v1#telemetry#alertstate_active")
+        expect(result.removes).toEqual([])
+      })
+
+      it("negative — composites NOT in payload AND NOT in keyRecord → gate still skips (multi-writer fix preserved)", () => {
+        // The v1.7.1 multi-writer leak fix: stamps writing only `{ published }`
+        // shouldn't blow away enrichment-owned + telemetry-owned GSI halves.
+        // Composites are NOT in keyRecord (keyRecord here only has the
+        // entity-PK composite `id`, NOT `accountId` / `alertState`) and NOT
+        // in payload → gate skips → noop. The v1.7.2 broadening must NOT
+        // re-open this leak.
+        const indexes: Record<string, KeyComposer.IndexDefinition> = {
+          primary: {
+            pk: { field: "pk", composite: ["id"] },
+            sk: { field: "sk", composite: [] },
+          },
+          byCurrentAlert: {
+            index: "gsi1",
+            pk: { field: "gsi1pk", composite: ["accountId"] }, // enrichment
+            sk: { field: "gsi1sk", composite: ["alertState"] }, // telemetry
+            indexPolicy: { pk: "preserve", sk: "sparse" },
+          },
+        }
+        const result = KeyComposer.composeGsiKeysForUpdatePolicyAware(
+          schema,
+          "Telemetry",
+          1,
+          indexes,
+          { published: "2026-04-30" }, // stamp writer — non-composite
+          { id: "i-1" }, // only entity-PK in keyRecord; composites are NOT here
+        )
+        // No SETs, no REMOVEs. Both halves untouched. v1.7.1 multi-writer
+        // fix preserved across the v1.7.2 broadening.
+        expect(result.sets).toEqual({})
+        expect(result.removes).toEqual([])
       })
     })
   })

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -2010,28 +2010,30 @@ describeConnected("PK-composites-only GSI shape (closes #43)", () => {
     )
   }, 15000)
 
-  it.effect("Entity.append() writes gsi1pk + gsi1sk on PK-composites-only GSI; byChannel query returns the item", () =>
-    Effect.gen(function* () {
-      const db = yield* DynamoClient.make({
-        entities: { ChannelDevicesTs },
-        tables: { CdTable },
-      })
+  it.effect(
+    "Entity.append() writes gsi1pk + gsi1sk on PK-composites-only GSI; byChannel query returns the item",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { ChannelDevicesTs },
+          tables: { CdTable },
+        })
 
-      yield* db.entities.ChannelDevicesTs.append({
-        channel: "ch-append",
-        deviceId: "d-append-1",
-        timestamp: DateTime.makeUnsafe("2026-04-30T10:00:00.000Z"),
-        reading: 42,
-      })
+        yield* db.entities.ChannelDevicesTs.append({
+          channel: "ch-append",
+          deviceId: "d-append-1",
+          timestamp: DateTime.makeUnsafe("2026-04-30T10:00:00.000Z"),
+          reading: 42,
+        })
 
-      // Pre-v1.7.2 this query returned 0 items because gsi1pk / gsi1sk
-      // were never written by .append().
-      const rows = yield* db.entities.ChannelDevicesTs.byChannel({
-        channel: "ch-append",
-      }).collect()
-      expect(rows).toHaveLength(1)
-      expect(rows[0]!.deviceId).toBe("d-append-1")
-    }).pipe(provideCd),
+        // Pre-v1.7.2 this query returned 0 items because gsi1pk / gsi1sk
+        // were never written by .append().
+        const rows = yield* db.entities.ChannelDevicesTs.byChannel({
+          channel: "ch-append",
+        }).collect()
+        expect(rows).toHaveLength(1)
+        expect(rows[0]!.deviceId).toBe("d-append-1")
+      }).pipe(provideCd),
   )
 
   it.effect(
@@ -2070,54 +2072,52 @@ describeConnected("PK-composites-only GSI shape (closes #43)", () => {
       }).pipe(provideCd),
   )
 
-  it.effect(
-    "Multiple sequential updates idempotently re-SET the same gsi key values",
-    () =>
-      Effect.gen(function* () {
-        const db = yield* DynamoClient.make({
-          entities: { ChannelDevicesPlain },
-          tables: { CdTable },
-        })
+  it.effect("Multiple sequential updates idempotently re-SET the same gsi key values", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { ChannelDevicesPlain },
+        tables: { CdTable },
+      })
 
-        yield* db.entities.ChannelDevicesPlain.put({
+      yield* db.entities.ChannelDevicesPlain.put({
+        channel: "ch-idem",
+        deviceId: "d-idem-1",
+        timestamp: DateTime.makeUnsafe("2026-04-30T10:00:00.000Z"),
+      }).asEffect()
+
+      // Multiple updates — each one SETs gsi2pk and gsi2sk to the same
+      // composed value (PK composites are immutable). DDB SET to the
+      // same value is a noop on the byte representation but a billable
+      // write — that's expected and acknowledged in DESIGN.md §7.
+      for (const i of [1, 2, 3]) {
+        yield* db.entities.ChannelDevicesPlain.update({
           channel: "ch-idem",
           deviceId: "d-idem-1",
-          timestamp: DateTime.makeUnsafe("2026-04-30T10:00:00.000Z"),
-        }).asEffect()
+        }).set({ otherField: `update-${i}` })
+      }
 
-        // Multiple updates — each one SETs gsi2pk and gsi2sk to the same
-        // composed value (PK composites are immutable). DDB SET to the
-        // same value is a noop on the byte representation but a billable
-        // write — that's expected and acknowledged in DESIGN.md §7.
-        for (const i of [1, 2, 3]) {
-          yield* db.entities.ChannelDevicesPlain.update({
-            channel: "ch-idem",
-            deviceId: "d-idem-1",
-          }).set({ otherField: `update-${i}` })
-        }
+      const rows = yield* db.entities.ChannelDevicesPlain.byChannel({
+        channel: "ch-idem",
+      }).collect()
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.deviceId).toBe("d-idem-1")
+      expect(rows[0]!.otherField).toBe("update-3")
 
-        const rows = yield* db.entities.ChannelDevicesPlain.byChannel({
-          channel: "ch-idem",
-        }).collect()
-        expect(rows).toHaveLength(1)
-        expect(rows[0]!.deviceId).toBe("d-idem-1")
-        expect(rows[0]!.otherField).toBe("update-3")
-
-        // Sanity-check the actual GSI keys via a direct query — they must
-        // hold the composed values across the three SETs.
-        const raw = yield* (yield* DynamoClient).getItem({
-          TableName: cdTableName,
-          Key: {
-            pk: {
-              S: "$cd-test#v1#channeldeviceplain#channel_ch-idem#deviceid_d-idem-1",
-            },
-            sk: { S: "$cd-test#v1#channeldeviceplain" },
+      // Sanity-check the actual GSI keys via a direct query — they must
+      // hold the composed values across the three SETs.
+      const raw = yield* (yield* DynamoClient).getItem({
+        TableName: cdTableName,
+        Key: {
+          pk: {
+            S: "$cd-test#v1#channeldeviceplain#channel_ch-idem#deviceid_d-idem-1",
           },
-        })
-        expect(raw.Item).toBeDefined()
-        expect(raw.Item!.gsi2pk?.S).toBe("$cd-test#v1#channeldeviceplain#channel_ch-idem")
-        expect(raw.Item!.gsi2sk?.S).toBe("$cd-test#v1#channeldeviceplain#deviceid_d-idem-1")
-      }).pipe(provideCd),
+          sk: { S: "$cd-test#v1#channeldeviceplain" },
+        },
+      })
+      expect(raw.Item).toBeDefined()
+      expect(raw.Item!.gsi2pk?.S).toBe("$cd-test#v1#channeldeviceplain#channel_ch-idem")
+      expect(raw.Item!.gsi2sk?.S).toBe("$cd-test#v1#channeldeviceplain#deviceid_d-idem-1")
+    }).pipe(provideCd),
   )
 
   it.effect(
@@ -2176,12 +2176,8 @@ describeConnected("PK-composites-only GSI shape (closes #43)", () => {
         expect(after.Item?.gsi4sk?.S).toBe(baselineGsi4sk)
         // byChannel keys (gsi3, PK-composites-only) SET on every write
         // (idempotent) — values unchanged but the SET clause was emitted.
-        expect(after.Item?.gsi3pk?.S).toBe(
-          "$cd-test#v1#channeldevicemixed#channel_ch-mixed-mw",
-        )
-        expect(after.Item?.gsi3sk?.S).toBe(
-          "$cd-test#v1#channeldevicemixed#deviceid_d-mw-1",
-        )
+        expect(after.Item?.gsi3pk?.S).toBe("$cd-test#v1#channeldevicemixed#channel_ch-mixed-mw")
+        expect(after.Item?.gsi3sk?.S).toBe("$cd-test#v1#channeldevicemixed#deviceid_d-mw-1")
       }).pipe(provideCd),
   )
 

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -1865,6 +1865,372 @@ describeConnected("timeSeries integration tests", () => {
 })
 
 // ===========================================================================
+// PK-composites-only GSI shape — closes #43
+// ===========================================================================
+//
+// The bug: GSIs whose composites are entirely entity-PK composites (e.g.
+// `byChannel: { pk: [channel], sk: [deviceId] }` on an entity with
+// `primaryKey: [channel, deviceId]`) had their `gsi*pk` / `gsi*sk` keys
+// silently skipped under v1.7.0 / v1.7.1. Items written through `.append()`
+// (and updates that didn't restate the PK composites in payload) were
+// invisible to channel-scoped GSI queries.
+//
+// These tests exercise the v1.7.2 fix end-to-end against DDB Local: the
+// items must be visible to byChannel queries after both `.append()` and
+// `.update()` writes, and the GSI keys must be preserved across multiple
+// updates (idempotent re-SET).
+// ===========================================================================
+
+class ChannelDevice extends Schema.Class<ChannelDevice>("ChannelDevice")({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  accountId: Schema.optional(Schema.String),
+  alertState: Schema.optional(Schema.String),
+  timestamp: Schema.DateTimeUtc,
+  reading: Schema.optional(Schema.Number),
+  otherField: Schema.optional(Schema.String),
+}) {}
+
+const ChannelDeviceAppendInput = Schema.Struct({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  timestamp: Schema.DateTimeUtc,
+  reading: Schema.optional(Schema.Number),
+})
+
+const cdSchema = DynamoSchema.make({ name: "cd-test", version: 1 })
+const cdTableName = `cd-test-${Date.now()}`
+
+// PK-composites-only GSI shape — the #43 bug repro entity. Time-series
+// because that was the originally-reported failure surface.
+const ChannelDevicesTs = Entity.make({
+  model: ChannelDevice,
+  entityType: "ChannelDeviceTs",
+  primaryKey: {
+    pk: { field: "pk", composite: ["channel", "deviceId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  indexes: {
+    byChannel: {
+      name: "gsi1",
+      pk: { field: "gsi1pk", composite: ["channel"] },
+      sk: { field: "gsi1sk", composite: ["deviceId"] },
+      indexPolicy: { pk: "preserve", sk: "preserve" },
+    },
+  },
+  timestamps: true,
+  timeSeries: {
+    orderBy: "timestamp",
+    ttl: Duration.days(7),
+    appendInput: ChannelDeviceAppendInput,
+  },
+})
+
+// Same shape but no time-series — exercises the standard `.update()` path.
+const ChannelDevicesPlain = Entity.make({
+  model: ChannelDevice,
+  entityType: "ChannelDevicePlain",
+  primaryKey: {
+    pk: { field: "pk", composite: ["channel", "deviceId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  indexes: {
+    byChannel: {
+      name: "gsi2",
+      pk: { field: "gsi2pk", composite: ["channel"] },
+      sk: { field: "gsi2sk", composite: ["deviceId"] },
+      indexPolicy: { pk: "preserve", sk: "preserve" },
+    },
+  },
+  timestamps: true,
+})
+
+// Multi-writer entity: TWO GSIs — one PK-composites-only (byChannel on gsi3),
+// one multi-writer with non-PK composites (byCurrentAlert on gsi4). Used to
+// verify both behaviors coexist — PK-only fires every write (idempotent SET),
+// multi-writer GSI is untouched by stamps.
+const ChannelDevicesMixed = Entity.make({
+  model: ChannelDevice,
+  entityType: "ChannelDeviceMixed",
+  primaryKey: {
+    pk: { field: "pk", composite: ["channel", "deviceId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  indexes: {
+    byChannel: {
+      // PK-composites-only — must fire on every write (#43).
+      name: "gsi3",
+      pk: { field: "gsi3pk", composite: ["channel"] },
+      sk: { field: "gsi3sk", composite: ["deviceId"] },
+      indexPolicy: { pk: "preserve", sk: "preserve" },
+    },
+    byCurrentAlert: {
+      // Multi-writer — neither composite is in the PK; stamp updates must
+      // leave both halves untouched (v1.7.1 multi-writer fix preserved).
+      name: "gsi4",
+      pk: { field: "gsi4pk", composite: ["accountId"] },
+      sk: { field: "gsi4sk", composite: ["alertState"] },
+      indexPolicy: { pk: "preserve", sk: "preserve" },
+    },
+  },
+  timestamps: true,
+})
+
+const CdTable = Table.make({
+  schema: cdSchema,
+  entities: { ChannelDevicesTs, ChannelDevicesPlain, ChannelDevicesMixed },
+})
+const CdLayer = Layer.mergeAll(ClientLayer, CdTable.layer({ name: cdTableName }))
+const provideCd = Effect.provide(CdLayer)
+
+describeConnected("PK-composites-only GSI shape (closes #43)", () => {
+  beforeAll(async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* DynamoClient
+        yield* client.createTable({
+          TableName: cdTableName,
+          BillingMode: "PAY_PER_REQUEST",
+          ...Table.definition(CdTable),
+        })
+      }).pipe(provideCd, Effect.scoped),
+    )
+  }, 15000)
+
+  afterAll(async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* DynamoClient
+        yield* client.deleteTable({ TableName: cdTableName })
+      }).pipe(
+        provideCd,
+        Effect.scoped,
+        Effect.catchTag("ResourceNotFoundError", () => Effect.void),
+      ),
+    )
+  }, 15000)
+
+  it.effect("Entity.append() writes gsi1pk + gsi1sk on PK-composites-only GSI; byChannel query returns the item", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { ChannelDevicesTs },
+        tables: { CdTable },
+      })
+
+      yield* db.entities.ChannelDevicesTs.append({
+        channel: "ch-append",
+        deviceId: "d-append-1",
+        timestamp: DateTime.makeUnsafe("2026-04-30T10:00:00.000Z"),
+        reading: 42,
+      })
+
+      // Pre-v1.7.2 this query returned 0 items because gsi1pk / gsi1sk
+      // were never written by .append().
+      const rows = yield* db.entities.ChannelDevicesTs.byChannel({
+        channel: "ch-append",
+      }).collect()
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.deviceId).toBe("d-append-1")
+    }).pipe(provideCd),
+  )
+
+  it.effect(
+    "Entity.update().set() preserves gsi keys on PK-composites-only GSI; byChannel still returns the item",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { ChannelDevicesTs },
+          tables: { CdTable },
+        })
+
+        // Seed via append.
+        yield* db.entities.ChannelDevicesTs.append({
+          channel: "ch-update",
+          deviceId: "d-update-1",
+          timestamp: DateTime.makeUnsafe("2026-04-30T10:00:00.000Z"),
+        })
+
+        // Issue an update that doesn't mention channel or deviceId in the
+        // payload. Pre-v1.7.2 the per-half gate skipped both halves and
+        // the gsi keys persisted unchanged (correct here only because
+        // append already wrote them — but pre-v1.7.2 append didn't, so the
+        // item was invisible from the start). Post-v1.7.2 the SK halves
+        // SET via the broadened gate using keyRecord membership.
+        yield* db.entities.ChannelDevicesTs.update({
+          channel: "ch-update",
+          deviceId: "d-update-1",
+        }).set({ otherField: "X" })
+
+        const rows = yield* db.entities.ChannelDevicesTs.byChannel({
+          channel: "ch-update",
+        }).collect()
+        expect(rows).toHaveLength(1)
+        expect(rows[0]!.deviceId).toBe("d-update-1")
+        expect(rows[0]!.otherField).toBe("X")
+      }).pipe(provideCd),
+  )
+
+  it.effect(
+    "Multiple sequential updates idempotently re-SET the same gsi key values",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { ChannelDevicesPlain },
+          tables: { CdTable },
+        })
+
+        yield* db.entities.ChannelDevicesPlain.put({
+          channel: "ch-idem",
+          deviceId: "d-idem-1",
+          timestamp: DateTime.makeUnsafe("2026-04-30T10:00:00.000Z"),
+        }).asEffect()
+
+        // Multiple updates — each one SETs gsi2pk and gsi2sk to the same
+        // composed value (PK composites are immutable). DDB SET to the
+        // same value is a noop on the byte representation but a billable
+        // write — that's expected and acknowledged in DESIGN.md §7.
+        for (const i of [1, 2, 3]) {
+          yield* db.entities.ChannelDevicesPlain.update({
+            channel: "ch-idem",
+            deviceId: "d-idem-1",
+          }).set({ otherField: `update-${i}` })
+        }
+
+        const rows = yield* db.entities.ChannelDevicesPlain.byChannel({
+          channel: "ch-idem",
+        }).collect()
+        expect(rows).toHaveLength(1)
+        expect(rows[0]!.deviceId).toBe("d-idem-1")
+        expect(rows[0]!.otherField).toBe("update-3")
+
+        // Sanity-check the actual GSI keys via a direct query — they must
+        // hold the composed values across the three SETs.
+        const raw = yield* (yield* DynamoClient).getItem({
+          TableName: cdTableName,
+          Key: {
+            pk: {
+              S: "$cd-test#v1#channeldeviceplain#channel_ch-idem#deviceid_d-idem-1",
+            },
+            sk: { S: "$cd-test#v1#channeldeviceplain" },
+          },
+        })
+        expect(raw.Item).toBeDefined()
+        expect(raw.Item!.gsi2pk?.S).toBe("$cd-test#v1#channeldeviceplain#channel_ch-idem")
+        expect(raw.Item!.gsi2sk?.S).toBe("$cd-test#v1#channeldeviceplain#deviceid_d-idem-1")
+      }).pipe(provideCd),
+  )
+
+  it.effect(
+    "Multi-writer GSI (NOT PK-composites-only) — stamp update leaves byCurrentAlert untouched",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { ChannelDevicesMixed },
+          tables: { CdTable },
+        })
+
+        // Seed: enrichment sets accountId, telemetry sets alertState.
+        yield* db.entities.ChannelDevicesMixed.put({
+          channel: "ch-mixed-mw",
+          deviceId: "d-mw-1",
+          accountId: "acct-1",
+          alertState: "active",
+          timestamp: DateTime.makeUnsafe("2026-04-30T10:00:00.000Z"),
+        }).asEffect()
+
+        // Capture the byCurrentAlert key composition baseline.
+        const baseline = yield* (yield* DynamoClient).getItem({
+          TableName: cdTableName,
+          Key: {
+            pk: {
+              S: "$cd-test#v1#channeldevicemixed#channel_ch-mixed-mw#deviceid_d-mw-1",
+            },
+            sk: { S: "$cd-test#v1#channeldevicemixed" },
+          },
+        })
+        const baselineGsi4pk = baseline.Item?.gsi4pk?.S
+        const baselineGsi4sk = baseline.Item?.gsi4sk?.S
+        expect(baselineGsi4pk).toBeDefined()
+        expect(baselineGsi4sk).toBeDefined()
+
+        // Stamp writer — touches a non-composite. byCurrentAlert (gsi4)
+        // composites (accountId, alertState) are NOT in the payload AND
+        // NOT in keyRecord (only channel/deviceId are). Per-half gate must
+        // skip both halves of byCurrentAlert. v1.7.1 multi-writer fix.
+        yield* db.entities.ChannelDevicesMixed.update({
+          channel: "ch-mixed-mw",
+          deviceId: "d-mw-1",
+        }).set({ otherField: "stamp-value" })
+
+        const after = yield* (yield* DynamoClient).getItem({
+          TableName: cdTableName,
+          Key: {
+            pk: {
+              S: "$cd-test#v1#channeldevicemixed#channel_ch-mixed-mw#deviceid_d-mw-1",
+            },
+            sk: { S: "$cd-test#v1#channeldevicemixed" },
+          },
+        })
+        // byCurrentAlert keys unchanged — multi-writer fix preserved.
+        expect(after.Item?.gsi4pk?.S).toBe(baselineGsi4pk)
+        expect(after.Item?.gsi4sk?.S).toBe(baselineGsi4sk)
+        // byChannel keys (gsi3, PK-composites-only) SET on every write
+        // (idempotent) — values unchanged but the SET clause was emitted.
+        expect(after.Item?.gsi3pk?.S).toBe(
+          "$cd-test#v1#channeldevicemixed#channel_ch-mixed-mw",
+        )
+        expect(after.Item?.gsi3sk?.S).toBe(
+          "$cd-test#v1#channeldevicemixed#deviceid_d-mw-1",
+        )
+      }).pipe(provideCd),
+  )
+
+  it.effect(
+    "Mixed entity (PK-composites-only + multi-writer GSIs) — both behaviors coexist on the same write",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { ChannelDevicesMixed },
+          tables: { CdTable },
+        })
+
+        yield* db.entities.ChannelDevicesMixed.put({
+          channel: "ch-mixed",
+          deviceId: "d-mixed-1",
+          accountId: "acct-2",
+          alertState: "warning",
+          timestamp: DateTime.makeUnsafe("2026-04-30T11:00:00.000Z"),
+        }).asEffect()
+
+        // Stamp update: only otherField changes. byChannel (gsi3,
+        // PK-composites-only) must SET (idempotent re-compose).
+        // byCurrentAlert (gsi4, multi-writer) must noop.
+        yield* db.entities.ChannelDevicesMixed.update({
+          channel: "ch-mixed",
+          deviceId: "d-mixed-1",
+        }).set({ otherField: "stamped" })
+
+        // byChannel query (gsi3) returns the item — proves PK-composites-only
+        // SET happened.
+        const byChannelRows = yield* db.entities.ChannelDevicesMixed.byChannel({
+          channel: "ch-mixed",
+        }).collect()
+        expect(byChannelRows).toHaveLength(1)
+        expect(byChannelRows[0]!.deviceId).toBe("d-mixed-1")
+        expect(byChannelRows[0]!.otherField).toBe("stamped")
+
+        // byCurrentAlert query (gsi4) also returns the item — proves the
+        // multi-writer GSI keys were preserved across the stamp update.
+        const byAlertRows = yield* db.entities.ChannelDevicesMixed.byCurrentAlert({
+          accountId: "acct-2",
+        }).collect()
+        expect(byAlertRows).toHaveLength(1)
+        expect(byAlertRows[0]!.alertState).toBe("warning")
+      }).pipe(provideCd),
+  )
+})
+
+// ===========================================================================
 // Entity Refs + Aggregate Connected Tests (separate table with GSI for aggregates)
 // ===========================================================================
 

--- a/packages/language-service/CHANGELOG.md
+++ b/packages/language-service/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @effect-dynamodb/language-service
 
+## 1.7.2
+
+### Patch Changes
+
+- **indexPolicy v1.7.2 — fix PK-composites-only GSI regression (closes [#43](https://github.com/jmenga/effect-dynamodb/issues/43)).**
+
+  v1.7.1 introduced a per-half evaluation gate that — by design — skipped GSI evaluation on halves the writer didn't touch. Unfortunately the gate consulted only `updatePayload` and so silently classified entire GSIs as untouched whenever their composites were entirely entity primary-key composites. Those PK composites never appear in `updatePayload` (writers address the row by key, never restate them in `.set({...})`, and `.append()` filtered them out before passing to the composer). The composer never ran, `gsiNpk` and `gsiNsk` were never written, and items were invisible to the GSI for their lifetime.
+
+  Concretely: an entity with `primaryKey: [channel, deviceId]` and a `byChannel: { pk: [channel], sk: [deviceId] }` GSI saw zero items returned from any channel-scoped query under v1.7.0 / v1.7.1, regardless of whether the writes used `.put()`, `.update()`, or `.append()` — the latter two never composed the keys, and `.update()` only re-composed them on calls that explicitly restated `channel` / `deviceId` in the payload (which no realistic writer does).
+
+  **The fix** (two minimal patches working together):
+  1. **`KeyComposer.composeGsiKeysForUpdatePolicyAware`** — the per-half gate now also counts `keyRecord` membership (the entity primary-key attributes carried into the composer alongside the payload). PK-composite-only GSI halves are now correctly classified as touched on every write that has a `keyRecord`.
+  2. **`Entity.append()`** — no longer filters PK composites out of the payload it passes to the composer. The filter never solved a real problem (the composer doesn't emit redundant SETs for the underlying composite fields, and idempotent recomposition from immutable PK composites is benign) and combined with the v1.7.1 gate to silently break this pattern.
+
+  The change is idempotent for entity-PK composites (re-composing the same value from immutable PK composites produces the same key) and preserves the v1.7.1 multi-writer fix: stamps' GSI composites are not in `updatePayload` AND not in `keyRecord` either (they're enrichment-owned model attrs), so their halves remain untouched as designed.
+
+  **Affected items:** items written to PK-composites-only GSIs under v1.7.0 or v1.7.1 will repair themselves on the next `Entity.update()` against them. The gate now fires correctly, the structural rule composes the immutable PK values, and the missing GSI keys are SET. **No data migration required** — reads via the GSI start returning these items as their next update lands. If you have items that aren't naturally updated, a one-shot bulk `Entity.update(key).set({ otherField: value })` (or even an empty-payload update touching only `updatedAt` + version) is enough to repair them.
+
+  **No API changes** — same `indexPolicy: { pk, sk }` declaration shape, same `Entity.update` / `Entity.append` signatures, same EDD-9025 invariants. Behavior change is strictly more correct than v1.7.1.
+
+  See `DESIGN.md §7` for the updated decision algorithm and `guides/index-policy.mdx` for the updated walkthrough plus the _byChannel GSI returns 0 items_ pitfall.
+
 ## 1.7.1
 
 ### Patch Changes

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/language-service",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "TypeScript Language Service Plugin for effect-dynamodb — shows DynamoDB operations on hover",
   "license": "MIT",
   "author": "Justin Menga",


### PR DESCRIPTION
Closes #43.

## Summary

- **What broke**: v1.7.1's per-half evaluation gate (`KeyComposer.composeGsiKeysForUpdatePolicyAware`) only consulted `updatePayload`. For GSI halves whose composites are entirely entity primary-key composites — e.g. `byChannel: { pk: [channel], sk: [deviceId] }` on `primaryKey: [channel, deviceId]` — those composites never appear in `updatePayload` (writers address the row by key; never restate them in `.set({...})`; `.append()` separates structural fields from the SET clause). The gate misclassified both halves as untouched on every write, the composer never ran, `gsiNpk` / `gsiNsk` were never written, and items were invisible to channel-scoped GSI queries.
- **Who reported it**: midgard (downstream consumer), via #43. Bug surfaced after bumping to 1.7.1.
- **The fix** — two minimal patches working together:
  1. **`KeyComposer`** — the per-half gate now also counts `keyRecord` membership (Option B in #43). Idempotent for entity-PK composites because they're immutable. Multi-writer fix preserved: stamps' GSI composites are not in either input source.
  2. **`Entity.append()`** — no longer filters PK composites out of the payload (Option A in #43). The filter never solved a real problem and combined with v1.7.1 to silently break this pattern.
- **Affected items**: items written under v1.7.0 / v1.7.1 will repair themselves on the next `Entity.update()` against them. The gate now fires correctly, the structural rule composes the immutable PK values, and the missing GSI keys are SET. **No data migration required** — reads via the GSI start returning these items as their next update lands.
- **No API changes** — same `indexPolicy` declaration shape, same `Entity.update` / `Entity.append` signatures, same EDD-9025 invariants. Strictly more correct than v1.7.1.

## Files changed (by category)

- **Source** (3 lines logic): `packages/effect-dynamodb/src/KeyComposer.ts`, `packages/effect-dynamodb/src/Entity.ts`
- **Design**: `DESIGN.md` §7 — extended gate documentation with `keyRecord` rationale + canonical-shapes section
- **Docs guide**: `packages/docs/src/content/docs/guides/index-policy.mdx` — gate doc update + new pitfall + v1.7.1→v1.7.2 migration
- **Tests** (unit + entity): `packages/effect-dynamodb/test/KeyComposer.test.ts`, `packages/effect-dynamodb/test/IndexPolicyV3.test.ts`
- **Tests** (connected): `packages/effect-dynamodb/test/connected.test.ts` — five new scenarios against DDB Local
- **Process** (no behavior): `CLAUDE.md` — canonical GSI-composite test-fixture shapes section
- **Release**: changeset + lockstep version bump to 1.7.2 across the three publishable packages

## Test coverage

**Unit (`KeyComposer.test.ts`):**
- Gate fires for PK-composites-only half via keyRecord (default preserve, sparse, preserve)
- Mixed GSI: PK from keyRecord + SK from payload — both halves SET
- Negative — composites not in payload AND not in keyRecord → gate skips (multi-writer fix preserved)

**Entity-level (`IndexPolicyV3.test.ts`):**
- Entity with `byChannel: {pk:[channel], sk:[deviceId]}` — `Entity.update().set({otherField})` produces SET for gsi1pk AND gsi1sk
- Same shape, time-series — `Entity.append()` produces SET for gsi1pk AND gsi1sk in TransactWriteItems
- Migration regression test (#36 / #41 / #43) updated to reflect v1.7.2 partition: PK halves of multi-writer GSIs noop, SK halves on entity-PK composite SET

**Connected (`connected.test.ts`):**
- Append path — `byChannel` query returns appended item (was 0 pre-v1.7.2)
- Update path — `Entity.update().set()` preserves gsi keys; query still returns
- Idempotent re-SET — three sequential updates → raw GetItem confirms gsi keys unchanged
- Negative — multi-writer GSI untouched by stamp updates (v1.7.1 fix preserved)
- Mixed entity — both PK-composites-only and multi-writer GSIs coexist on the same write

## Quality gates

- [x] `pnpm lint` — zero errors
- [x] `pnpm check` — zero type errors across all 5 packages
- [x] `pnpm test` — 1223 unit tests pass (1053 effect-dynamodb + 56 geo + 47 doctest + 67 language-service)
- [x] `pnpm --filter effect-dynamodb test:connected` — **104 connected tests pass against DynamoDB Local** (was 99; +5 new)
- [x] `pnpm --filter @effect-dynamodb/geo test:connected` — 3 geo connected tests pass
- [x] `pnpm --filter @effect-dynamodb/doctest test` — 47 doctest sync + typecheck pass
- [x] `npx tsx examples/guide-index-policy.ts` — runs end-to-end against DDB Local

## Test plan

- [ ] Reviewer pulls the branch, runs `docker run -d --rm -p 8000:8000 amazon/dynamodb-local`, then `pnpm --filter effect-dynamodb test:connected` — expects 104 / 104 green.
- [ ] Reviewer reads the new `byChannel` pitfall in `index-policy.mdx` and confirms the v1.7.0 / v1.7.1 → v1.7.2 narrative is clear for downstream consumers.
- [ ] Reviewer scans the canonical-shapes section in `CLAUDE.md` and `DESIGN.md` and confirms the test-fixture matrix is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)