### PR TITLE
feat(table): configurable TTL attribute name via TableConfig.ttlAttributeName

### DIFF
--- a/packages/docs/src/content/docs/guides/timeseries.mdx
+++ b/packages/docs/src/content/docs/guides/timeseries.mdx
@@ -281,9 +281,55 @@ Terminals are the standard `BoundQuery` set: `.collect()`, `.fetch()`, `.paginat
 
 ## TTL and retention
 
-`ttl: Duration.days(N)` on `TimeSeriesConfig` sets a `_ttl` attribute on each event item at `Math.floor(Date.now()/1000) + toSeconds(ttl)`. DynamoDB's built-in TTL processor prunes expired events asynchronously (typically within 48 hours of expiration).
+`ttl: Duration.days(N)` on `TimeSeriesConfig` sets a TTL attribute on each event item at `Math.floor(Date.now()/1000) + toSeconds(ttl)`. DynamoDB's built-in TTL processor prunes expired events asynchronously (typically within 48 hours of expiration).
 
-The current item never has `_ttl` — it is the live projection and must not expire.
+The current item never has a TTL — it is the live projection and must not expire.
+
+### Aligning with `TimeToLiveSpecification.AttributeName`
+
+By default the library writes the TTL value to an attribute named `_ttl`. DynamoDB tables enable expiry by setting `TimeToLiveSpecification.AttributeName` (the `TTL` configuration on the console / CloudFormation), and that name must match what the library writes. If your table is already provisioned with a different name (e.g. `ttl`), set `ttlAttributeName` when providing the runtime `TableConfig`:
+
+```ts
+// Default: TTL writes go to `_ttl`.
+MainTable.layer({ name: "telemetry-table" })
+
+// Override: align with a table whose TimeToLiveSpecification uses `ttl`.
+MainTable.layer({
+  name: "telemetry-table",
+  ttlAttributeName: "ttl",
+})
+
+// Or from Effect Config (env-driven, optional):
+MainTable.layerConfig({
+  name: Config.string("TABLE_NAME"),
+  ttlAttributeName: Config.string("TTL_ATTRIBUTE").pipe(Config.withDefault("_ttl")),
+})
+```
+
+A single `ttlAttributeName` applies to every lifecycle feature on the physical table — `timeSeries: { ttl }`, `softDelete: { ttl }`, and `versioned: { retain, ttl }` all write to the same attribute, and `Entity.restore()` strips it. DynamoDB allows only one TTL attribute per table, so this matches the underlying constraint by design.
+
+Use this to give yourself a migration path: declare the legacy attribute name in code, deploy without a destructive table replacement, then perform the standard two-step DDB rename later when you can.
+
+The example below provides a `MainTable` layer whose TTL attribute is the non-default `"ttl"`, then asserts the appended event carries the expiry on the configured attribute name:
+
+```ts region="ttl-attribute-name" example="guide-timeseries.ts"
+// Provide the table layer with a non-default TTL attribute name.
+const overriddenLayer = MainTable.layer({
+  name: "timeseries-demo-table",
+  ttlAttributeName: "ttl",
+})
+
+const program = Effect.gen(function* () {
+  const db = yield* DynamoClient.make({ entities: { Telemetries }, tables: { MainTable } })
+  yield* db.entities.Telemetries.append({
+    channel: "c-ttl-demo",
+    deviceId: "d-1",
+    timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+  })
+})
+
+yield* program.pipe(Effect.provide(Layer.mergeAll(ClientLayer, overriddenLayer)))
+```
 
 ## Multi-stream per partition
 

--- a/packages/effect-dynamodb-geo/CHANGELOG.md
+++ b/packages/effect-dynamodb-geo/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @effect-dynamodb/geo
 
+## 1.8.0
+
+### Minor Changes
+
+- Add `TableConfig.ttlAttributeName` (default `"_ttl"`) so the library writes TTL values to a configurable attribute name instead of the hardcoded `_ttl`. Closes [#51](https://github.com/jmenga/effect-dynamodb/issues/51).
+
+  A single setting applies to every lifecycle feature on the physical table — `timeSeries: { ttl }`, `softDelete: { ttl }`, and `versioned: { retain, ttl }` write to the same attribute and `Entity.restore()` strips it. This matches DynamoDB's per-table `TimeToLiveSpecification.AttributeName`, which permits exactly one TTL attribute.
+
+  ```ts
+  const MainTable = Table.make({ schema, entities: { Users } });
+
+  // Default (unchanged): writes to "_ttl"
+  MainTable.layer({ name: "users-prod" });
+
+  // Override: align with a TimeToLiveSpecification.AttributeName = "ttl"
+  MainTable.layer({ name: "users-prod", ttlAttributeName: "ttl" });
+
+  // Or from Effect Config
+  MainTable.layerConfig({
+    name: Config.string("TABLE_NAME"),
+    ttlAttributeName: Config.string("TTL_ATTR").pipe(
+      Config.withDefault("_ttl"),
+    ),
+  });
+  ```
+
+  This is fully backwards compatible — consumers who don't set the field continue to write to `_ttl`. Use it to align the library's writes with a pre-existing or migrated DynamoDB table whose TTL attribute differs, without the destructive table replacement or multi-deploy DDB rename dance.
+
 ## 1.7.4
 
 ### Patch Changes

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/geo",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "Geospatial index and search for effect-dynamodb using H3 hexagonal grid",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/CHANGELOG.md
+++ b/packages/effect-dynamodb/CHANGELOG.md
@@ -1,5 +1,33 @@
 # effect-dynamodb
 
+## 1.8.0
+
+### Minor Changes
+
+- Add `TableConfig.ttlAttributeName` (default `"_ttl"`) so the library writes TTL values to a configurable attribute name instead of the hardcoded `_ttl`. Closes [#51](https://github.com/jmenga/effect-dynamodb/issues/51).
+
+  A single setting applies to every lifecycle feature on the physical table — `timeSeries: { ttl }`, `softDelete: { ttl }`, and `versioned: { retain, ttl }` write to the same attribute and `Entity.restore()` strips it. This matches DynamoDB's per-table `TimeToLiveSpecification.AttributeName`, which permits exactly one TTL attribute.
+
+  ```ts
+  const MainTable = Table.make({ schema, entities: { Users } });
+
+  // Default (unchanged): writes to "_ttl"
+  MainTable.layer({ name: "users-prod" });
+
+  // Override: align with a TimeToLiveSpecification.AttributeName = "ttl"
+  MainTable.layer({ name: "users-prod", ttlAttributeName: "ttl" });
+
+  // Or from Effect Config
+  MainTable.layerConfig({
+    name: Config.string("TABLE_NAME"),
+    ttlAttributeName: Config.string("TTL_ATTR").pipe(
+      Config.withDefault("_ttl"),
+    ),
+  });
+  ```
+
+  This is fully backwards compatible — consumers who don't set the field continue to write to `_ttl`. Use it to align the library's writes with a pre-existing or migrated DynamoDB table whose TTL attribute differs, without the destructive table replacement or multi-deploy DDB rename dance.
+
 ## 1.7.4
 
 ### Patch Changes

--- a/packages/effect-dynamodb/examples/guide-timeseries.ts
+++ b/packages/effect-dynamodb/examples/guide-timeseries.ts
@@ -243,7 +243,76 @@ const program = Effect.gen(function* () {
 })
 
 // =============================================================================
-// 5. Run
+// 5. TTL attribute-name override (issue #51)
+//
+// `TableConfig.ttlAttributeName` overrides the default `_ttl` attribute used
+// across `timeSeries: { ttl }`, `softDelete: { ttl }`, and
+// `versioned: { retain, ttl }` lifecycle features. Use it to align the
+// library's writes with a pre-existing or migrated DynamoDB table whose
+// `TimeToLiveSpecification.AttributeName` differs from the default.
 // =============================================================================
 
-Effect.runPromise(program.pipe(Effect.provide(AppLayer), Effect.scoped))
+const ttlOverrideProgram = Effect.gen(function* () {
+  const client = yield* DynamoClient
+  yield* client.createTable({
+    TableName: "timeseries-demo-table",
+    BillingMode: "PAY_PER_REQUEST",
+    ...Table.definition(MainTable),
+  })
+
+  // #region ttl-attribute-name
+  // Provide the table layer with a non-default TTL attribute name.
+  const overriddenLayer = MainTable.layer({
+    name: "timeseries-demo-table",
+    ttlAttributeName: "ttl",
+  })
+
+  const program = Effect.gen(function* () {
+    const db = yield* DynamoClient.make({ entities: { Telemetries }, tables: { MainTable } })
+    yield* db.entities.Telemetries.append({
+      channel: "c-ttl-demo",
+      deviceId: "d-1",
+      timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+    })
+  })
+
+  yield* program.pipe(Effect.provide(Layer.mergeAll(ClientLayer, overriddenLayer)))
+  // #endregion
+
+  // Assert the event item carries TTL on the configured "ttl" attribute (not "_ttl").
+  const raw = yield* client.query({
+    TableName: "timeseries-demo-table",
+    KeyConditionExpression: "#pk = :pk AND begins_with(#sk, :skPrefix)",
+    ExpressionAttributeNames: { "#pk": "pk", "#sk": "sk" },
+    ExpressionAttributeValues: {
+      ":pk": { S: "$timeseries-demo#v1#telemetry#channel_c-ttl-demo#deviceid_d-1" },
+      ":skPrefix": { S: "$timeseries-demo#v1#telemetry#e#" },
+    },
+  })
+  if (!raw.Items || raw.Items.length !== 1) {
+    yield* Effect.die(new Error("expected exactly one event item"))
+  }
+  const event = raw.Items![0]!
+  if (event.ttl?.N === undefined) {
+    yield* Effect.die(new Error("expected 'ttl' attribute to be set on event item"))
+  }
+  if (event._ttl !== undefined) {
+    yield* Effect.die(new Error("'_ttl' must be absent when override is in effect"))
+  }
+  yield* Console.log(`TTL written to 'ttl' attribute: ${event.ttl!.N}`)
+
+  yield* client.deleteTable({ TableName: "timeseries-demo-table" })
+})
+
+// =============================================================================
+// 6. Run
+// =============================================================================
+
+// Run the main program first, then the override demo sequentially — both share
+// the `timeseries-demo-table` name, so they must not overlap.
+const runAll = Effect.gen(function* () {
+  yield* program.pipe(Effect.provide(AppLayer), Effect.scoped)
+  yield* ttlOverrideProgram.pipe(Effect.provide(ClientLayer), Effect.scoped)
+})
+
+Effect.runPromise(runAll)

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-dynamodb",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "Effect TS ORM for DynamoDB — schema-driven entity modeling, single-table design, composite keys, transactions, and Stream-based pagination",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/src/Entity.ts
+++ b/packages/effect-dynamodb/src/Entity.ts
@@ -68,7 +68,7 @@ import {
 } from "./Marshaller.js"
 import * as Query from "./Query.js"
 import { filterExpr, selectPaths } from "./Query.js"
-import type { TableConfig } from "./Table.js"
+import { resolveTtlAttributeName, type TableConfig } from "./Table.js"
 
 // Internal modules (decomposed from Entity.ts)
 export type {
@@ -2022,12 +2022,17 @@ const makeImpl = <
   /**
    * Build a version snapshot item: same PK, version SK, stripped GSI keys,
    * keeps __edd_e__ for entity type filtering.
+   *
+   * The TTL attribute name is resolved from the caller's TableConfig and
+   * passed in — the snapshot belongs to the same physical table, so it must
+   * align with that table's `TimeToLiveSpecification.AttributeName`.
    */
   const buildSnapshotItem = (
     item: globalThis.Record<string, unknown>,
     version: number,
     _tablePkField: string,
     tableSkField: string,
+    ttlAttrName: string,
   ): globalThis.Record<string, unknown> => {
     const snapshot: globalThis.Record<string, unknown> = { ...item }
 
@@ -2042,7 +2047,7 @@ const makeImpl = <
     // Add optional TTL
     const ttl = retainTtl()
     if (ttl) {
-      snapshot._ttl = Math.floor(Date.now() / 1000) + Duration.toSeconds(ttl)
+      snapshot[ttlAttrName] = Math.floor(Date.now() / 1000) + Duration.toSeconds(ttl)
     }
 
     return snapshot
@@ -2351,7 +2356,9 @@ const makeImpl = <
       (mode: DecodeMode, opts: { readonly condition: Expr | ConditionInput | undefined }) =>
         Effect.gen(function* () {
           const client = yield* DynamoClient
-          const { name: tableName } = yield* tableTag
+          const tc = yield* tableTag
+          const tableName = tc.name
+          const ttlAttrName = resolveTtlAttributeName(tc)
 
           // Encode user input → wire form. Users typically construct domain
           // values for transforms (DateTime, Redacted, Number) and plain
@@ -2494,6 +2501,7 @@ const makeImpl = <
                 1,
                 config.indexes.primary.pk.field,
                 config.indexes.primary.sk.field,
+                ttlAttrName,
               )
               transactItems.push({
                 Put: {
@@ -2696,7 +2704,9 @@ const makeImpl = <
           const evExpected = uState.expectedVersion
           const userCond = uState.condition
           const client = yield* DynamoClient
-          const { name: tableName } = yield* tableTag
+          const tc = yield* tableTag
+          const tableName = tc.name
+          const ttlAttrName = resolveTtlAttributeName(tc)
 
           // Decode key
           const decodedKey = yield* Schema.decodeUnknownEffect(
@@ -3033,6 +3043,7 @@ const makeImpl = <
                   currentVersion,
                   config.indexes.primary.pk.field,
                   config.indexes.primary.sk.field,
+                  ttlAttrName,
                 )
               : undefined
 
@@ -3691,7 +3702,9 @@ const makeImpl = <
       }) =>
         Effect.gen(function* () {
           const client = yield* DynamoClient
-          const { name: tableName } = yield* tableTag
+          const tc = yield* tableTag
+          const tableName = tc.name
+          const ttlAttrName = resolveTtlAttributeName(tc)
 
           // Decode key
           const decodedKey = yield* Schema.decodeUnknownEffect(
@@ -3751,7 +3764,7 @@ const makeImpl = <
             // Add optional TTL
             const sdTtl = softDeleteTtl()
             if (sdTtl) {
-              deletedItem._ttl = Math.floor(Date.now() / 1000) + Duration.toSeconds(sdTtl)
+              deletedItem[ttlAttrName] = Math.floor(Date.now() / 1000) + Duration.toSeconds(sdTtl)
             }
 
             // Build transaction
@@ -3784,6 +3797,7 @@ const makeImpl = <
                 currentVersion,
                 primary.pk.field,
                 primary.sk.field,
+                ttlAttrName,
               )
               transactItems.push({
                 Put: {
@@ -4180,7 +4194,7 @@ const makeImpl = <
   //  - UpdateItem on current: scoped SET (appendInput fields only) + CAS on
   //    `orderBy`, with GSI keys recomposed when any appendInput field is a
   //    GSI composite. `createdAt` uses if_not_exists on first append.
-  //  - Put of event: full decoded input + __edd_e__ + _ttl (if configured),
+  //  - Put of event: full decoded input + __edd_e__ + TTL attr (if configured),
   //    GSI keys stripped, SK replaced with `<currentSk>#e#<orderByValue>`.
   //
   // Concurrency outcome (stale-as-error contract — supersedes
