### PR TITLE
feat: .append(input).remove(attrs) on time-series entities — v1.7.4

### DIFF
--- a/.changeset/bump-effect-beta59.md
+++ b/.changeset/bump-effect-beta59.md
@@ -1,4 +1,0 @@
----
----
-
-Chore: bump `effect` and `@effect/vitest` from `4.0.0-beta.48` to `4.0.0-beta.59` (devDeps + peerDep range). No version change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,13 @@ jobs:
 
       - uses: pnpm/action-setup@v5
         with:
-          version: latest
+          # Pin to pnpm 10 — pnpm 11 introduced a stricter
+          # ERR_PNPM_IGNORED_BUILDS check that errors even when
+          # `onlyBuiltDependencies` is declared (in either
+          # `package.json#pnpm` or `pnpm-workspace.yaml`). Move to
+          # `version: latest` once the pnpm 11 install path is
+          # validated end-to-end against this monorepo.
+          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,7 +26,9 @@ jobs:
 
       - uses: pnpm/action-setup@v5
         with:
-          version: latest
+          # Pin to pnpm 10 — matches ci.yml. See the rationale comment
+          # there for the pnpm 11 ERR_PNPM_IGNORED_BUILDS issue.
+          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
 
       - uses: pnpm/action-setup@v5
         with:
-          version: latest
+          # Pin to pnpm 10 — matches ci.yml. See the rationale comment
+          # there for the pnpm 11 ERR_PNPM_IGNORED_BUILDS issue.
+          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/packages/docs/src/content/docs/guides/timeseries.mdx
+++ b/packages/docs/src/content/docs/guides/timeseries.mdx
@@ -153,6 +153,42 @@ Both errors carry `current` as `Option<unknown>` rather than `Option<Model>` bec
 
 **Why on the error channel?** Stale and user-condition rejection are PROGRAM-LEVEL FAILURES — the write you intended did not happen. Effect's error channel exists precisely to make those failures visible to typed combinators (`Effect.catchTag`, `Effect.retry`, `Effect.orElse`) and impossible to forget at the type level. The previous discriminated-union return hid the failure inside a value, which routinely produced bugs where callers destructured `r.current` without inspecting `r.applied`.
 
+### `.remove(attrs)` — clear attributes atomically
+
+`.append(input).remove(attrs)` rides the same `UpdateItem` as the scoped `SET` and CAS predicate. Use it when an event should clear one or more `appendInput` attributes on the current item — e.g. a status event whose absence of an `alert` field means "no alert this cycle; drop the existing alert state."
+
+```typescript region="remove" example="guide-timeseries.ts"
+yield* db.entities.Telemetries.append({
+  channel: "c-1",
+  deviceId: "d-7",
+  timestamp: DateTime.makeUnsafe("2026-04-22T10:02:00.000Z"),
+  // Note: `alert` is intentionally omitted from the payload. The .remove()
+  // call below clears it on the current item in the same UpdateItem.
+}).remove(["alert"])
+```
+
+**Why this matters.** Without `.remove()`, callers were stuck with three unsatisfactory workarounds:
+
+| Workaround | Problem |
+|---|---|
+| `.append(...)` then `.update().remove([...])` (two writes) | Race window — a concurrent writer between the two writes can clobber the cleared state |
+| Sentinel value (e.g. `alertState: "DISABLED"`) | Keeps the attribute set; sparse-policied GSIs continue to include the item |
+| `Schema.NullOr` + null payload | Writes a literal `NULL` into the item; downstream readers must tolerate it |
+
+`.remove()` closes the race window structurally — the single `UpdateItem` carries `SET + REMOVE + CAS` atomically.
+
+**GSI cascade.** Any GSI half whose composite list intersects `attrs` follows the v1.7.1 cascade-override semantics: the half evaluates with the removed composite treated as absent. Under `'sparse'` the half drops; under `'preserve'` it's a no-op (the stored key field is left as-is unless overridden). The motivating shape is a sparse-PK GSI keyed on the cleared attribute — the item drops out of that GSI in the same write.
+
+**Validation.** Names listed in `.remove()` are checked at execution time. The Effect fails with `ValidationError(operation: "append.remove")` if any name:
+
+- is not declared in `appendInput` (enrichment-preservation contract — use `.update().remove([...])` for fields outside `appendInput`)
+- names `orderBy` (would invalidate the CAS anchor)
+- names a primary-key composite (would orphan the item)
+- names a ref field (refs are create-time denormalisations — reassign via `.update()`)
+- also appears in the encoded payload with a non-`undefined` value (DynamoDB rejects `SET`/`REMOVE` overlap)
+
+Chained `.remove()` calls accumulate. The combinator composes with `.condition()` and `.skipFollowUp()` in any order.
+
 ### `.skipFollowUp()` — fire-and-forget ingest
 
 For high-volume ingest paths that don't need `current`, chain `.skipFollowUp()` to suppress the post-transaction `GetItem`. The success channel narrows to `void`:

--- a/packages/effect-dynamodb-geo/CHANGELOG.md
+++ b/packages/effect-dynamodb-geo/CHANGELOG.md
@@ -1,5 +1,46 @@
 # @effect-dynamodb/geo
 
