### PR TITLE
chore(deps): bump effect + @effect/vitest to 4.0.0-beta.59

### DIFF
--- a/.changeset/bump-effect-beta59.md
+++ b/.changeset/bump-effect-beta59.md
@@ -1,0 +1,4 @@
+---
+---
+
+Chore: bump `effect` and `@effect/vitest` from `4.0.0-beta.48` to `4.0.0-beta.59` (devDeps + peerDep range). No version change.

--- a/packages/doctest/package.json
+++ b/packages/doctest/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.59",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
   }

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -55,14 +55,14 @@
     "h3-js": "^4.2.1"
   },
   "peerDependencies": {
-    "effect": "^4.0.0-beta.48",
+    "effect": "^4.0.0-beta.59",
     "effect-dynamodb": "workspace:^"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.700.0",
-    "@effect/vitest": "4.0.0-beta.48",
+    "@effect/vitest": "4.0.0-beta.59",
     "@types/node": "^25.0.0",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.59",
     "effect-dynamodb": "workspace:*",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -59,12 +59,12 @@
     "@aws-sdk/util-dynamodb": "^3.700.0"
   },
   "peerDependencies": {
-    "effect": "^4.0.0-beta.48"
+    "effect": "^4.0.0-beta.59"
   },
   "devDependencies": {
-    "@effect/vitest": "4.0.0-beta.48",
+    "@effect/vitest": "4.0.0-beta.59",
     "@types/node": "^25.5.0",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.59",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.15
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.59
+        version: 4.0.0-beta.59
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -92,14 +92,14 @@ importers:
         version: 3.990.0(@aws-sdk/client-dynamodb@3.990.0)
     devDependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48(effect@4.0.0-beta.48)(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
+        specifier: 4.0.0-beta.59
+        version: 4.0.0-beta.59(effect@4.0.0-beta.59)(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.59
+        version: 4.0.0-beta.59
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -117,14 +117,14 @@ importers:
         specifier: ^3.700.0
         version: 3.990.0
       '@effect/vitest':
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48(effect@4.0.0-beta.48)(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
+        specifier: 4.0.0-beta.59
+        version: 4.0.0-beta.59(effect@4.0.0-beta.59)(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
       '@types/node':
         specifier: ^25.0.0
         version: 25.5.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.59
+        version: 4.0.0-beta.59
       effect-dynamodb:
         specifier: workspace:*
         version: link:../effect-dynamodb
@@ -564,10 +564,10 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
-  '@effect/vitest@4.0.0-beta.48':
-    resolution: {integrity: sha512-ONG24EIfUXTrJzIDJctIr6y6JOeml97eoZ53WRUNdwp/tHIAU+U3ME5uUdmtLBKSFeyivYjXGPvEP2DW8f/bCQ==}
+  '@effect/vitest@4.0.0-beta.59':
+    resolution: {integrity: sha512-jhpJbpDs1ED58SmFzcfmqLXxle84fiexaMEhV8SBl8WC2GM3FT5DW0WJYFjbZIH5/735brp3iGdjY5/uAxS7Bg==}
     peerDependencies:
-      effect: ^4.0.0-beta.48
+      effect: ^4.0.0-beta.59
       vitest: ^3.0.0 || ^4.0.0
 
   '@emmetio/abbreviation@2.3.3':
@@ -1945,8 +1945,8 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
-  effect@4.0.0-beta.48:
-    resolution: {integrity: sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==}
+  effect@4.0.0-beta.59:
+    resolution: {integrity: sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA==}
 
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
@@ -4474,9 +4474,9 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
-  '@effect/vitest@4.0.0-beta.48(effect@4.0.0-beta.48)(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@effect/vitest@4.0.0-beta.59(effect@4.0.0-beta.59)(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
-      effect: 4.0.0-beta.48
+      effect: 4.0.0-beta.59
       vitest: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@emmetio/abbreviation@2.3.3':
@@ -5876,7 +5876,7 @@ snapshots:
 
   dset@3.1.4: {}
 
-  effect@4.0.0-beta.48:
+  effect@4.0.0-beta.59:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.6.0


### PR DESCRIPTION
## Summary

- Bumps `effect` and `@effect/vitest` from `4.0.0-beta.48` to `4.0.0-beta.59` across `effect-dynamodb`, `effect-dynamodb-geo`, and `doctest` (devDeps + peerDep range). 11 betas of drift caught up.
- Empty chore changeset — no consumer-facing version change.

## Why now

The repo had drifted from `beta.48` to `beta.59`. Reviewing the changelog over that window, the only breaking change in scope for what we use is the `Schema.makeFilter` / `SchemaGetter.checkEffect` predicate return shape rename (`{ path, message }` → `{ path, issue }`) in `beta.51`. We have zero call sites of those APIs (we only use `SchemaGetter.transform` / `transformOrFail`, which are unchanged), so this is a code-free upgrade. Everything else in the range is HTTP / RPC / SQL / CLI work that this library doesn't touch.

## Test plan

- [x] `pnpm lint` — 131 files, clean
- [x] `pnpm check` — 0 errors across all 5 packages (incl. Astro check on docs)
- [x] `pnpm test` — **1226 unit tests passed** (effect-dynamodb 1056, effect-dynamodb-geo 56, language-service 67, doctest sync 47)
- [x] `pnpm --filter effect-dynamodb test:connected` — **108 / 108** passed against DDB Local
- [x] `pnpm --filter @effect-dynamodb/doctest test:connected` — **31 / 31** examples ran end-to-end against DDB Local

🤖 Generated with [Claude Code](https://claude.com/claude-code)