@@ -4218,7 +4232,9 @@ const makeImpl = <
         })
       }
       const client = yield* DynamoClient
-      const { name: tableName } = yield* tableTag
+      const tc = yield* tableTag
+      const tableName = tc.name
+      const ttlAttrName = resolveTtlAttributeName(tc)
       const orderByField = timeSeriesConfig.orderBy
       const ttlDuration = timeSeriesConfig.ttl
       const appendInputSchema = schemas.appendInputSchema as Schema.Codec<any>
@@ -4455,9 +4471,9 @@ const makeImpl = <
       eventItem[primary.sk.field] = eventSk
       // __edd_e__
       eventItem.__edd_e__ = entityType
-      // _ttl
+      // TTL — attribute name comes from TableConfig (default "_ttl")
       if (ttlDuration) {
-        eventItem._ttl = Math.floor(Date.now() / 1000) + Duration.toSeconds(ttlDuration)
+        eventItem[ttlAttrName] = Math.floor(Date.now() / 1000) + Duration.toSeconds(ttlDuration)
       }
       // Events never participate in indexes: strip any GSI key fields that the
       // naive spread above may have carried over. gsiKeys weren't written into
@@ -4893,7 +4909,9 @@ const makeImpl = <
       (mode: DecodeMode, _opts: EntityGetOpts) =>
         Effect.gen(function* () {
           const client = yield* DynamoClient
-          const { name: tableName } = yield* tableTag
+          const tc = yield* tableTag
+          const tableName = tc.name
+          const ttlAttrName = resolveTtlAttributeName(tc)
 
           // Decode key
           const decodedKey = yield* Schema.decodeUnknownEffect(
@@ -4943,12 +4961,12 @@ const makeImpl = <
             ],
           })
 