+## 1.7.4
+
+### Patch Changes
+
+- **`.append(input).remove(attrs)` — atomic SET + REMOVE + CAS on time-series entities (closes [#49](https://github.com/jmenga/effect-dynamodb/issues/49)).**
+
+  `BoundAppend` gains a `.remove(attrs)` combinator that emits `REMOVE` clauses on the same `UpdateItem` that carries the scoped `SET` and CAS predicate. Use it when an event needs to clear one or more `appendInput` attributes atomically — e.g. an IoT status event whose absence of an `alert` field means "no alert this cycle; drop the existing alert state on the current item."
+
+  **Motivating problem.** Before v1.7.4, callers wanting to clear an `appendInput` attribute were stuck with three unsatisfactory workarounds:
+  - `.append(...)` then `.update().remove([...])` (two writes) — race window: a concurrent writer between the two writes could clobber the cleared state.
+  - Sentinel value (e.g. `alertState: "DISABLED"`) — keeps the attribute set, leaves the item in any `'sparse'`-policied GSI half that composes it.
+  - `Schema.NullOr` + null payload — writes a literal `NULL` into the item; downstream readers must tolerate it.
+
+  `.append(input).remove(attrs)` closes the race window structurally: a single `UpdateItem` carries `SET + REMOVE + CAS`, atomic with the event `Put`.
+
+  **GSI cascade.** Any GSI half whose composite list intersects `attrs` follows the v1.7.1 cascade-override semantics — the half evaluates with the removed composite treated as absent. Under `'sparse'` the half drops; under `'preserve'` it's a no-op (the stored key field is left as-is unless overridden). The motivating shape is a sparse-PK GSI keyed on the cleared attribute — the item drops out of that GSI in the same write.
+
+  **Validation.** Names listed in `.remove()` are checked at execution time. The Effect fails with `ValidationError(operation: "append.remove")` if any name:
+  - is not declared in `appendInput` (enrichment-preservation contract — use `.update().remove([...])` for fields outside `appendInput`);
+  - names `orderBy` (would invalidate the CAS anchor);
+  - names a primary-key composite (would orphan the item);
+  - names a ref field (refs are create-time denormalisations — reassign via `.update()`);
+  - also appears in the encoded payload with a non-`undefined` value (DynamoDB rejects `SET`/`REMOVE` overlap).
+
+  Chained `.remove()` calls accumulate. The combinator composes with `.condition()` and `.skipFollowUp()` in any order.
+
+  **API.** New fluent combinator on `BoundAppend`:
+
+  ```ts
+  yield *
+    db.entities.Telemetry.append({ channel, deviceId, timestamp }).remove([
+      "alertState",
+    ]);
+  ```
+
+  The entity-level unbound `Entity.append()` also gains an optional fourth positional argument (`removeAttrs?: ReadonlyArray<string>`) — used by `BoundAppend`'s `.remove()` wiring; library consumers should prefer the fluent form on `BoundAppend`.
+
+  **No on-disk impact, no backfill required.** Pure feature add — existing time-series entities and existing items are unaffected.
+
+  See `guides/timeseries.mdx` for the documented usage pattern and the issue [#49](https://github.com/jmenga/effect-dynamodb/issues/49) motivating IoT case.
+
 ## 1.7.3
 
 ### Patch Changes

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/geo",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Geospatial index and search for effect-dynamodb using H3 hexagonal grid",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/CHANGELOG.md
+++ b/packages/effect-dynamodb/CHANGELOG.md
@@ -1,5 +1,46 @@
 # effect-dynamodb
 
+## 1.7.4
+
+### Patch Changes
+
+- **`.append(input).remove(attrs)` — atomic SET + REMOVE + CAS on time-series entities (closes [#49](https://github.com/jmenga/effect-dynamodb/issues/49)).**
+
+  `BoundAppend` gains a `.remove(attrs)` combinator that emits `REMOVE` clauses on the same `UpdateItem` that carries the scoped `SET` and CAS predicate. Use it when an event needs to clear one or more `appendInput` attributes atomically — e.g. an IoT status event whose absence of an `alert` field means "no alert this cycle; drop the existing alert state on the current item."
+
+  **Motivating problem.** Before v1.7.4, callers wanting to clear an `appendInput` attribute were stuck with three unsatisfactory workarounds:
+  - `.append(...)` then `.update().remove([...])` (two writes) — race window: a concurrent writer between the two writes could clobber the cleared state.
+  - Sentinel value (e.g. `alertState: "DISABLED"`) — keeps the attribute set, leaves the item in any `'sparse'`-policied GSI half that composes it.
+  - `Schema.NullOr` + null payload — writes a literal `NULL` into the item; downstream readers must tolerate it.
+
+  `.append(input).remove(attrs)` closes the race window structurally: a single `UpdateItem` carries `SET + REMOVE + CAS`, atomic with the event `Put`.
+
+  **GSI cascade.** Any GSI half whose composite list intersects `attrs` follows the v1.7.1 cascade-override semantics — the half evaluates with the removed composite treated as absent. Under `'sparse'` the half drops; under `'preserve'` it's a no-op (the stored key field is left as-is unless overridden). The motivating shape is a sparse-PK GSI keyed on the cleared attribute — the item drops out of that GSI in the same write.
+
+  **Validation.** Names listed in `.remove()` are checked at execution time. The Effect fails with `ValidationError(operation: "append.remove")` if any name:
+  - is not declared in `appendInput` (enrichment-preservation contract — use `.update().remove([...])` for fields outside `appendInput`);
+  - names `orderBy` (would invalidate the CAS anchor);
+  - names a primary-key composite (would orphan the item);
+  - names a ref field (refs are create-time denormalisations — reassign via `.update()`);
+  - also appears in the encoded payload with a non-`undefined` value (DynamoDB rejects `SET`/`REMOVE` overlap).
+
+  Chained `.remove()` calls accumulate. The combinator composes with `.condition()` and `.skipFollowUp()` in any order.
+
+  **API.** New fluent combinator on `BoundAppend`:
+
+  ```ts
+  yield *
+    db.entities.Telemetry.append({ channel, deviceId, timestamp }).remove([
+      "alertState",
+    ]);
+  ```
+
+  The entity-level unbound `Entity.append()` also gains an optional fourth positional argument (`removeAttrs?: ReadonlyArray<string>`) — used by `BoundAppend`'s `.remove()` wiring; library consumers should prefer the fluent form on `BoundAppend`.
+
+  **No on-disk impact, no backfill required.** Pure feature add — existing time-series entities and existing items are unaffected.
+
+  See `guides/timeseries.mdx` for the documented usage pattern and the issue [#49](https://github.com/jmenga/effect-dynamodb/issues/49) motivating IoT case.
+
 ## 1.7.3
 
 ### Patch Changes

--- a/packages/effect-dynamodb/examples/guide-timeseries.ts
+++ b/packages/effect-dynamodb/examples/guide-timeseries.ts
@@ -172,6 +172,28 @@ const program = Effect.gen(function* () {
     )
   // #endregion
 
+  // ---------- Clear an attribute atomically via .remove() ----------
+  // `.append(input).remove([...])` rides the same UpdateItem as the scoped
+  // SET + CAS. Use it to signal "this attribute should no longer exist on
+  // the current item" — e.g. an IoT device reporting a status event whose
+  // absence of an `alert` field means "no alert this event, clear the
+  // existing alert state". The single TransactWriteItems closes the race
+  // window the previous two-write workaround (`.append()` then
+  // `.update().remove([...])`) exposed.
+  //
+  // Names listed in `.remove()` must be in `appendInput`, must not be
+  // `orderBy` / a PK composite / a ref-derived `${name}Id`, and must not
+  // also appear in the append payload (DDB rejects SET/REMOVE overlap).
+  // #region remove
+  yield* db.entities.Telemetries.append({
+    channel: "c-1",
+    deviceId: "d-7",
+    timestamp: DateTime.makeUnsafe("2026-04-22T10:02:00.000Z"),
+    // Note: `alert` is intentionally omitted from the payload. The .remove()
+    // call below clears it on the current item in the same UpdateItem.
+  }).remove(["alert"])
+  // #endregion
+
   // ---------- Enrichment preservation ----------
   // #region enrichment
   // Device appends (no accountId in appendInput — cannot touch enrichment):

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-dynamodb",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Effect TS ORM for DynamoDB — schema-driven entity modeling, single-table design, composite keys, transactions, and Stream-based pagination",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/src/Entity.ts
+++ b/packages/effect-dynamodb/src/Entity.ts
@@ -636,6 +636,8 @@ export interface Entity<
         (
           input: AppendInputType<TAI>,
           condition?: Expr | ConditionInput,
+          skipFollowUp?: false,
+          removeAttrs?: ReadonlyArray<string>,
         ): Effect.Effect<
           { readonly current: ModelType<TModel> },
           DynamoClientError | ValidationError | StaleAppend | ConditionalCheckFailed,
@@ -645,6 +647,7 @@ export interface Entity<
           input: AppendInputType<TAI>,
           condition: Expr | ConditionInput | undefined,
           skipFollowUp: true,
+          removeAttrs?: ReadonlyArray<string>,
         ): Effect.Effect<
           void,
           DynamoClientError | ValidationError | StaleAppend,
@@ -4200,7 +4203,12 @@ const makeImpl = <
 
   const timeSeriesConfig = config.timeSeries as TimeSeriesConfig<any> | undefined
 
-  const append = (input: unknown, userCondition?: Expr | ConditionInput, skipFollowUp = false) =>
+  const append = (
+    input: unknown,
+    userCondition?: Expr | ConditionInput,
+    skipFollowUp = false,
+    removeAttrs?: ReadonlyArray<string>,
+  ) =>
     Effect.gen(function* () {
       if (!timeSeriesConfig) {
         return yield* new ValidationError({
@@ -4215,6 +4223,61 @@ const makeImpl = <
       const ttlDuration = timeSeriesConfig.ttl
       const appendInputSchema = schemas.appendInputSchema as Schema.Codec<any>
 
+      // ---------- Validate removeAttrs (issue #49) ----------
+      // `.remove(attrs)` clears `appendInput` attributes in the same UpdateItem
+      // as the scoped SET + CAS. Composite-attribute removal cascades through
+      // `composeGsiKeysForUpdatePolicyAware` via the `removedSet` option.
+      // Validation enforces the time-series invariants — orderBy, PK/SK
+      // composites, and ref fields must not be cleared, and the caller cannot
+      // remove enrichment fields outside `appendInput` (that's a `.update()`
+      // operation, not an append).
+      const removedSet =
+        removeAttrs !== undefined && removeAttrs.length > 0 ? new Set(removeAttrs) : undefined
+      if (removedSet !== undefined) {
+        const primary = config.indexes.primary
+        const pkSkComposites = new Set<string>([...primary.pk.composite, ...primary.sk.composite])
+        const appendInputTop = timeSeriesConfig.appendInput as Schema.Top
+        const appendInputFieldSet = new Set<string>(
+          "fields" in appendInputTop && typeof (appendInputTop as any).fields === "object"
+            ? Object.keys((appendInputTop as any).fields)
+            : [],
+        )
+        const model = config.model as Schema.Top
+        for (const attr of removedSet) {
+          if (!appendInputFieldSet.has(attr)) {
+            return yield* new ValidationError({
+              entityType,
+              operation: "append.remove",
+              cause:
+                `Attribute "${attr}" passed to .remove() is not declared in appendInput. ` +
+                `.append().remove() can only clear fields the entity exposes via appendInput. ` +
+                `Use .update().remove([...]) on the entity for enrichment fields outside appendInput.`,
+            })
+          }
+          if (attr === orderByField) {
+            return yield* new ValidationError({
+              entityType,
+              operation: "append.remove",
+              cause: `Attribute "${attr}" is the orderBy clock — removing it would invalidate the CAS anchor.`,
+            })
+          }
+          if (pkSkComposites.has(attr)) {
+            return yield* new ValidationError({
+              entityType,
+              operation: "append.remove",
+              cause: `Attribute "${attr}" is a primary-key composite — removing it would orphan the item.`,
+            })
+          }
+          if (isRefField(attr, model)) {
+            return yield* new ValidationError({
+              entityType,
+              operation: "append.remove",
+              cause: `Attribute "${attr}" is a ref field — refs are create-time denormalisations and cannot be cleared via .append(). Use .update() to reassign.`,
+            })
+          }
+        }
+      }
+
       // Encode user input via appendInputSchema (see `put` for strategy).
       const encodedInput = yield* encodeOrDecodeEncode(
         appendInputSchema,
@@ -4223,6 +4286,28 @@ const makeImpl = <
         "append",
       )
       const encoded = encodedInput as globalThis.Record<string, unknown>
+
+      // After encoding, detect SET/REMOVE conflict — DynamoDB rejects an
+      // UpdateExpression that touches the same attribute in SET and REMOVE.
+      // The SET loop (below) skips entries with `undefined` values, so the
+      // conflict is only real when the payload carries a non-undefined value
+      // for an attribute also named in `.remove()`.
+      if (removedSet !== undefined) {
+        for (const attr of removedSet) {
+          if (
+            attr in encoded &&
+            (encoded as globalThis.Record<string, unknown>)[attr] !== undefined
+          ) {
+            return yield* new ValidationError({
+              entityType,
+              operation: "append.remove",
+              cause:
+                `Attribute "${attr}" appears in both the append payload and .remove(). ` +
+                `Choose one — either set the new value or remove the attribute.`,
+            })
+          }
+        }
+      }
 
       // Compose current-item primary key (pk + sk derived from PK/SK composites)
       const primary = config.indexes.primary
@@ -4282,6 +4367,7 @@ const makeImpl = <
         allIndexes,
         encoded,
         encoded,
+        removedSet !== undefined ? { removedSet } : undefined,
       )
       for (const [field, value] of Object.entries(gsiUpdate.sets)) {
         const nameKey = `#a${counter}`
@@ -4297,6 +4383,19 @@ const makeImpl = <
         names[nameKey] = keyField
         appendRemoveClauses.push(nameKey)
         counter++
+      }
+      // User-supplied attribute REMOVEs (issue #49). Validation above ensured
+      // these are safe — they're appendInput fields, not orderBy / PK
+      // composites / refs, and don't overlap the encoded payload. The cascade
+      // override on any GSI half whose composite list intersects `removedSet`
+      // is already wired through `composeGsiKeysForUpdatePolicyAware` above.
+      if (removedSet !== undefined) {
+        for (const attr of removedSet) {
+          const nameKey = `#a${counter}`
+          names[nameKey] = resolveDbName(attr)
+          appendRemoveClauses.push(nameKey)
+          counter++
+        }
       }
 
       // Entity type discriminator — idempotent; ensures existing items
@@ -5404,8 +5503,9 @@ export const bind = <
                   i: unknown,
                   c: Expr | ConditionInput | undefined,
                   s: boolean,
+                  r: ReadonlyArray<string> | undefined,
                 ) => Effect.Effect<any, any, any>
-              )(opts.input, opts.condition, opts.skipFollowUp),
+              )(opts.input, opts.condition, opts.skipFollowUp, opts.removeAttrs),
             ),
         }
         return makeBoundAppend(input, appendCfg)

--- a/packages/effect-dynamodb/src/internal/BoundCrud.ts
+++ b/packages/effect-dynamodb/src/internal/BoundCrud.ts
@@ -416,19 +416,43 @@ export const makeBoundUpdate = <Model, A, U, E>(
  *
  * Combinators:
  * - `.condition(...)` — AND a user condition onto the CAS predicate.
+ * - `.remove(attrs)` — emit REMOVE clauses for `appendInput` attributes the
+ *   caller wants cleared atomically. The same UpdateItem carries SET +
+ *   REMOVE + CAS; any GSI half whose composite list intersects `attrs` drops
+ *   via the v1.7.1 cascade override.
  * - `.skipFollowUp()` — skip the post-transaction GetItem; success is `void`,
  *   user-condition failures collapse into `StaleAppend` (cannot disambiguate).
  *
  * ```ts
- * yield* db.entities.Telemetry.append(input)                 // → { current }
- * yield* db.entities.Telemetry.append(input).condition(c)    // → { current }
- * yield* db.entities.Telemetry.append(input).skipFollowUp()  // → void
+ * yield* db.entities.Telemetry.append(input)                        // → { current }
+ * yield* db.entities.Telemetry.append(input).condition(c)           // → { current }
+ * yield* db.entities.Telemetry.append(input).remove(["alertState"]) // → { current }
+ * yield* db.entities.Telemetry.append(input).skipFollowUp()         // → void
  * yield* db.entities.Telemetry.append(input).condition(c).skipFollowUp() // → void
  * ```
  */
 export interface BoundAppend<Model, A, E, ESkip> extends Pipeable.Pipeable {
   /** Add a condition expression. Callback or shorthand. */
   readonly condition: (cond: ConditionArg<Model>) => BoundAppend<Model, A, E, ESkip>
+  /**
+   * Emit REMOVE clauses for `appendInput` attributes the caller wants cleared
+   * on the current item. Cleared attributes also cascade-drop any GSI half
+   * whose composite list intersects `attrs` (v1.7.1 cascade override). The
+   * REMOVE clauses ride the same UpdateItem as the scoped SET + CAS — no
+   * separate write, no race window.
+   *
+   * Validated at execution time:
+   * - Names must appear in `appendInput` (enrichment fields outside
+   *   `appendInput` cannot be cleared via `.append()` — use `.update()`).
+   * - Names must not name `orderBy`, a primary-key composite, or a
+   *   ref-derived `${name}Id` field.
+   * - Names must not overlap the encoded payload (DynamoDB rejects an
+   *   UpdateExpression that touches the same attribute in both SET and
+   *   REMOVE).
+   *
+   * Chained `.remove()` calls accumulate.
+   */
+  readonly remove: (attrs: ReadonlyArray<string>) => BoundAppend<Model, A, E, ESkip>
   /** Skip the follow-up GetItem; success becomes `void`. */
   readonly skipFollowUp: () => BoundAppend<Model, void, ESkip, ESkip>
   /** Convert to an executable Effect for Effect combinator interop. */
@@ -444,6 +468,7 @@ export interface BoundAppendConfig<Model> extends BoundCrudConfig<Model> {
     readonly input: unknown
     readonly condition: Expr | undefined
     readonly skipFollowUp: boolean
+    readonly removeAttrs: ReadonlyArray<string> | undefined
   }) => Effect.Effect<unknown, unknown, never>
 }
 
@@ -454,15 +479,22 @@ export class BoundAppendImpl<Model, A, E, ESkip> implements BoundAppend<Model, A
     readonly _config: BoundAppendConfig<Model>,
     readonly _condition: Expr | undefined = undefined,
     readonly _skip: boolean = false,
+    readonly _removeAttrs: ReadonlyArray<string> | undefined = undefined,
   ) {}
 
   condition(cond: ConditionArg<Model>): BoundAppendImpl<Model, A, E, ESkip> {
     const compiled = buildCondition(this._config, cond)
-    return new BoundAppendImpl(this._input, this._config, compiled, this._skip)
+    return new BoundAppendImpl(this._input, this._config, compiled, this._skip, this._removeAttrs)
+  }
+
+  remove(attrs: ReadonlyArray<string>): BoundAppendImpl<Model, A, E, ESkip> {
+    // Chained `.remove()` calls accumulate.
+    const merged = this._removeAttrs === undefined ? attrs : [...this._removeAttrs, ...attrs]
+    return new BoundAppendImpl(this._input, this._config, this._condition, this._skip, merged)
   }
 
   skipFollowUp(): BoundAppendImpl<Model, void, ESkip, ESkip> {
-    return new BoundAppendImpl(this._input, this._config, this._condition, true)
+    return new BoundAppendImpl(this._input, this._config, this._condition, true, this._removeAttrs)
   }
 
   asEffect(): Effect.Effect<A, E, never> {
@@ -470,6 +502,7 @@ export class BoundAppendImpl<Model, A, E, ESkip> implements BoundAppend<Model, A
       input: this._input,
       condition: this._condition,
       skipFollowUp: this._skip,
+      removeAttrs: this._removeAttrs,
     }) as Effect.Effect<A, E, never>
   }
 

--- a/packages/effect-dynamodb/test/BoundCrud.test.ts
+++ b/packages/effect-dynamodb/test/BoundCrud.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, expect, it } from "@effect/vitest"
-import { Effect, Layer, Schema } from "effect"
+import { DateTime, Effect, Layer, Schema } from "effect"
 import { beforeEach, vi } from "vitest"
 import { DynamoClient } from "../src/DynamoClient.js"
 import * as DynamoSchema from "../src/DynamoSchema.js"
@@ -479,5 +479,168 @@ describe("BoundPatch", () => {
       const call = mockUpdateItem.mock.calls[0]![0]
       expect(call.ConditionExpression).toContain("attribute_exists")
     }).pipe(Effect.provide(TestLayer)),
+  )
+})
+
+// ---------------------------------------------------------------------------
+// BoundAppend — fluent .remove() chain (issue #49)
+// ---------------------------------------------------------------------------
+
+class TelemetryFixture extends Schema.Class<TelemetryFixture>("TelemetryFixture")({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  timestamp: Schema.DateTimeUtc,
+  location: Schema.optional(Schema.String),
+  alert: Schema.optional(Schema.Boolean),
+  accountId: Schema.optional(Schema.String),
+}) {}
+
+const TelemetryFixtureAppendInput = Schema.Struct({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  timestamp: Schema.DateTimeUtc,
+  location: Schema.optional(Schema.String),
+  alert: Schema.optional(Schema.Boolean),
+})
+
+const TelemetryFixtureEntity = Entity.make({
+  model: TelemetryFixture,
+  entityType: "TelemetryFixture",
+  primaryKey: {
+    pk: { field: "pk", composite: ["channel", "deviceId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  timeSeries: {
+    orderBy: "timestamp",
+    appendInput: TelemetryFixtureAppendInput,
+  },
+})
+
+const TelemetryFixtureTable = Table.make({
+  schema: AppSchema,
+  entities: { TelemetryFixture: TelemetryFixtureEntity },
+})
+
+const mockTransactWriteItems = vi.fn()
+const mockGetItemTs = vi.fn()
+
+const TestClientTs = Layer.succeed(DynamoClient, {
+  putItem: () => Effect.die("not used"),
+  getItem: (input) =>
+    Effect.tryPromise({
+      try: () => mockGetItemTs(input),
+      catch: (e) => new DynamoError({ operation: "GetItem", cause: e }),
+    }),
+  deleteItem: () => Effect.die("not used"),
+  updateItem: () => Effect.die("not used"),
+  query: () => Effect.die("not used"),
+  scan: () => Effect.die("not used"),
+  batchGetItem: () => Effect.die("not used"),
+  batchWriteItem: () => Effect.die("not used"),
+  transactGetItems: () => Effect.die("not used"),
+  transactWriteItems: (input) =>
+    Effect.tryPromise({
+      try: () => mockTransactWriteItems(input),
+      catch: (e) => new DynamoError({ operation: "TransactWriteItems", cause: e }),
+    }),
+  createTable: () => Effect.die("not used"),
+  deleteTable: () => Effect.die("not used"),
+  describeTable: () => Effect.die("not used"),
+})
+
+const TableLayerTs = TelemetryFixtureTable.layer({ name: "bound-append-test-table" })
+const TestLayerTs = Layer.merge(TestClientTs, TableLayerTs)
+
+const mockHappyPathTs = () => {
+  mockTransactWriteItems.mockResolvedValueOnce({})
+  mockGetItemTs.mockResolvedValueOnce({
+    Item: {
+      pk: { S: "$testapp#v1#telemetryfixture#c-1#d-7" },
+      sk: { S: "$testapp#v1#telemetryfixture_1" },
+      channel: { S: "c-1" },
+      deviceId: { S: "d-7" },
+      timestamp: { S: "2026-04-22T10:00:00.000Z" },
+      __edd_e__: { S: "TelemetryFixture" },
+    },
+  })
+}
+
+describe("BoundAppend", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.effect(".append(input).remove([...]) chain emits REMOVE clause", () =>
+    Effect.gen(function* () {
+      mockHappyPathTs()
+      const db = yield* DynamoClient.make({
+        entities: { TelemetryFixture: TelemetryFixtureEntity },
+        tables: { TelemetryFixtureTable },
+      })
+      yield* db.entities.TelemetryFixture.append({
+        channel: "c-1",
+        deviceId: "d-7",
+        timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+      }).remove(["alert"])
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      const expr = call.TransactItems[0].Update.UpdateExpression as string
+      expect(expr).toMatch(/\bREMOVE\b/)
+      const ean = call.TransactItems[0].Update.ExpressionAttributeNames
+      expect(Object.values(ean)).toContain("alert")
+    }).pipe(Effect.provide(TestLayerTs)),
+  )
+
+  it.effect(".remove() composes with .condition() and .skipFollowUp() in any order", () =>
+    Effect.gen(function* () {
+      mockTransactWriteItems.mockResolvedValueOnce({})
+      // No mockGetItemTs — skipFollowUp must not call GetItem.
+
+      const db = yield* DynamoClient.make({
+        entities: { TelemetryFixture: TelemetryFixtureEntity },
+        tables: { TelemetryFixtureTable },
+      })
+      const result = yield* db.entities.TelemetryFixture.append({
+        channel: "c-1",
+        deviceId: "d-7",
+        timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+      })
+        .condition({ eq: { location: "rack-1" } })
+        .remove(["alert"])
+        .skipFollowUp()
+
+      expect(result).toBeUndefined()
+      expect(mockGetItemTs).not.toHaveBeenCalled()
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      const cond = call.TransactItems[0].Update.ConditionExpression as string
+      // CAS AND user condition.
+      expect(cond).toContain("AND")
+      const expr = call.TransactItems[0].Update.UpdateExpression as string
+      expect(expr).toMatch(/\bREMOVE\b/)
+    }).pipe(Effect.provide(TestLayerTs)),
+  )
+
+  it.effect("chained .remove() calls accumulate attribute names", () =>
+    Effect.gen(function* () {
+      mockHappyPathTs()
+      const db = yield* DynamoClient.make({
+        entities: { TelemetryFixture: TelemetryFixtureEntity },
+        tables: { TelemetryFixtureTable },
+      })
+      yield* db.entities.TelemetryFixture.append({
+        channel: "c-1",
+        deviceId: "d-7",
+        timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+      })
+        .remove(["alert"])
+        .remove(["location"])
+
+      const ean = mockTransactWriteItems.mock.calls[0]![0].TransactItems[0].Update
+        .ExpressionAttributeNames as globalThis.Record<string, string>
+      const physical = new Set(Object.values(ean))
+      expect(physical.has("alert")).toBe(true)
+      expect(physical.has("location")).toBe(true)
+    }).pipe(Effect.provide(TestLayerTs)),
   )
 })

--- a/packages/effect-dynamodb/test/TimeSeries.test.ts
+++ b/packages/effect-dynamodb/test/TimeSeries.test.ts
@@ -971,3 +971,771 @@ describe("TimeSeries — indexPolicy on append", () => {
     },
   )
 })
