### PR TITLE
chore(workspace): build effect-dynamodb before recursive check

### DIFF
--- a/.changeset/build-effect-dynamodb-before-check.md
+++ b/.changeset/build-effect-dynamodb-before-check.md
@@ -1,0 +1,4 @@
+---
+---
+
+Chore: build `effect-dynamodb` before running `pnpm check` so downstream packages (`@effect-dynamodb/geo`, `@effect-dynamodb/doctest`) can resolve types from `dist/` on a clean checkout. No version change.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test",
-    "check": "pnpm -r check",
+    "check": "pnpm --filter effect-dynamodb build && pnpm -r check",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "docs:dev": "pnpm --filter @effect-dynamodb/docs dev",


### PR DESCRIPTION
## Summary

Fixes a clean-checkout regression in `pnpm check` from the workspace root. After cloning the repo (or deleting `packages/*/dist`), `pnpm check` fails because:

- `@effect-dynamodb/geo` and `@effect-dynamodb/doctest` typecheck via `tsc --noEmit`
- They import from `effect-dynamodb` by package name
- TypeScript resolves that import to `effect-dynamodb`'s `package.json` `types` field → `dist/index.d.ts`
- On a clean checkout that file doesn't exist yet → resolution fails → typecheck errors

Fix: change the root `check` script from `pnpm -r check` to `pnpm --filter effect-dynamodb build && pnpm -r check`. Build `effect-dynamodb` first, then run `check` across the workspace.

## Verification

- `rm -rf packages/*/dist` to simulate a clean checkout state
- `pnpm install`
- `pnpm check` → all 5 workspace packages pass (effect-dynamodb, geo, doctest, language-service, docs)
- `pnpm lint` → 0 errors

## Type of change

Chore — workspace tooling fix. **No code changes**, **no API changes**, **no published-package contents changes**. Per CLAUDE.md Release Workflow → Chore PRs convention, the changeset is empty (no version bump on any of the three publishable packages).

## Trade-off

pnpm check from root now always builds effect-dynamodb first (a few seconds via tsc incremental). Acceptable overhead — the alternative is requiring contributors to manually run pnpm build before any check passes on a fresh checkout, which fails closed in a hostile-to-newcomers way.

## Test plan

- [x] Clean-checkout simulation: rm -rf packages/*/dist && pnpm check passes
- [x] pnpm lint passes
- [x] Chore changeset (empty frontmatter) — no version bumps