-          // Build restored item: original SK, recompose all GSI keys, remove deletedAt + _ttl
+          // Build restored item: original SK, recompose all GSI keys, remove deletedAt + TTL
           const restoredItem: globalThis.Record<string, unknown> = {
             ...(deletedRaw as globalThis.Record<string, unknown>),
           }
           delete restoredItem.deletedAt
-          delete restoredItem._ttl
+          delete restoredItem[ttlAttrName]
 
           // Increment version
           const currentVersion = systemFields.version
@@ -4997,6 +5015,7 @@ const makeImpl = <
               currentVersion,
               primary.pk.field,
               primary.sk.field,
+              ttlAttrName,
             )
             transactItems.push({
               Put: {

--- a/packages/effect-dynamodb/src/Table.ts
+++ b/packages/effect-dynamodb/src/Table.ts
@@ -18,7 +18,24 @@ import type { IndexDefinition } from "./KeyComposer.js"
 export interface TableConfig {
   /** Physical DynamoDB table name. */
   readonly name: string
+  /**
+   * Attribute name used for DynamoDB TTL (`TimeToLiveSpecification.AttributeName`).
+   * Lifecycle features (`versioned: { retain, ttl }`, `softDelete: { ttl }`,
+   * `timeSeries: { ttl }`) write the epoch-seconds expiry to this attribute, and
+   * `Entity.restore()` strips it. Defaults to `"_ttl"`. Set this to align with a
+   * pre-existing or migrated table whose TTL attribute is named differently
+   * (e.g. `"ttl"`). DynamoDB allows only one TTL attribute per physical table,
+   * so a single value applies to all lifecycle features on this table.
+   */
+  readonly ttlAttributeName?: string | undefined
 }
+
+/** Default attribute name used for DynamoDB TTL when {@link TableConfig.ttlAttributeName} is unset. */
+export const DEFAULT_TTL_ATTRIBUTE_NAME = "_ttl"
+
+/** Resolve the effective TTL attribute name from a TableConfig. */
+export const resolveTtlAttributeName = (tc: TableConfig): string =>
+  tc.ttlAttributeName ?? DEFAULT_TTL_ATTRIBUTE_NAME
 
 /**
  * Counter for generating unique Tag identifiers.
@@ -75,9 +92,14 @@ export interface Table<
   readonly Tag: Context.Service<TableConfig, TableConfig>
   /** Provide the physical table name */
   readonly layer: (config: TableConfig) => Layer.Layer<TableConfig>
-  /** Provide the physical table name from Effect Config */
+  /**
+   * Provide the physical table name (and optional TTL attribute name) from Effect Config.
+   *
+   * `ttlAttributeName` is optional — omit it to use the `"_ttl"` default.
+   */
   readonly layerConfig: (config: {
     readonly name: Config.Config<string>
+    readonly ttlAttributeName?: Config.Config<string> | undefined
   }) => Layer.Layer<TableConfig, Config.ConfigError>
 }
 
@@ -132,12 +154,22 @@ export const make = <
     aggregates,
     Tag,
     layer: (tableConfig: TableConfig) => Layer.succeed(Tag, tableConfig),
-    layerConfig: (configDef: { readonly name: Config.Config<string> }) =>
+    layerConfig: (configDef: {
+      readonly name: Config.Config<string>
+      readonly ttlAttributeName?: Config.Config<string> | undefined
+    }) =>
       Layer.effect(
         Tag,
         Effect.gen(function* () {
           const tableName = yield* configDef.name
-          return { name: tableName }
+          const ttlAttributeName = configDef.ttlAttributeName
+            ? yield* configDef.ttlAttributeName
+            : undefined
+          const result: TableConfig =
+            ttlAttributeName !== undefined
+              ? { name: tableName, ttlAttributeName }
+              : { name: tableName }
+          return result
         }),
       ),
   }

--- a/packages/effect-dynamodb/src/internal/EntityConfig.ts
+++ b/packages/effect-dynamodb/src/internal/EntityConfig.ts
@@ -70,7 +70,8 @@ export type SoftDeleteConfig =
  * per partition and many immutable "event" items. See guides/timeseries.mdx.
  *
  * Current-item SK matches the primary index SK. Event-item SK is
- * `<currentSk>#e#<orderBy-value>`, GSI keys stripped, `_ttl` set.
+ * `<currentSk>#e#<orderBy-value>`, GSI keys stripped, TTL attribute set
+ * (attribute name comes from `TableConfig.ttlAttributeName`, default `"_ttl"`).
  *
  * `.append(input)` is a `TransactWriteItems` (UpdateItem current + Put event)
  * with CAS `attribute_not_exists(pk) OR #orderBy < :newOb`. Returns

--- a/packages/effect-dynamodb/test/Entity.test.ts
+++ b/packages/effect-dynamodb/test/Entity.test.ts
@@ -100,6 +100,14 @@ const TestDynamoClient = Layer.succeed(DynamoClient, {
 const TestTableConfig = MainTable.layer({ name: "test-table" })
 const TestLayer = Layer.merge(TestDynamoClient, TestTableConfig)
 
+/**
+ * Layer fixture for issue #51 — pins {@link Table.TableConfig.ttlAttributeName}
+ * to `"ttl"` instead of the `"_ttl"` default. Used by the lifecycle tests that
+ * assert TTL writes target the configured attribute name.
+ */
+const TestTableConfigCustomTtl = MainTable.layer({ name: "test-table", ttlAttributeName: "ttl" })
+const TestLayerCustomTtl = Layer.merge(TestDynamoClient, TestTableConfigCustomTtl)
+
 // ---------------------------------------------------------------------------
 // Entity.make() basics
 // ---------------------------------------------------------------------------
@@ -4320,6 +4328,33 @@ describe("Entity", () => {
         expect(snapshotPut.Item._ttl.N).toBeDefined()
       }).pipe(Effect.provide(TestLayer)),
     )
+
+    it.effect("version snapshot honours TableConfig.ttlAttributeName override (#51)", () =>
+      Effect.gen(function* () {
+        mockTransactWriteItems.mockResolvedValueOnce({})
+
+        const TtlRetainEntity = withConfig(
+          Entity.make({
+            model: SimpleItem,
+            entityType: "TtlRetainCustomAttr",
+            primaryKey: {
+              pk: { field: "pk", composite: ["itemId"] },
+              sk: { field: "sk", composite: [] },
+            },
+            versioned: { retain: true, ttl: Duration.days(90) },
+          }),
+        )
+
+        yield* TtlRetainEntity.put({ itemId: "i-1", name: "Test" }).asEffect()
+
+        const call = mockTransactWriteItems.mock.calls[0]![0]
+        const snapshotPut = call.TransactItems[1].Put
+        // TTL written to "ttl", not "_ttl"
+        expect(snapshotPut.Item.ttl).toBeDefined()
+        expect(snapshotPut.Item.ttl.N).toBeDefined()
+        expect(snapshotPut.Item._ttl).toBeUndefined()
+      }).pipe(Effect.provide(TestLayerCustomTtl)),
+    )
   })
 
   // ---------------------------------------------------------------------------