+
+// ---------------------------------------------------------------------------
+// 5. .append().remove(attrs) — atomic SET + REMOVE + CAS (issue #49)
+// ---------------------------------------------------------------------------
+//
+// `.remove(attrs)` accumulates REMOVE clauses onto the same UpdateItem that
+// carries the scoped SET and CAS predicate, closing the race window the
+// previous workarounds (two-write pattern, NullOr sentinels) all suffered
+// from. Validation rejects names that would break time-series invariants
+// (orderBy, PK/SK composites, refs) and names outside `appendInput`. Any
+// GSI half whose composite list intersects the removed attribute cascades
+// through `composeGsiKeysForUpdatePolicyAware` via `removedSet`.
+//
+// Covers issue #49.
+// ---------------------------------------------------------------------------
+
+describe("TimeSeries — .append().remove() basic emission", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  const buildEntity = () => {
+    const entity = Entity.make({
+      model: Telemetry,
+      entityType: "Telemetry",
+      primaryKey: {
+        pk: { field: "pk", composite: ["channel", "deviceId"] },
+        sk: { field: "sk", composite: [] },
+      },
+      timestamps: true,
+      timeSeries: {
+        orderBy: "timestamp",
+        appendInput: TelemetryAppendInput,
+      },
+    })
+    return makeEntityWithTag(entity)
+  }
+
+  const mockHappyPathReadback = () => {
+    mockTransactWriteItems.mockResolvedValueOnce({})
+    mockGetItem.mockResolvedValueOnce({
+      Item: {
+        pk: { S: "$tsapp#v1#telemetry#c-1#d-7" },
+        sk: { S: "$tsapp#v1#telemetry_1" },
+        channel: { S: "c-1" },
+        deviceId: { S: "d-7" },
+        timestamp: { S: "2026-04-22T10:00:00.000Z" },
+        __edd_e__: { S: "Telemetry" },
+      },
+    })
+  }
+
+  // The unbound entity-level append signature is positional:
+  //   append(input, condition, skipFollowUp, removeAttrs)
+  // BoundAppend tests cover the fluent .remove() chain in BoundCrud.test.ts.
+
+  it.effect("single attr in removeAttrs emits a REMOVE clause naming that attribute", () => {
+    const { entity, tableLayer } = buildEntity()
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      mockHappyPathReadback()
+
+      yield* (entity as any).append(
+        {
+          channel: "c-1",
+          deviceId: "d-7",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+        },
+        undefined,
+        false,
+        ["alert"],
+      )
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      const update = call.TransactItems[0].Update
+      const expr = update.UpdateExpression as string
+      expect(expr).toMatch(/\bREMOVE\b/)
+
+      const ean = update.ExpressionAttributeNames as globalThis.Record<string, string>
+      const removeIdx = expr.indexOf("REMOVE")
+      const remExpr = expr.slice(removeIdx)
+      const alertAlias = Object.entries(ean).find(([_, v]) => v === "alert")?.[0]
+      expect(alertAlias).toBeDefined()
+      expect(remExpr.includes(alertAlias!)).toBe(true)
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("multiple attrs emit a REMOVE list naming each attribute", () => {
+    const { entity, tableLayer } = buildEntity()
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      mockHappyPathReadback()
+
+      yield* (entity as any).append(
+        {
+          channel: "c-1",
+          deviceId: "d-7",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+        },
+        undefined,
+        false,
+        ["alert", "gpio"],
+      )
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      const update = call.TransactItems[0].Update
+      const expr = update.UpdateExpression as string
+      const ean = update.ExpressionAttributeNames as globalThis.Record<string, string>
+      const alertAlias = Object.entries(ean).find(([_, v]) => v === "alert")?.[0]
+      const gpioAlias = Object.entries(ean).find(([_, v]) => v === "gpio")?.[0]
+      const removeIdx = expr.indexOf("REMOVE")
+      const remExpr = expr.slice(removeIdx)
+      expect(remExpr.includes(alertAlias!)).toBe(true)
+      expect(remExpr.includes(gpioAlias!)).toBe(true)
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("removeAttrs still issues a single TransactWriteItems (2 items, atomic)", () => {
+    const { entity, tableLayer } = buildEntity()
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      mockHappyPathReadback()
+
+      yield* (entity as any).append(
+        {
+          channel: "c-1",
+          deviceId: "d-7",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+        },
+        undefined,
+        false,
+        ["alert"],
+      )
+
+      expect(mockTransactWriteItems).toHaveBeenCalledOnce()
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      // Same TransactWriteItems shape: UpdateItem + Put (event).
+      expect(call.TransactItems).toHaveLength(2)
+      const update = call.TransactItems[0].Update
+      // CAS predicate is preserved alongside SET + REMOVE.
+      expect(update.ConditionExpression).toMatch(
+        /attribute_not_exists\(#_tspk\) OR #_tsob < :_tsNewOb/,
+      )
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("removeAttrs composes with user condition (ANDed onto CAS)", () => {
+    const { entity, tableLayer } = buildEntity()
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      mockHappyPathReadback()
+
+      yield* (entity as any).append(
+        {
+          channel: "c-1",
+          deviceId: "d-7",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+        },
+        { eq: { location: "rack-1" } },
+        false,
+        ["alert"],
+      )
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      const update = call.TransactItems[0].Update
+      const cond = update.ConditionExpression as string
+      expect(cond).toContain("attribute_not_exists(#_tspk) OR #_tsob < :_tsNewOb")
+      expect(cond).toContain("AND")
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("removeAttrs composes with skipFollowUp — no GetItem, REMOVE clause present", () => {
+    const { entity, tableLayer } = buildEntity()
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      mockTransactWriteItems.mockResolvedValueOnce({})
+      // Note: no mockGetItem — skipFollowUp must not issue one.
+
+      const result = yield* (entity as any).append(
+        {
+          channel: "c-1",
+          deviceId: "d-7",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+        },
+        undefined,
+        true,
+        ["alert"],
+      )
+
+      expect(result).toBeUndefined()
+      expect(mockGetItem).not.toHaveBeenCalled()
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      const expr = call.TransactItems[0].Update.UpdateExpression as string
+      expect(expr).toMatch(/\bREMOVE\b/)
+    }).pipe(Effect.provide(layer))
+  })
+})
+
+describe("TimeSeries — .append().remove() validation", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  const buildEntity = () => {
+    const entity = Entity.make({
+      model: Telemetry,
+      entityType: "Telemetry",
+      primaryKey: {
+        pk: { field: "pk", composite: ["channel", "deviceId"] },
+        sk: { field: "sk", composite: [] },
+      },
+      timestamps: true,
+      timeSeries: {
+        orderBy: "timestamp",
+        appendInput: TelemetryAppendInput,
+      },
+    })
+    return makeEntityWithTag(entity)
+  }
+
+  it.effect("rejects an attribute not declared in appendInput (ValidationError)", () => {
+    // `accountId` is in the Telemetry model but NOT in TelemetryAppendInput —
+    // this is the enrichment-preservation contract. `.remove()` cannot cross
+    // it; use `.update().remove([...])` for enrichment fields.
+    const { entity, tableLayer } = buildEntity()
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      const err = yield* (entity as any)
+        .append(
+          {
+            channel: "c-1",
+            deviceId: "d-7",
+            timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+          },
+          undefined,
+          false,
+          ["accountId"],
+        )
+        .pipe(Effect.flip)
+
+      expect(err._tag).toBe("ValidationError")
+      if (err._tag === "ValidationError") {
+        expect(err.operation).toBe("append.remove")
+        expect(String(err.cause)).toContain("appendInput")
+      }
+      // No DynamoDB call should have been issued.
+      expect(mockTransactWriteItems).not.toHaveBeenCalled()
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("rejects orderBy (ValidationError)", () => {
+    const { entity, tableLayer } = buildEntity()
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      const err = yield* (entity as any)
+        .append(
+          {
+            channel: "c-1",
+            deviceId: "d-7",
+            timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+          },
+          undefined,
+          false,
+          ["timestamp"],
+        )
+        .pipe(Effect.flip)
+
+      expect(err._tag).toBe("ValidationError")
+      if (err._tag === "ValidationError") {
+        expect(err.operation).toBe("append.remove")
+        expect(String(err.cause)).toContain("orderBy")
+      }
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("rejects a primary-key composite (ValidationError)", () => {
+    const { entity, tableLayer } = buildEntity()
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      const err = yield* (entity as any)
+        .append(
+          {
+            channel: "c-1",
+            deviceId: "d-7",
+            timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+          },
+          undefined,
+          false,
+          ["channel"],
+        )
+        .pipe(Effect.flip)
+
+      expect(err._tag).toBe("ValidationError")
+      if (err._tag === "ValidationError") {
+        expect(err.operation).toBe("append.remove")
+        expect(String(err.cause)).toContain("primary-key composite")
+      }
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect(
+    "rejects SET/REMOVE conflict — same attribute in payload AND removeAttrs (ValidationError)",
+    () => {
+      const { entity, tableLayer } = buildEntity()
+      const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+      return Effect.gen(function* () {
+        const err = yield* (entity as any)
+          .append(
+            {
+              channel: "c-1",
+              deviceId: "d-7",
+              timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+              // `location` is in the payload AND in removeAttrs — ambiguous.
+              location: "rack-1",
+            },
+            undefined,
+            false,
+            ["location"],
+          )
+          .pipe(Effect.flip)
+
+        expect(err._tag).toBe("ValidationError")
+        if (err._tag === "ValidationError") {
+          expect(err.operation).toBe("append.remove")
+          expect(String(err.cause)).toContain("both")
+        }
+        // Validation rejects before any DDB call.
+        expect(mockTransactWriteItems).not.toHaveBeenCalled()
+      }).pipe(Effect.provide(layer))
+    },
+  )
+
+  it.effect(
+    "payload-as-undefined + removeAttrs is NOT a conflict (undefined is skipped from SET)",
+    () => {
+      // `alert: undefined` in the payload is skipped from the SET clause loop
+      // (Entity.ts append builder) — naming it in removeAttrs does not produce
+      // a SET/REMOVE conflict at the DynamoDB level.
+      const { entity, tableLayer } = buildEntity()
+      const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+      return Effect.gen(function* () {
+        mockTransactWriteItems.mockResolvedValueOnce({})
+        mockGetItem.mockResolvedValueOnce({
+          Item: {
+            pk: { S: "$tsapp#v1#telemetry#c-1#d-7" },
+            sk: { S: "$tsapp#v1#telemetry_1" },
+            channel: { S: "c-1" },
+            deviceId: { S: "d-7" },
+            timestamp: { S: "2026-04-22T10:00:00.000Z" },
+            __edd_e__: { S: "Telemetry" },
+          },
+        })
+
+        yield* (entity as any).append(
+          {
+            channel: "c-1",
+            deviceId: "d-7",
+            timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+            alert: undefined,
+          },
+          undefined,
+          false,
+          ["alert"],
+        )
+
+        expect(mockTransactWriteItems).toHaveBeenCalledOnce()
+        const expr = mockTransactWriteItems.mock.calls[0]![0].TransactItems[0].Update
+          .UpdateExpression as string
+        expect(expr).toMatch(/\bREMOVE\b/)
+      }).pipe(Effect.provide(layer))
+    },
+  )
+
+  it.effect("empty removeAttrs is a no-op — no REMOVE clause, no failure", () => {
+    const { entity, tableLayer } = buildEntity()
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      mockTransactWriteItems.mockResolvedValueOnce({})
+      mockGetItem.mockResolvedValueOnce({
+        Item: {
+          pk: { S: "$tsapp#v1#telemetry#c-1#d-7" },
+          sk: { S: "$tsapp#v1#telemetry_1" },
+          channel: { S: "c-1" },
+          deviceId: { S: "d-7" },
+          timestamp: { S: "2026-04-22T10:00:00.000Z" },
+          __edd_e__: { S: "Telemetry" },
+        },
+      })
+
+      yield* (entity as any).append(
+        {
+          channel: "c-1",
+          deviceId: "d-7",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+        },
+        undefined,
+        false,
+        [],
+      )
+
+      const expr = mockTransactWriteItems.mock.calls[0]![0].TransactItems[0].Update
+        .UpdateExpression as string
+      // No REMOVE clause when the list is empty (no GSI keys to remove either
+      // because there are no indexes on this fixture).
+      expect(expr).not.toMatch(/\bREMOVE\b/)
+    }).pipe(Effect.provide(layer))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 6. GSI cascade behavior via .append().remove() — issue #49 motivating case
+// ---------------------------------------------------------------------------
+//
+// Per CLAUDE.md "Canonical GSI-composite test-fixture shapes": any change to
+// the policy-aware composer or its callers must span shapes 1, 2, 5, 6.
+// `.append().remove()` is a new caller of `composeGsiKeysForUpdatePolicyAware`
+// with `removedSet` populated — exercise the cascade end-to-end across the
+// shapes that matter for time-series writers.
+// ---------------------------------------------------------------------------
+
+describe("TimeSeries — .append().remove() GSI cascade (canonical shapes)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  // Shape #5 (all-mutable composites) + the issue #49 motivating case:
+  // sparse-PK GSI keyed on alertState. Removing alertState drops gsi3pk.
+  it.effect(
+    "shape #5: sparse PK composite cleared via .remove() → REMOVE gsi3pk (cascade override)",
+    () => {
+      const entity = Entity.make({
+        model: Telemetry,
+        entityType: "Telemetry",
+        primaryKey: {
+          pk: { field: "pk", composite: ["channel", "deviceId"] },
+          sk: { field: "sk", composite: [] },
+        },
+        indexes: {
+          byCurrentAlert: {
+            name: "gsi3",
+            pk: { field: "gsi3pk", composite: ["alert"] },
+            sk: { field: "gsi3sk", composite: ["timestamp"] },
+            indexPolicy: { pk: "sparse", sk: "preserve" },
+          },
+        },
+        timestamps: true,
+        timeSeries: {
+          orderBy: "timestamp",
+          appendInput: TelemetryAppendInput,
+        },
+      })
+      const { entity: wired, tableLayer } = makeEntityWithTag(entity)
+      const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+      return Effect.gen(function* () {
+        mockTransactWriteItems.mockResolvedValueOnce({})
+        mockGetItem.mockResolvedValueOnce({
+          Item: {
+            pk: { S: "$tsapp#v1#telemetry#c-1#d-7" },
+            sk: { S: "$tsapp#v1#telemetry_1" },
+            channel: { S: "c-1" },
+            deviceId: { S: "d-7" },
+            timestamp: { S: "2026-04-22T10:00:00.000Z" },
+            __edd_e__: { S: "Telemetry" },
+          },
+        })
+
+        // Append carries the clock but does NOT carry alert. Explicit
+        // removeAttrs ["alert"] signals "drop the alert state". The PK half
+        // is `'sparse'` so cascade override → REMOVE gsi3pk. The SK half is
+        // `'preserve'`; timestamp is present so SET gsi3sk.
+        yield* (wired as any).append(
+          {
+            channel: "c-1",
+            deviceId: "d-7",
+            timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+          },
+          undefined,
+          false,
+          ["alert"],
+        )
+
+        const update = mockTransactWriteItems.mock.calls[0]![0].TransactItems[0].Update
+        const expr = update.UpdateExpression as string
+        const ean = update.ExpressionAttributeNames as globalThis.Record<string, string>
+        const aliasOf = (physical: string) =>
+          Object.entries(ean).find(([_, v]) => v === physical)?.[0]
+        const gsi3pkAlias = aliasOf("gsi3pk")
+        const gsi3skAlias = aliasOf("gsi3sk")
+        const alertAlias = aliasOf("alert")
+
+        const removeIdx = expr.indexOf("REMOVE")
+        const setExpr = removeIdx === -1 ? expr : expr.slice(0, removeIdx)
+        const remExpr = removeIdx === -1 ? "" : expr.slice(removeIdx)
+
+        // gsi3pk REMOVE'd via cascade override.
+        expect(remExpr.includes(gsi3pkAlias!)).toBe(true)
+        expect(setExpr.includes(gsi3pkAlias!)).toBe(false)
+        // gsi3sk SET (timestamp present).
+        expect(setExpr.includes(gsi3skAlias!)).toBe(true)
+        expect(remExpr.includes(gsi3skAlias!)).toBe(false)
+        // The attribute itself is also REMOVE'd.
+        expect(remExpr.includes(alertAlias!)).toBe(true)
+      }).pipe(Effect.provide(layer))
+    },
+  )
+
+  // Shape #6: empty-composite half (SK is constant prefix). The PK composite
+  // is appendInput-owned and sparse — clearing it via .remove() cascades a
+  // drop on the PK half only; the empty SK half always evaluates.
+  it.effect(
+    "shape #6: empty-composite SK half + sparse PK + .remove() → REMOVE gsi5pk, SET gsi5sk",
+    () => {
+      // Use a fixture entity where the model has `accountId` but appendInput
+      // exposes it (so we can pass it on first write then remove on second).
+      class T extends Schema.Class<T>("T")({
+        channel: Schema.String,
+        deviceId: Schema.String,
+        timestamp: Schema.DateTimeUtc,
+        accountId: Schema.optional(Schema.String),
+      }) {}
+      const TAppendInput = Schema.Struct({
+        channel: Schema.String,
+        deviceId: Schema.String,
+        timestamp: Schema.DateTimeUtc,
+        accountId: Schema.optional(Schema.String),
+      })
+
+      const entity = Entity.make({
+        model: T,
+        entityType: "T",
+        primaryKey: {
+          pk: { field: "pk", composite: ["channel", "deviceId"] },
+          sk: { field: "sk", composite: [] },
+        },
+        indexes: {
+          byAccount: {
+            name: "gsi5",
+            // Empty-composite SK half — the SK is just the entity prefix.
+            pk: { field: "gsi5pk", composite: ["accountId"] },
+            sk: { field: "gsi5sk", composite: [] },
+            indexPolicy: { pk: "sparse", sk: "preserve" },
+          },
+        },
+        timeSeries: {
+          orderBy: "timestamp",
+          appendInput: TAppendInput,
+        },
+      })
+      const { entity: wired, tableLayer } = makeEntityWithTag(entity)
+      const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+      return Effect.gen(function* () {
+        mockTransactWriteItems.mockResolvedValueOnce({})
+        mockGetItem.mockResolvedValueOnce({
+          Item: {
+            pk: { S: "$tsapp#v1#t#c-1#d-7" },
+            sk: { S: "$tsapp#v1#t_1" },
+            channel: { S: "c-1" },
+            deviceId: { S: "d-7" },
+            timestamp: { S: "2026-04-22T10:00:00.000Z" },
+            __edd_e__: { S: "T" },
+          },
+        })
+
+        yield* (wired as any).append(
+          {
+            channel: "c-1",
+            deviceId: "d-7",
+            timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+          },
+          undefined,
+          false,
+          ["accountId"],
+        )
+
+        const update = mockTransactWriteItems.mock.calls[0]![0].TransactItems[0].Update
+        const expr = update.UpdateExpression as string
+        const ean = update.ExpressionAttributeNames as globalThis.Record<string, string>
+        const aliasOf = (physical: string) =>
+          Object.entries(ean).find(([_, v]) => v === physical)?.[0]
+        const gsi5pkAlias = aliasOf("gsi5pk")
+        const gsi5skAlias = aliasOf("gsi5sk")
+
+        const removeIdx = expr.indexOf("REMOVE")
+        const setExpr = removeIdx === -1 ? expr : expr.slice(0, removeIdx)
+        const remExpr = removeIdx === -1 ? "" : expr.slice(removeIdx)
+
+        // PK cascade-removed; empty-composite SK half is still SET because
+        // it has nothing to multi-writer-clobber — closes the v1.7.3 #46
+        // class of bug, preserved by issue #49 work.
+        expect(remExpr.includes(gsi5pkAlias!)).toBe(true)
+        expect(setExpr.includes(gsi5skAlias!)).toBe(true)
+        expect(setExpr.includes(gsi5pkAlias!)).toBe(false)
+      }).pipe(Effect.provide(layer))
+    },
+  )
+
+  // Shape #2: PK-composites-only GSI (`byChannel: pk=[channel], sk=[deviceId]`
+  // on `primaryKey: [channel, deviceId]`). `.remove()` of a non-composite
+  // attribute must NOT cascade-drop a GSI whose composites are entirely PK
+  // composites — the per-half gate must continue to SET both halves
+  // idempotently (preserves the v1.7.2 #43 fix).
+  it.effect("shape #2: .remove() of unrelated attr leaves PK-composites-only GSI fully SET", () => {
+    const entity = Entity.make({
+      model: Telemetry,
+      entityType: "Telemetry",
+      primaryKey: {
+        pk: { field: "pk", composite: ["channel", "deviceId"] },
+        sk: { field: "sk", composite: [] },
+      },
+      indexes: {
+        byChannel: {
+          name: "gsi1",
+          pk: { field: "gsi1pk", composite: ["channel"] },
+          sk: { field: "gsi1sk", composite: ["deviceId"] },
+          indexPolicy: { pk: "preserve", sk: "preserve" },
+        },
+      },
+      timestamps: true,
+      timeSeries: {
+        orderBy: "timestamp",
+        appendInput: TelemetryAppendInput,
+      },
+    })
+    const { entity: wired, tableLayer } = makeEntityWithTag(entity)
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      mockTransactWriteItems.mockResolvedValueOnce({})
+      mockGetItem.mockResolvedValueOnce({
+        Item: {
+          pk: { S: "$tsapp#v1#telemetry#c-1#d-7" },
+          sk: { S: "$tsapp#v1#telemetry_1" },
+          channel: { S: "c-1" },
+          deviceId: { S: "d-7" },
+          timestamp: { S: "2026-04-22T10:00:00.000Z" },
+          __edd_e__: { S: "Telemetry" },
+        },
+      })
+
+      // Remove `alert` (not part of byChannel composites).
+      yield* (wired as any).append(
+        {
+          channel: "c-1",
+          deviceId: "d-7",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+        },
+        undefined,
+        false,
+        ["alert"],
+      )
+
+      const update = mockTransactWriteItems.mock.calls[0]![0].TransactItems[0].Update
+      const expr = update.UpdateExpression as string
+      const ean = update.ExpressionAttributeNames as globalThis.Record<string, string>
+      const aliasOf = (physical: string) =>
+        Object.entries(ean).find(([_, v]) => v === physical)?.[0]
+      const gsi1pkAlias = aliasOf("gsi1pk")
+      const gsi1skAlias = aliasOf("gsi1sk")
+
+      const removeIdx = expr.indexOf("REMOVE")
+      const setExpr = removeIdx === -1 ? expr : expr.slice(0, removeIdx)
+      const remExpr = removeIdx === -1 ? "" : expr.slice(removeIdx)
+
+      // Both halves SET — #43 fix preserved under .remove().
+      expect(setExpr.includes(gsi1pkAlias!)).toBe(true)
+      expect(setExpr.includes(gsi1skAlias!)).toBe(true)
+      expect(remExpr.includes(gsi1pkAlias!)).toBe(false)
+      expect(remExpr.includes(gsi1skAlias!)).toBe(false)
+    }).pipe(Effect.provide(layer))
+  })
+
+  // Shape #1: Multi-writer GSI — PK enrichment-owned (accountId not in
+  // appendInput), SK ingest-owned (alert + timestamp). `.remove(['alert'])`
+  // is an ingest-owned signal that must not touch the enrichment-owned PK
+  // half (multi-writer protection holds), but should cascade-drop the SK
+  // half whose composite list contains `alert`.
+  it.effect(
+    "shape #1: multi-writer GSI — .remove() on ingest composite leaves enrichment PK alone, drops ingest SK",
+    () => {
+      const entity = Entity.make({
+        model: Telemetry,
+        entityType: "Telemetry",
+        primaryKey: {
+          pk: { field: "pk", composite: ["channel", "deviceId"] },
+          sk: { field: "sk", composite: [] },
+        },
+        indexes: {
+          byAccountAlert: {
+            name: "gsi6",
+            // PK: enrichment-owned (accountId is NOT in appendInput).
+            pk: { field: "gsi6pk", composite: ["accountId"] },
+            // SK: ingest-owned (alert + timestamp ARE in appendInput).
+            sk: { field: "gsi6sk", composite: ["alert", "timestamp"] },
+            indexPolicy: { pk: "preserve", sk: "sparse" },
+          },
+        },
+        timestamps: true,
+        timeSeries: {
+          orderBy: "timestamp",
+          appendInput: TelemetryAppendInput,
+        },
+      })
+      const { entity: wired, tableLayer } = makeEntityWithTag(entity)
+      const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+      return Effect.gen(function* () {
+        mockTransactWriteItems.mockResolvedValueOnce({})
+        mockGetItem.mockResolvedValueOnce({
+          Item: {
+            pk: { S: "$tsapp#v1#telemetry#c-1#d-7" },
+            sk: { S: "$tsapp#v1#telemetry_1" },
+            channel: { S: "c-1" },
+            deviceId: { S: "d-7" },
+            timestamp: { S: "2026-04-22T10:00:00.000Z" },
+            __edd_e__: { S: "Telemetry" },
+          },
+        })
+
+        yield* (wired as any).append(
+          {
+            channel: "c-1",
+            deviceId: "d-7",
+            timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+          },
+          undefined,
+          false,
+          ["alert"],
+        )
+
+        const update = mockTransactWriteItems.mock.calls[0]![0].TransactItems[0].Update
+        const expr = update.UpdateExpression as string
+        const ean = update.ExpressionAttributeNames as globalThis.Record<string, string>
+        const aliasOf = (physical: string) =>
+          Object.entries(ean).find(([_, v]) => v === physical)?.[0]
+        const gsi6pkAlias = aliasOf("gsi6pk")
+        const gsi6skAlias = aliasOf("gsi6sk")
+
+        const removeIdx = expr.indexOf("REMOVE")
+        const setExpr = removeIdx === -1 ? expr : expr.slice(0, removeIdx)
+        const remExpr = removeIdx === -1 ? "" : expr.slice(removeIdx)
+
+        // PK half — enrichment-owned, multi-writer protection holds: not
+        // SET, not REMOVE'd. accountId not in payload, not in keyRecord, not
+        // in removedSet → skipPk=true.
+        expect(setExpr.includes(gsi6pkAlias!)).toBe(false)
+        expect(remExpr.includes(gsi6pkAlias!)).toBe(false)
+        // SK half — alert ∈ removedSet → cascade override fires → can't
+        // compose (alert absent from merged) → sparse → REMOVE.
+        expect(remExpr.includes(gsi6skAlias!)).toBe(true)
+        expect(setExpr.includes(gsi6skAlias!)).toBe(false)
+      }).pipe(Effect.provide(layer))
+    },
+  )
+})

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -1865,6 +1865,323 @@ describeConnected("timeSeries integration tests", () => {
 })
 
 // ===========================================================================
+// timeSeries .append().remove() — atomic SET + REMOVE + CAS — closes #49
+// ===========================================================================
+//
+// `.append(input).remove(attrs)` clears `appendInput` attributes in the same
+// UpdateItem as the scoped SET and CAS predicate, closing the race window
+// that the two-write workaround (.append() then .update().remove()) suffered
+// from. Any GSI half whose composite list intersects the removed attribute
+// cascades through `composeGsiKeysForUpdatePolicyAware` via `removedSet`.
+//
+// Fixture entity: sparse-PK GSI keyed on `alertState`, mirroring the issue
+// #49 motivating IoT case. End-to-end: write with alertState, observe via
+// byCurrentAlert; remove alertState, observe item drop from the GSI; item
+// remains addressable via primary key.
+// ===========================================================================
+
+class TsAlertDevice extends Schema.Class<TsAlertDevice>("TsAlertDevice")({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  timestamp: Schema.DateTimeUtc,
+  alertState: Schema.optional(Schema.String),
+  location: Schema.optional(Schema.String),
+  accountId: Schema.optional(Schema.String), // enrichment — not in appendInput
+}) {}
+
+const TsAlertDeviceAppendInput = Schema.Struct({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  timestamp: Schema.DateTimeUtc,
+  alertState: Schema.optional(Schema.String),
+  location: Schema.optional(Schema.String),
+})
+
+const tsAlertSchema = DynamoSchema.make({ name: "ts-alert-test", version: 1 })
+const tsAlertTableName = `ts-alert-test-${Date.now()}`
+
+const TsAlertDevices = Entity.make({
+  model: TsAlertDevice,
+  entityType: "TsAlertDevice",
+  primaryKey: {
+    pk: { field: "pk", composite: ["channel", "deviceId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  indexes: {
+    // Sparse-PK GSI on alertState — the issue #49 motivating shape.
+    byCurrentAlert: {
+      name: "gsi1",
+      pk: { field: "gsi1pk", composite: ["alertState"] },
+      sk: { field: "gsi1sk", composite: ["timestamp"] },
+      indexPolicy: { pk: "sparse", sk: "preserve" },
+    },
+    // PK-composites-only GSI — must remain populated under .remove() of an
+    // unrelated attribute (preserves the #43 fix under the new code path).
+    byChannel: {
+      name: "gsi2",
+      pk: { field: "gsi2pk", composite: ["channel"] },
+      sk: { field: "gsi2sk", composite: ["deviceId"] },
+      indexPolicy: { pk: "preserve", sk: "preserve" },
+    },
+  },
+  timeSeries: {
+    orderBy: "timestamp",
+    appendInput: TsAlertDeviceAppendInput,
+  },
+})
+
+const TsAlertTable = Table.make({ schema: tsAlertSchema, entities: { TsAlertDevices } })
+const TsAlertLayer = Layer.mergeAll(ClientLayer, TsAlertTable.layer({ name: tsAlertTableName }))
+const provideTsAlert = Effect.provide(TsAlertLayer)
+
+describeConnected("timeSeries .append().remove() integration tests (closes #49)", () => {
+  beforeAll(async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* DynamoClient
+        yield* client.createTable({
+          TableName: tsAlertTableName,
+          BillingMode: "PAY_PER_REQUEST",
+          ...Table.definition(TsAlertTable),
+        })
+      }).pipe(provideTsAlert, Effect.scoped),
+    )
+  }, 15000)
+
+  afterAll(async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* DynamoClient
+        yield* client.deleteTable({ TableName: tsAlertTableName })
+      }).pipe(
+        provideTsAlert,
+        Effect.scoped,
+        Effect.catchTag("ResourceNotFoundError", () => Effect.void),
+      ),
+    )
+  }, 15000)
+
+  it.effect(
+    "round-trip: .remove() clears the attribute on the current item, item remains addressable",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { TsAlertDevices },
+          tables: { TsAlertTable },
+        })
+
+        // 1. Initial append with alertState set.
+        yield* db.entities.TsAlertDevices.append({
+          channel: "ch-rt",
+          deviceId: "d-rt-1",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+          alertState: "ACTIVE",
+          location: "rack-1",
+        })
+
+        const beforeRemove = yield* db.entities.TsAlertDevices.get({
+          channel: "ch-rt",
+          deviceId: "d-rt-1",
+        })
+        expect(beforeRemove.alertState).toBe("ACTIVE")
+        expect(beforeRemove.location).toBe("rack-1")
+
+        // 2. Append with .remove(['alertState']) clears it atomically.
+        yield* db.entities.TsAlertDevices.append({
+          channel: "ch-rt",
+          deviceId: "d-rt-1",
+          timestamp: DateTime.makeUnsafe("2026-04-22T10:05:00.000Z"),
+          location: "rack-2",
+        }).remove(["alertState"])
+
+        const afterRemove = yield* db.entities.TsAlertDevices.get({
+          channel: "ch-rt",
+          deviceId: "d-rt-1",
+        })
+        // alertState absent (Schema.optional decodes to undefined).
+        expect(afterRemove.alertState).toBeUndefined()
+        // Other appendInput field unaffected.
+        expect(afterRemove.location).toBe("rack-2")
+        // orderBy updated.
+        expect(DateTime.formatIso(afterRemove.timestamp)).toBe("2026-04-22T10:05:00.000Z")
+      }).pipe(provideTsAlert),
+  )
+
+  it.effect(
+    "sparse-PK GSI cascade: item drops from byCurrentAlert after .remove(['alertState'])",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { TsAlertDevices },
+          tables: { TsAlertTable },
+        })
+
+        // 1. Initial append → item visible under alertState=ACTIVE.
+        yield* db.entities.TsAlertDevices.append({
+          channel: "ch-drop",
+          deviceId: "d-drop-1",
+          timestamp: DateTime.makeUnsafe("2026-04-22T11:00:00.000Z"),
+          alertState: "ACTIVE",
+        })
+
+        const beforeRows = yield* db.entities.TsAlertDevices.byCurrentAlert({
+          alertState: "ACTIVE",
+        }).collect()
+        expect(beforeRows).toHaveLength(1)
+        expect(beforeRows[0]!.deviceId).toBe("d-drop-1")
+
+        // 2. .remove(['alertState']) cascades a drop on the byCurrentAlert PK
+        //    half via `removedSet` → `'sparse'` → can't-compose → REMOVE.
+        yield* db.entities.TsAlertDevices.append({
+          channel: "ch-drop",
+          deviceId: "d-drop-1",
+          timestamp: DateTime.makeUnsafe("2026-04-22T11:05:00.000Z"),
+        }).remove(["alertState"])
+
+        // 3. Item must no longer be visible to byCurrentAlert(alertState=ACTIVE).
+        const afterRows = yield* db.entities.TsAlertDevices.byCurrentAlert({
+          alertState: "ACTIVE",
+        }).collect()
+        expect(afterRows).toHaveLength(0)
+      }).pipe(provideTsAlert),
+  )
+
+  it.effect(
+    "PK-composites-only GSI preserved: byChannel still returns item after unrelated .remove()",
+    () =>
+      Effect.gen(function* () {
+        // Removing `location` (not part of any GSI composite) must NOT
+        // disturb the byChannel GSI — the #43 fix must hold under this path.
+        const db = yield* DynamoClient.make({
+          entities: { TsAlertDevices },
+          tables: { TsAlertTable },
+        })
+
+        yield* db.entities.TsAlertDevices.append({
+          channel: "ch-preserve",
+          deviceId: "d-preserve-1",
+          timestamp: DateTime.makeUnsafe("2026-04-22T12:00:00.000Z"),
+          location: "rack-X",
+        })
+
+        yield* db.entities.TsAlertDevices.append({
+          channel: "ch-preserve",
+          deviceId: "d-preserve-1",
+          timestamp: DateTime.makeUnsafe("2026-04-22T12:05:00.000Z"),
+        }).remove(["location"])
+
+        const rows = yield* db.entities.TsAlertDevices.byChannel({
+          channel: "ch-preserve",
+        }).collect()
+        expect(rows).toHaveLength(1)
+        expect(rows[0]!.deviceId).toBe("d-preserve-1")
+        // location is gone from the item.
+        expect(rows[0]!.location).toBeUndefined()
+      }).pipe(provideTsAlert),
+  )
+
+  it.effect(
+    "enrichment preservation: .remove(['alertState']) leaves out-of-appendInput accountId intact",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { TsAlertDevices },
+          tables: { TsAlertTable },
+        })
+
+        // Seed via append with alert state.
+        yield* db.entities.TsAlertDevices.append({
+          channel: "ch-enrich",
+          deviceId: "d-enrich-1",
+          timestamp: DateTime.makeUnsafe("2026-04-22T13:00:00.000Z"),
+          alertState: "ACTIVE",
+        })
+
+        // Out-of-band enrichment via .update() — accountId is NOT in appendInput.
+        yield* db.entities.TsAlertDevices.update({
+          channel: "ch-enrich",
+          deviceId: "d-enrich-1",
+        }).set({ accountId: "acct-7" })
+
+        // Append + remove alertState. accountId must survive — it is outside
+        // appendInput, so .append() never touches it (enrichment-preservation
+        // contract). .remove(['alertState']) operates on alertState only.
+        yield* db.entities.TsAlertDevices.append({
+          channel: "ch-enrich",
+          deviceId: "d-enrich-1",
+          timestamp: DateTime.makeUnsafe("2026-04-22T13:05:00.000Z"),
+        }).remove(["alertState"])
+
+        const cur = yield* db.entities.TsAlertDevices.get({
+          channel: "ch-enrich",
+          deviceId: "d-enrich-1",
+        })
+        expect(cur.accountId).toBe("acct-7")
+        expect(cur.alertState).toBeUndefined()
+      }).pipe(provideTsAlert),
+  )
+
+  it.effect("stale .remove(): older orderBy → StaleAppend, REMOVE not applied", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { TsAlertDevices },
+        tables: { TsAlertTable },
+      })
+
+      // Seed at t=14:00 with alertState=ACTIVE.
+      yield* db.entities.TsAlertDevices.append({
+        channel: "ch-stale",
+        deviceId: "d-stale-1",
+        timestamp: DateTime.makeUnsafe("2026-04-22T14:00:00.000Z"),
+        alertState: "ACTIVE",
+      })
+
+      // Stale append with older orderBy + .remove() — CAS fires, transaction
+      // rejected, alertState is NOT cleared.
+      const result = yield* db.entities.TsAlertDevices.append({
+        channel: "ch-stale",
+        deviceId: "d-stale-1",
+        timestamp: DateTime.makeUnsafe("2026-04-22T13:00:00.000Z"),
+      })
+        .remove(["alertState"])
+        .asEffect()
+        .pipe(Effect.flip)
+
+      expect(result._tag).toBe("StaleAppend")
+
+      const cur = yield* db.entities.TsAlertDevices.get({
+        channel: "ch-stale",
+        deviceId: "d-stale-1",
+      })
+      // alertState preserved — the failed remove did not land.
+      expect(cur.alertState).toBe("ACTIVE")
+    }).pipe(provideTsAlert),
+  )
+
+  it.effect(
+    "validation: .remove() of an attribute outside appendInput fails fast with ValidationError",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { TsAlertDevices },
+          tables: { TsAlertTable },
+        })
+
+        const err = yield* db.entities.TsAlertDevices.append({
+          channel: "ch-val",
+          deviceId: "d-val-1",
+          timestamp: DateTime.makeUnsafe("2026-04-22T15:00:00.000Z"),
+        })
+          .remove(["accountId"]) // accountId is NOT in appendInput
+          .asEffect()
+          .pipe(Effect.flip)
+
+        expect(err._tag).toBe("ValidationError")
+      }).pipe(provideTsAlert),
+  )
+})
+
+// ===========================================================================
 // PK-composites-only GSI shape — closes #43
 // ===========================================================================
 //