@@ -4447,6 +4482,77 @@ describe("Entity", () => {
         const call = mockTransactWriteItems.mock.calls[0]![0]
         // 2 items only: Delete current + Put soft-deleted (no sentinel delete)
         expect(call.TransactItems).toHaveLength(2)
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    it.effect("soft delete writes TTL to the configured attribute name (#51)", () =>
+      Effect.gen(function* () {
+        const SoftDeleteTtlEntity = withConfig(
+          Entity.make({
+            model: SimpleItem,
+            entityType: "SoftItemTtl",
+            primaryKey: {
+              pk: { field: "pk", composite: ["itemId"] },
+              sk: { field: "sk", composite: [] },
+            },
+            softDelete: { ttl: Duration.days(30) },
+          }),
+        )
+
+        mockGetItem.mockResolvedValueOnce({
+          Item: toAttributeMap({
+            itemId: "i-1",
+            name: "Test",
+            pk: "$myapp#v1#softitemttl#i-1",
+            sk: "$myapp#v1#softitemttl",
+            __edd_e__: "SoftItemTtl",
+          }),
+        })
+        mockTransactWriteItems.mockResolvedValueOnce({})
+
+        yield* SoftDeleteTtlEntity.delete({ itemId: "i-1" }).asEffect()
+
+        const call = mockTransactWriteItems.mock.calls[0]![0]
+        const softDeletePut = call.TransactItems[1].Put
+        // TTL written to "ttl", not "_ttl"
+        expect(softDeletePut.Item.ttl).toBeDefined()
+        expect(softDeletePut.Item.ttl.N).toBeDefined()
+        expect(softDeletePut.Item._ttl).toBeUndefined()
+      }).pipe(Effect.provide(TestLayerCustomTtl)),
+    )
+
+    it.effect("soft delete defaults TTL attribute to _ttl when override unset", () =>
+      Effect.gen(function* () {
+        const SoftDeleteTtlEntity = withConfig(
+          Entity.make({
+            model: SimpleItem,
+            entityType: "SoftItemDefaultTtl",
+            primaryKey: {
+              pk: { field: "pk", composite: ["itemId"] },
+              sk: { field: "sk", composite: [] },
+            },
+            softDelete: { ttl: Duration.days(30) },
+          }),
+        )
+
+        mockGetItem.mockResolvedValueOnce({
+          Item: toAttributeMap({
+            itemId: "i-1",
+            name: "Test",
+            pk: "$myapp#v1#softitemdefaultttl#i-1",
+            sk: "$myapp#v1#softitemdefaultttl",
+            __edd_e__: "SoftItemDefaultTtl",
+          }),
+        })
+        mockTransactWriteItems.mockResolvedValueOnce({})
+
+        yield* SoftDeleteTtlEntity.delete({ itemId: "i-1" }).asEffect()
+
+        const call = mockTransactWriteItems.mock.calls[0]![0]
+        const softDeletePut = call.TransactItems[1].Put
+        expect(softDeletePut.Item._ttl).toBeDefined()
+        expect(softDeletePut.Item._ttl.N).toBeDefined()
+        expect(softDeletePut.Item.ttl).toBeUndefined()
       }).pipe(Effect.provide(TestLayer)),
     )
 
@@ -4641,6 +4747,45 @@ describe("Entity", () => {
         // Should not have deletedAt
         expect(restoredPut.Item.deletedAt).toBeUndefined()
       }).pipe(Effect.provide(TestLayer)),
+    )
+
+    it.effect("restore strips the configured TTL attribute (#51)", () =>
+      Effect.gen(function* () {
+        // The soft-deleted item carries a "ttl" attribute (not "_ttl"). Restore
+        // must strip it so the resurrected current item never inherits an
+        // expiry. We seed both the legacy "_ttl" and the configured "ttl"
+        // attributes on the deleted record — the restore path must strip the
+        // configured name and leave the unrelated attribute untouched.
+        mockQuery.mockResolvedValueOnce({
+          Items: [
+            toAttributeMap({
+              itemId: "i-1",
+              name: "Test",
+              createdAt: "2024-01-15T00:00:00Z",
+              updatedAt: "2024-01-15T00:00:00Z",
+              version: 2,
+              deletedAt: "2024-02-01T10:00:00Z",
+              _ttl: 9_999_999_999,
+              ttl: 9_999_999_999,
+              pk: "$myapp#v1#restoreitem#i-1",
+              sk: "$myapp#v1#restoreitem#deleted#2024-02-01T10:00:00Z",
+              __edd_e__: "RestoreItem",
+            }),
+          ],
+          LastEvaluatedKey: undefined,
+        })
+        mockTransactWriteItems.mockResolvedValueOnce({})
+
+        yield* RestoreEntity.restore({ itemId: "i-1" }).asEffect()
+
+        const call = mockTransactWriteItems.mock.calls[0]![0]
+        const restoredPut = call.TransactItems[1].Put
+        // Configured attribute name is stripped.
+        expect(restoredPut.Item.ttl).toBeUndefined()
+        // Legacy "_ttl" left untouched — only the configured name is the
+        // contract surface.
+        expect(restoredPut.Item._ttl).toBeDefined()
+      }).pipe(Effect.provide(TestLayerCustomTtl)),
     )
 
     it.effect("restore with unique constraints re-establishes sentinels", () =>

--- a/packages/effect-dynamodb/test/TimeSeries.test.ts
+++ b/packages/effect-dynamodb/test/TimeSeries.test.ts
@@ -87,6 +87,7 @@ const TestDynamoClient = Layer.succeed(DynamoClient, mockService)
 /** Build a wired entity with a real Table tag. */
 const makeEntityWithTag = <E extends { _configure: (...args: any) => any }>(
   entity: E,
+  opts?: { ttlAttributeName?: string },
 ): { entity: E; tableLayer: Layer.Layer<any> } => {
   // Build a per-test Table definition with only this entity and bind the tag.
   const table = Table.make({
@@ -94,7 +95,11 @@ const makeEntityWithTag = <E extends { _configure: (...args: any) => any }>(
     entities: { Telemetry: entity as any },
   })
   entity._configure(AppSchema, table.Tag)
-  return { entity, tableLayer: table.layer({ name: "test-table" }) }
+  const tableConfig =
+    opts?.ttlAttributeName !== undefined
+      ? { name: "test-table", ttlAttributeName: opts.ttlAttributeName }
+      : { name: "test-table" }
+  return { entity, tableLayer: table.layer(tableConfig) }
 }
 
 // ---------------------------------------------------------------------------
@@ -286,7 +291,7 @@ describe("TimeSeries — append payload shape", () => {
     vi.resetAllMocks()
   })
 
-  const buildEntity = (opts?: { ttl?: Duration.Duration }) => {
+  const buildEntity = (opts?: { ttl?: Duration.Duration; ttlAttributeName?: string }) => {
     const entity = Entity.make({
       model: Telemetry,
       entityType: "Telemetry",
@@ -301,7 +306,12 @@ describe("TimeSeries — append payload shape", () => {
         appendInput: TelemetryAppendInput,
       },
     })
-    return makeEntityWithTag(entity)
+    return makeEntityWithTag(
+      entity,
+      opts?.ttlAttributeName !== undefined
+        ? { ttlAttributeName: opts.ttlAttributeName }
+        : undefined,
+    )
   }
 
   it.effect("builds exactly 2 TransactWriteItems (Update current + Put event)", () => {
@@ -1738,4 +1748,118 @@ describe("TimeSeries — .append().remove() GSI cascade (canonical shapes)", () 
       }).pipe(Effect.provide(layer))
     },
   )
+})
+
+// ---------------------------------------------------------------------------
+// TTL attribute name override (issue #51)
+// ---------------------------------------------------------------------------
+
+describe("TimeSeries — ttlAttributeName override (#51)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  const buildEntity = (opts?: { ttl?: Duration.Duration; ttlAttributeName?: string }) => {
+    const entity = Entity.make({
+      model: Telemetry,
+      entityType: "Telemetry",
+      primaryKey: {
+        pk: { field: "pk", composite: ["channel", "deviceId"] },
+        sk: { field: "sk", composite: [] },
+      },
+      timestamps: true,
+      timeSeries: {
+        orderBy: "timestamp",
+        ...(opts?.ttl ? { ttl: opts.ttl } : {}),
+        appendInput: TelemetryAppendInput,
+      },
+    })
+    return makeEntityWithTag(
+      entity,
+      opts?.ttlAttributeName !== undefined
+        ? { ttlAttributeName: opts.ttlAttributeName }
+        : undefined,
+    )
+  }
+
+  const seedAppendMocks = () => {
+    mockTransactWriteItems.mockResolvedValueOnce({})
+    mockGetItem.mockResolvedValueOnce({
+      Item: {
+        pk: { S: "$tsapp#v1#telemetry#c-1#d-7" },
+        sk: { S: "$tsapp#v1#telemetry_1" },
+        channel: { S: "c-1" },
+        deviceId: { S: "d-7" },
+        timestamp: { S: "2026-04-22T10:00:00.000Z" },
+        __edd_e__: { S: "Telemetry" },
+      },
+    })
+  }
+
+  it.effect("writes TTL to the configured attribute name (custom 'ttl')", () => {
+    const { entity, tableLayer } = buildEntity({
+      ttl: Duration.days(7),
+      ttlAttributeName: "ttl",
+    })
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      seedAppendMocks()
+
+      yield* entity.append({
+        channel: "c-1",
+        deviceId: "d-7",
+        timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+      })
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      const put = call.TransactItems[1].Put
+      // Custom name is used, default name is absent.
+      expect(put.Item.ttl).toBeDefined()
+      expect(put.Item.ttl.N).toBeDefined()
+      expect(put.Item._ttl).toBeUndefined()
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("falls back to default '_ttl' when ttlAttributeName is unset", () => {
+    const { entity, tableLayer } = buildEntity({ ttl: Duration.days(7) })
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      seedAppendMocks()
+
+      yield* entity.append({
+        channel: "c-1",
+        deviceId: "d-7",
+        timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+      })
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      const put = call.TransactItems[1].Put
+      expect(put.Item._ttl).toBeDefined()
+      expect(put.Item._ttl.N).toBeDefined()
+      // A custom attribute name should not leak when none configured.
+      expect(put.Item.ttl).toBeUndefined()
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("custom attribute name has no effect when timeSeries.ttl is omitted", () => {
+    const { entity, tableLayer } = buildEntity({ ttlAttributeName: "ttl" })
+    const layer = Layer.merge(TestDynamoClient, tableLayer)
+
+    return Effect.gen(function* () {
+      seedAppendMocks()
+
+      yield* entity.append({
+        channel: "c-1",
+        deviceId: "d-7",
+        timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+      })
+
+      const call = mockTransactWriteItems.mock.calls[0]![0]
+      const put = call.TransactItems[1].Put
+      expect(put.Item.ttl).toBeUndefined()
+      expect(put.Item._ttl).toBeUndefined()
+    }).pipe(Effect.provide(layer))
+  })
 })

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -3953,3 +3953,243 @@ describeConnected("Empty-composite-half GSI shape (closes #46)", () => {
       }).pipe(provideVehicle),
   )
 })
+
+// ---------------------------------------------------------------------------
+// TTL attribute name override (closes #51)
+//
+// Consumers may have pre-existing tables whose `TimeToLiveSpecification.AttributeName`
+// is not `_ttl` (the library default). This describeConnected block verifies the
+// end-to-end behaviour with `TableConfig.ttlAttributeName: "ttl"` across all
+// three lifecycle features that write TTL — `timeSeries: { ttl }`,
+// `softDelete: { ttl }`, and `versioned: { retain, ttl }` — and the restore
+// path that strips the configured name.
+// ---------------------------------------------------------------------------
+
+class TtlEvent extends Schema.Class<TtlEvent>("TtlEvent")({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  timestamp: Schema.DateTimeUtc,
+  reading: Schema.optional(Schema.Number),
+}) {}
+
+const TtlEventAppendInput = Schema.Struct({
+  channel: Schema.String,
+  deviceId: Schema.String,
+  timestamp: Schema.DateTimeUtc,
+  reading: Schema.optional(Schema.Number),
+})
+
+class TtlSoftItem extends Schema.Class<TtlSoftItem>("TtlSoftItem")({
+  itemId: Schema.String,
+  label: Schema.String,
+}) {}
+
+class TtlRetainItem extends Schema.Class<TtlRetainItem>("TtlRetainItem")({
+  itemId: Schema.String,
+  payload: Schema.String,
+}) {}
+
+const ttlSchema = DynamoSchema.make({ name: "ttl-attr-test", version: 1 })
+const ttlTableName = `ttl-attr-test-${Date.now()}`
+
+const TtlEvents = Entity.make({
+  model: TtlEvent,
+  entityType: "TtlEvent",
+  primaryKey: {
+    pk: { field: "pk", composite: ["channel", "deviceId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  timestamps: true,
+  timeSeries: {
+    orderBy: "timestamp",
+    ttl: Duration.days(7),
+    appendInput: TtlEventAppendInput,
+  },
+})
+
+const TtlSoftItems = Entity.make({
+  model: TtlSoftItem,
+  entityType: "TtlSoftItem",
+  primaryKey: {
+    pk: { field: "pk", composite: ["itemId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  timestamps: true,
+  versioned: true,
+  softDelete: { ttl: Duration.days(30) },
+})
+
+const TtlRetainItems = Entity.make({
+  model: TtlRetainItem,
+  entityType: "TtlRetainItem",
+  primaryKey: {
+    pk: { field: "pk", composite: ["itemId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  timestamps: true,
+  versioned: { retain: true, ttl: Duration.days(90) },
+})
+
+const TtlTable = Table.make({
+  schema: ttlSchema,
+  entities: { TtlEvents, TtlSoftItems, TtlRetainItems },
+})
+const TtlTestLayer = Layer.mergeAll(
+  ClientLayer,
+  TtlTable.layer({ name: ttlTableName, ttlAttributeName: "ttl" }),
+)
+const provideTtl = Effect.provide(TtlTestLayer)
+
+describeConnected("TableConfig.ttlAttributeName override (closes #51)", () => {
+  beforeAll(async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* DynamoClient
+        yield* client.createTable({
+          TableName: ttlTableName,
+          BillingMode: "PAY_PER_REQUEST",
+          ...Table.definition(TtlTable),
+        })
+      }).pipe(provideTtl, Effect.scoped),
+    )
+  }, 15000)
+
+  afterAll(async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* DynamoClient
+        yield* client.deleteTable({ TableName: ttlTableName })
+      }).pipe(
+        provideTtl,
+        Effect.scoped,
+        Effect.catchTag("ResourceNotFoundError", () => Effect.void),
+      ),
+    )
+  }, 15000)
+
+  it.effect("timeSeries event writes TTL to the configured attribute name", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { TtlEvents },
+        tables: { TtlTable },
+      })
+
+      yield* db.entities.TtlEvents.append({
+        channel: "c-cfg-1",
+        deviceId: "d-1",
+        timestamp: DateTime.makeUnsafe("2026-04-22T10:00:00.000Z"),
+      })
+
+      const raw = yield* (yield* DynamoClient).query({
+        TableName: ttlTableName,
+        KeyConditionExpression: "#pk = :pk AND begins_with(#sk, :skPrefix)",
+        ExpressionAttributeNames: { "#pk": "pk", "#sk": "sk" },
+        ExpressionAttributeValues: {
+          ":pk": { S: "$ttl-attr-test#v1#ttlevent#channel_c-cfg-1#deviceid_d-1" },
+          ":skPrefix": { S: "$ttl-attr-test#v1#ttlevent#e#" },
+        },
+      })
+      expect(raw.Items).toBeDefined()
+      expect(raw.Items!.length).toBe(1)
+      const event = raw.Items![0]!
+      // Configured attribute "ttl" carries the epoch-seconds expiry.
+      expect(event.ttl?.N).toBeDefined()
+      const ttlVal = Number(event.ttl!.N)
+      const now = Math.floor(Date.now() / 1000)
+      expect(ttlVal).toBeGreaterThan(now + 6 * 86400)
+      expect(ttlVal).toBeLessThan(now + 8 * 86400)
+      // Library default "_ttl" must NOT be written when override is in effect.
+      expect(event._ttl).toBeUndefined()
+    }).pipe(provideTtl),
+  )
+
+  it.effect("soft-deleted item writes TTL to the configured attribute name", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { TtlSoftItems },
+        tables: { TtlTable },
+      })
+
+      yield* db.entities.TtlSoftItems.put({ itemId: "sd-1", label: "to be deleted" })
+      yield* db.entities.TtlSoftItems.delete({ itemId: "sd-1" })
+
+      // Read the soft-deleted record raw to assert the attribute name.
+      const raw = yield* (yield* DynamoClient).query({
+        TableName: ttlTableName,
+        KeyConditionExpression: "#pk = :pk AND begins_with(#sk, :skPrefix)",
+        ExpressionAttributeNames: { "#pk": "pk", "#sk": "sk" },
+        ExpressionAttributeValues: {
+          ":pk": { S: "$ttl-attr-test#v1#ttlsoftitem#itemid_sd-1" },
+          ":skPrefix": { S: "$ttl-attr-test#v1#ttlsoftitem#deleted#" },
+        },
+      })
+      expect(raw.Items).toBeDefined()
+      expect(raw.Items!.length).toBe(1)
+      const deleted = raw.Items![0]!
+      expect(deleted.ttl?.N).toBeDefined()
+      const ttlVal = Number(deleted.ttl!.N)
+      const now = Math.floor(Date.now() / 1000)
+      // Roughly 30 days from now.
+      expect(ttlVal).toBeGreaterThan(now + 29 * 86400)
+      expect(ttlVal).toBeLessThan(now + 31 * 86400)
+      expect(deleted._ttl).toBeUndefined()
+    }).pipe(provideTtl),
+  )
+
+  it.effect("restore strips the configured TTL attribute from the resurrected item", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { TtlSoftItems },
+        tables: { TtlTable },
+      })
+
+      yield* db.entities.TtlSoftItems.put({ itemId: "sd-2", label: "round-trip" })
+      yield* db.entities.TtlSoftItems.delete({ itemId: "sd-2" })
+      yield* db.entities.TtlSoftItems.restore({ itemId: "sd-2" })
+
+      const raw = yield* (yield* DynamoClient).getItem({
+        TableName: ttlTableName,
+        Key: {
+          pk: { S: "$ttl-attr-test#v1#ttlsoftitem#itemid_sd-2" },
+          sk: { S: "$ttl-attr-test#v1#ttlsoftitem" },
+        },
+      })
+      expect(raw.Item).toBeDefined()
+      // Restored item should not carry the TTL — restore strips the configured name.
+      expect(raw.Item!.ttl).toBeUndefined()
+      expect(raw.Item!._ttl).toBeUndefined()
+    }).pipe(provideTtl),
+  )
+
+  it.effect("versioned snapshot writes TTL to the configured attribute name", () =>
+    Effect.gen(function* () {
+      const db = yield* DynamoClient.make({
+        entities: { TtlRetainItems },
+        tables: { TtlTable },
+      })
+
+      // First put produces a v1 snapshot under the retain config (which has ttl).
+      yield* db.entities.TtlRetainItems.put({ itemId: "rt-1", payload: "initial" })
+
+      const raw = yield* (yield* DynamoClient).query({
+        TableName: ttlTableName,
+        KeyConditionExpression: "#pk = :pk AND begins_with(#sk, :skPrefix)",
+        ExpressionAttributeNames: { "#pk": "pk", "#sk": "sk" },
+        ExpressionAttributeValues: {
+          ":pk": { S: "$ttl-attr-test#v1#ttlretainitem#itemid_rt-1" },
+          ":skPrefix": { S: "$ttl-attr-test#v1#ttlretainitem#v#" },
+        },
+      })
+      expect(raw.Items).toBeDefined()
+      expect(raw.Items!.length).toBe(1)
+      const snapshot = raw.Items![0]!
+      expect(snapshot.ttl?.N).toBeDefined()
+      const ttlVal = Number(snapshot.ttl!.N)
+      const now = Math.floor(Date.now() / 1000)
+      // Roughly 90 days from now.
+      expect(ttlVal).toBeGreaterThan(now + 89 * 86400)
+      expect(ttlVal).toBeLessThan(now + 91 * 86400)
+      expect(snapshot._ttl).toBeUndefined()
+    }).pipe(provideTtl),
+  )
+})

--- a/packages/language-service/CHANGELOG.md
+++ b/packages/language-service/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @effect-dynamodb/language-service
 
+## 1.8.0
+
+### Minor Changes
+
+- Add `TableConfig.ttlAttributeName` (default `"_ttl"`) so the library writes TTL values to a configurable attribute name instead of the hardcoded `_ttl`. Closes [#51](https://github.com/jmenga/effect-dynamodb/issues/51).
+
+  A single setting applies to every lifecycle feature on the physical table — `timeSeries: { ttl }`, `softDelete: { ttl }`, and `versioned: { retain, ttl }` write to the same attribute and `Entity.restore()` strips it. This matches DynamoDB's per-table `TimeToLiveSpecification.AttributeName`, which permits exactly one TTL attribute.
+
+  ```ts
+  const MainTable = Table.make({ schema, entities: { Users } });
+
+  // Default (unchanged): writes to "_ttl"
+  MainTable.layer({ name: "users-prod" });
+
+  // Override: align with a TimeToLiveSpecification.AttributeName = "ttl"
+  MainTable.layer({ name: "users-prod", ttlAttributeName: "ttl" });
+
+  // Or from Effect Config
+  MainTable.layerConfig({
+    name: Config.string("TABLE_NAME"),
+    ttlAttributeName: Config.string("TTL_ATTR").pipe(
+      Config.withDefault("_ttl"),
+    ),
+  });
+  ```
+
+  This is fully backwards compatible — consumers who don't set the field continue to write to `_ttl`. Use it to align the library's writes with a pre-existing or migrated DynamoDB table whose TTL attribute differs, without the destructive table replacement or multi-deploy DDB rename dance.
+
 ## 1.7.4
 
 ### Patch Changes

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/language-service",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "TypeScript Language Service Plugin for effect-dynamodb — shows DynamoDB operations on hover",
   "license": "MIT",
   "author": "Justin Menga",


### PR DESCRIPTION
## Summary

- Adds `TableConfig.ttlAttributeName` (default `"_ttl"`) so the library writes TTL values to a configurable attribute name across every lifecycle feature on a physical table — `timeSeries: { ttl }`, `softDelete: { ttl }`, and `versioned: { retain, ttl }` write to the same attribute, and `Entity.restore()` strips it.
- The default `"_ttl"` is preserved — fully backwards-compatible. Set the override to align with a pre-existing or migrated DynamoDB table whose `TimeToLiveSpecification.AttributeName` differs (e.g. `"ttl"`), avoiding the destructive table replacement or multi-deploy DDB rename dance.
- Table-level (not per-feature) because DynamoDB allows exactly one TTL attribute per table. The issue proposed a `timeSeries`-scoped knob; broadening to the table level prevents the latent footgun where versioned snapshots / soft-deleted items continue targeting `_ttl` while timeSeries events target a different name on the same table — DDB would silently sweep neither.

Closes #51.

## API

```ts
const MainTable = Table.make({ schema, entities: { Users } })

// Default (unchanged): writes to "_ttl"
MainTable.layer({ name: "users-prod" })

// Override: align with a TimeToLiveSpecification.AttributeName = "ttl"
MainTable.layer({ name: "users-prod", ttlAttributeName: "ttl" })

// Or from Effect Config
MainTable.layerConfig({
  name: Config.string("TABLE_NAME"),
  ttlAttributeName: Config.string("TTL_ATTR").pipe(Config.withDefault("_ttl")),
})
```

## Implementation

- `TableConfig` gains `ttlAttributeName?: string | undefined`
- `Table.layer()` / `Table.layerConfig()` accept the new optional field
- `resolveTtlAttributeName(tc)` returns `tc.ttlAttributeName ?? "_ttl"`
- Four `_ttl` write sites in `Entity.ts` (snapshot, softDelete, timeSeries event, restore strip) now resolve the attribute name from the runtime `TableConfig` resolved via the entity's `tableTag`

## Test plan

- [x] Unit: 7 new tests across `TimeSeries.test.ts` and `Entity.test.ts` covering the override + default-fallback across all three lifecycle features (timeSeries event, versioned snapshot, soft-delete item, restore strip)
- [x] Connected: 4 new tests against DDB Local exercising timeSeries event TTL, soft-delete TTL, restore strip, and versioned snapshot TTL with the configured `"ttl"` attribute end-to-end
- [x] Docs: `guides/timeseries.mdx` includes an illustrative API block plus a sync-checked `ttl-attribute-name` example region backed by `examples/guide-timeseries.ts`
- [x] Example runs end-to-end against DDB Local

## Quality gates

- [x] `pnpm lint` — clean (Biome formatter ran)
- [x] `pnpm check` — zero type errors across the workspace
- [x] `pnpm test` — 1081 unit tests pass + 47 doctest + 56 geo tests
- [x] `pnpm --filter effect-dynamodb test:connected` — 118 connected tests pass (DDB Local)
- [x] `pnpm --filter @effect-dynamodb/doctest test` — 47 sync/typecheck/runtime tests pass

## Versioning

Lockstep minor bump: 1.7.4 → 1.8.0 (additive, non-breaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)