--- a/packages/language-service/CHANGELOG.md
+++ b/packages/language-service/CHANGELOG.md
@@ -1,5 +1,46 @@
 # @effect-dynamodb/language-service
 
+## 1.7.4
+
+### Patch Changes
+
+- **`.append(input).remove(attrs)` — atomic SET + REMOVE + CAS on time-series entities (closes [#49](https://github.com/jmenga/effect-dynamodb/issues/49)).**
+
+  `BoundAppend` gains a `.remove(attrs)` combinator that emits `REMOVE` clauses on the same `UpdateItem` that carries the scoped `SET` and CAS predicate. Use it when an event needs to clear one or more `appendInput` attributes atomically — e.g. an IoT status event whose absence of an `alert` field means "no alert this cycle; drop the existing alert state on the current item."
+
+  **Motivating problem.** Before v1.7.4, callers wanting to clear an `appendInput` attribute were stuck with three unsatisfactory workarounds:
+  - `.append(...)` then `.update().remove([...])` (two writes) — race window: a concurrent writer between the two writes could clobber the cleared state.
+  - Sentinel value (e.g. `alertState: "DISABLED"`) — keeps the attribute set, leaves the item in any `'sparse'`-policied GSI half that composes it.
+  - `Schema.NullOr` + null payload — writes a literal `NULL` into the item; downstream readers must tolerate it.
+
+  `.append(input).remove(attrs)` closes the race window structurally: a single `UpdateItem` carries `SET + REMOVE + CAS`, atomic with the event `Put`.
+
+  **GSI cascade.** Any GSI half whose composite list intersects `attrs` follows the v1.7.1 cascade-override semantics — the half evaluates with the removed composite treated as absent. Under `'sparse'` the half drops; under `'preserve'` it's a no-op (the stored key field is left as-is unless overridden). The motivating shape is a sparse-PK GSI keyed on the cleared attribute — the item drops out of that GSI in the same write.
+
+  **Validation.** Names listed in `.remove()` are checked at execution time. The Effect fails with `ValidationError(operation: "append.remove")` if any name:
+  - is not declared in `appendInput` (enrichment-preservation contract — use `.update().remove([...])` for fields outside `appendInput`);
+  - names `orderBy` (would invalidate the CAS anchor);
+  - names a primary-key composite (would orphan the item);
+  - names a ref field (refs are create-time denormalisations — reassign via `.update()`);
+  - also appears in the encoded payload with a non-`undefined` value (DynamoDB rejects `SET`/`REMOVE` overlap).
+
+  Chained `.remove()` calls accumulate. The combinator composes with `.condition()` and `.skipFollowUp()` in any order.
+
+  **API.** New fluent combinator on `BoundAppend`:
+
+  ```ts
+  yield *
+    db.entities.Telemetry.append({ channel, deviceId, timestamp }).remove([
+      "alertState",
+    ]);
+  ```
+
+  The entity-level unbound `Entity.append()` also gains an optional fourth positional argument (`removeAttrs?: ReadonlyArray<string>`) — used by `BoundAppend`'s `.remove()` wiring; library consumers should prefer the fluent form on `BoundAppend`.
+
+  **No on-disk impact, no backfill required.** Pure feature add — existing time-series entities and existing items are unaffected.
+
+  See `guides/timeseries.mdx` for the documented usage pattern and the issue [#49](https://github.com/jmenga/effect-dynamodb/issues/49) motivating IoT case.
+
 ## 1.7.3
 
 ### Patch Changes

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/language-service",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "TypeScript Language Service Plugin for effect-dynamodb — shows DynamoDB operations on hover",
   "license": "MIT",
   "author": "Justin Menga",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
 packages:
   - "packages/*"
+
+# pnpm 11+ reads `onlyBuiltDependencies` from this file rather than from
+# `package.json`'s `pnpm.onlyBuiltDependencies` field — the latter is still
+# accepted by pnpm 10 but ignored by pnpm 11. CI uses `pnpm/action-setup@v5`
+# with `version: latest`, which jumped to pnpm 11 after PR #48 landed; without
+# this list the install fails with ERR_PNPM_IGNORED_BUILDS.
+onlyBuiltDependencies:
+  - esbuild
+  - msgpackr-extract
+  - sharp


### PR DESCRIPTION
## Summary

- Adds `BoundAppend.remove(attrs)` — emits REMOVE clauses on the same UpdateItem that carries `.append()`'s scoped SET and CAS predicate.
- Closes the race window the two-write workaround (`.append()` then `.update().remove([...])`) exposed for callers wanting to clear an `appendInput` attribute atomically.
- Any GSI half whose composite list intersects `attrs` follows the v1.7.1 cascade-override semantics — under `'sparse'` the half drops, under `'preserve'` the stored key is left alone.

Closes #49.

## Motivating case (from the issue)

Sparse-PK GSI keyed on `alertState`:

```ts
byCurrentAlert: {
  pk: { field: 'gsi1pk', composite: ['alertState'] },
  sk: { field: 'gsi1sk', composite: ['timestamp'] },
  indexPolicy: { pk: 'sparse', sk: 'preserve' }
}
```

A status event whose absence of `alertState` means "clear the alert" used to require either two writes (race-prone), a sentinel value (keeps GSI populated), or `Schema.NullOr` (writes a literal NULL). Now:

```ts
yield* db.entities.Telemetry
  .append({ channel, deviceId, timestamp })
  .remove(['alertState'])
```

The item drops out of byCurrentAlert in the same UpdateItem.

## API

```ts
yield* db.entities.Telemetry.append(input).remove(['alertState'])             // → { current }
yield* db.entities.Telemetry.append(input).condition(c).remove(['x']).skipFollowUp()
```

Validation rejects names that would break time-series invariants:
- not declared in `appendInput`
- `orderBy`
- primary-key composites
- ref fields
- SET/REMOVE payload overlap

All surface as `ValidationError(operation: "append.remove")` before any DDB call.

## Implementation

- `packages/effect-dynamodb/src/internal/BoundCrud.ts` — `BoundAppend.remove()` accumulates names; threaded through `BoundAppendConfig.run` as `removeAttrs`.
- `packages/effect-dynamodb/src/Entity.ts` — `append(input, condition, skipFollowUp, removeAttrs?)` validates the list, passes `{ removedSet }` to `composeGsiKeysForUpdatePolicyAware`, and appends REMOVE clause aliases to `appendRemoveClauses`.

## Test coverage

Per CLAUDE.md canonical-shapes mandate, the new code path is exercised across the canonical GSI shapes (#1 multi-writer, #2 PK-composites-only, #5 all-mutable, #6 empty-composite-half) at unit, entity-level, and connected layers.

- `test/TimeSeries.test.ts` — 15 new unit tests (basic emission, validation surface, GSI cascade across canonical shapes).
- `test/BoundCrud.test.ts` — 3 new tests locking the fluent chain wiring (remove/condition/skipFollowUp composition, accumulation across chained `.remove()` calls).
- `test/connected.test.ts` — 6 new integration tests against DDB Local (round-trip, sparse-PK GSI drop, PK-composites-only preservation, enrichment preservation, stale CAS, validation).

## Docs

- `examples/guide-timeseries.ts` — new `remove` region demonstrating the alert-state motivating case.
- `guides/timeseries.mdx` — new `.remove(attrs)` section documenting API, GSI cascade semantics, and validation surface.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm check` — clean (workspace typecheck)
- [x] `pnpm test` — 1080 unit tests pass (29 test files)
- [x] `pnpm --filter effect-dynamodb test:connected` — 114 tests pass (108 existing + 6 new) against DDB Local
- [x] `pnpm --filter @effect-dynamodb/geo test:connected` — 3 tests pass
- [x] `pnpm --filter @effect-dynamodb/doctest test` — 47 sync tests pass
- [x] `pnpm --filter @effect-dynamodb/doctest test:connected` — 31 runtime tests pass
- [x] `npx tsx packages/effect-dynamodb/examples/guide-timeseries.ts` — example runs cleanly end-to-end
- [x] `pnpm changeset version` — three packages lockstep-bumped 1.7.3 → 1.7.4; CHANGELOGs regenerated

## Versioning

Lockstep patch bump 1.7.3 → 1.7.4 across:
- `effect-dynamodb`
- `@effect-dynamodb/geo`
- `@effect-dynamodb/language-service`

No on-disk impact, no backfill required — pure feature add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)