### PR TITLE
fix(language-service): EDD-9002 false positive on ref-derived `${field}Id` composites

### DIFF
--- a/packages/docs/src/content/docs/guides/validations.mdx
+++ b/packages/docs/src/content/docs/guides/validations.mdx
@@ -80,6 +80,14 @@ const Users = Entity.make({
 
 **Fix:** Use field names that exist on the model, or add the field to the model.
 
+:::note[Ref-derived composites]
+For a field configured as a [ref](/effect-dynamodb/guides/aggregates/), the composite must reference the
+surfaced identifier attribute `<field>Id`, **not** the bare field name. A `team` ref is
+exposed in the key/input schema as `teamId`, so `composite: ["teamId"]` is correct and
+`composite: ["team"]` is the error. The diagnostic recognises every `${field}Id` derived
+from the entity's `refs` config as a valid composite attribute.
+:::
+
 ### EDD-9003: Invalid GSI Format
 
 GSI indexes must use the new format with `name`, `pk: { field, composite }`, and `sk: { field, composite }`.

--- a/packages/effect-dynamodb-geo/CHANGELOG.md
+++ b/packages/effect-dynamodb-geo/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @effect-dynamodb/geo
 
+## 1.8.2
+
+### Patch Changes
+
+- Fix EDD-9002 false positive on ref-derived `<field>Id` composites in the language-service. Closes [#54](https://github.com/jmenga/effect-dynamodb/issues/54).
+
+  Index and primary-key composites that reference a ref's surfaced identifier attribute (e.g. `teamId` for a `team` ref) were incorrectly flagged as unknown attributes. The diagnostic's valid-attribute set was derived only from the model schema's read-side fields and never accounted for the `${field}Id` substitution the runtime applies for `refs`.
+
+  The diagnostic now mirrors the runtime key/input schema: each field listed in the entity's `refs` config is removed from the valid-composite set and replaced by its `<field>Id` form. Referencing the bare ref field name (e.g. `team`) is still reported as an error, matching what `tsc` rejects.
+
 ## 1.8.1
 
 ### Patch Changes

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/geo",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Geospatial index and search for effect-dynamodb using H3 hexagonal grid",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/CHANGELOG.md
+++ b/packages/effect-dynamodb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # effect-dynamodb
 
+## 1.8.2
+
+### Patch Changes
+
+- Fix EDD-9002 false positive on ref-derived `<field>Id` composites in the language-service. Closes [#54](https://github.com/jmenga/effect-dynamodb/issues/54).
+
+  Index and primary-key composites that reference a ref's surfaced identifier attribute (e.g. `teamId` for a `team` ref) were incorrectly flagged as unknown attributes. The diagnostic's valid-attribute set was derived only from the model schema's read-side fields and never accounted for the `${field}Id` substitution the runtime applies for `refs`.
+
+  The diagnostic now mirrors the runtime key/input schema: each field listed in the entity's `refs` config is removed from the valid-composite set and replaced by its `<field>Id` form. Referencing the bare ref field name (e.g. `team`) is still reported as an error, matching what `tsc` rejects.
+
 ## 1.8.1
 
 ### Patch Changes

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-dynamodb",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Effect TS ORM for DynamoDB — schema-driven entity modeling, single-table design, composite keys, transactions, and Stream-based pagination",
   "type": "module",
   "license": "MIT",

--- a/packages/language-service/CHANGELOG.md
+++ b/packages/language-service/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @effect-dynamodb/language-service
 
+## 1.8.2
+
+### Patch Changes
+
+- Fix EDD-9002 false positive on ref-derived `<field>Id` composites in the language-service. Closes [#54](https://github.com/jmenga/effect-dynamodb/issues/54).
+
+  Index and primary-key composites that reference a ref's surfaced identifier attribute (e.g. `teamId` for a `team` ref) were incorrectly flagged as unknown attributes. The diagnostic's valid-attribute set was derived only from the model schema's read-side fields and never accounted for the `${field}Id` substitution the runtime applies for `refs`.
+
+  The diagnostic now mirrors the runtime key/input schema: each field listed in the entity's `refs` config is removed from the valid-composite set and replaced by its `<field>Id` form. Referencing the bare ref field name (e.g. `team`) is still reported as an error, matching what `tsc` rejects.
+
 ## 1.8.1
 
 ### Patch Changes

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/language-service",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "TypeScript Language Service Plugin for effect-dynamodb — shows DynamoDB operations on hover",
   "license": "MIT",
   "author": "Justin Menga",

--- a/packages/language-service/src/features/diagnostics.ts
+++ b/packages/language-service/src/features/diagnostics.ts
@@ -193,8 +193,12 @@ function tryValidateEntityMake(
 
   const diagnostics: ts.Diagnostic[] = []
 
-  // Extract model field names via TypeChecker
-  const modelFields = extractModelFields(ts, configArg, program)
+  // Extract model field names via TypeChecker, then apply ref-derived `${field}Id`
+  // substitution so composites referencing a ref's surfaced ID attribute (e.g.
+  // `teamId` for a `team` ref) are recognised as valid. See applyRefFields.
+  const baseModelFields = extractModelFields(ts, configArg, program)
+  const refFields = extractRefFields(ts, configArg)
+  const modelFields = applyRefFields(baseModelFields, refFields)
 
   // Extract entityType for error messages
   let entityType = "unknown"
@@ -678,6 +682,58 @@ function extractModelFields(
   }
 
   return undefined
+}
+
+/**
+ * Extract the set of ref field names from the `refs` property of an
+ * Entity.make() config: `refs: { team: { entity: Teams }, player: { ... } }`
+ * → `{ team, player }`.
+ *
+ * The runtime surfaces a ref field `team` in the entity's key/input schemas as
+ * `${field}Id` (e.g. `teamId`) and removes the bare field — the `refs` keys are
+ * the authoritative signal for which fields are refs (the runtime builds its
+ * resolvedRefs list solely from `config.refs`). See
+ * `internal/EntitySchemas.ts` (input/create/update ref substitution) and
+ * `Entity.ts` (`idFieldName: \`${fieldName}Id\``).
+ */
+function extractRefFields(
+  ts: typeof import("typescript"),
+  config: ts.ObjectLiteralExpression,
+): ReadonlySet<string> {
+  const refFields = new Set<string>()
+  for (const prop of config.properties) {
+    if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue
+    if (prop.name.text !== "refs") continue
+    if (!ts.isObjectLiteralExpression(prop.initializer)) continue
+    for (const refProp of prop.initializer.properties) {
+      if (ts.isPropertyAssignment(refProp) && ts.isIdentifier(refProp.name)) {
+        refFields.add(refProp.name.text)
+      } else if (ts.isShorthandPropertyAssignment(refProp)) {
+        refFields.add(refProp.name.text)
+      }
+    }
+  }
+  return refFields
+}
+
+/**
+ * Apply ref-derived `${field}Id` substitution to the valid-composite set,
+ * mirroring the runtime key/input schema: each ref field is removed and its
+ * surfaced `${field}Id` attribute is added in its place. Composites must
+ * reference `teamId`, not the bare `team`, so the substitution both adds the ID
+ * form and drops the original — matching what `tsc` accepts.
+ */
+function applyRefFields(
+  modelFields: ReadonlySet<string> | undefined,
+  refFields: ReadonlySet<string>,
+): ReadonlySet<string> | undefined {
+  if (!modelFields || refFields.size === 0) return modelFields
+  const adjusted = new Set(modelFields)
+  for (const refField of refFields) {
+    adjusted.delete(refField)
+    adjusted.add(`${refField}Id`)
+  }
+  return adjusted
 }
 
 /** Extract field names from a Schema.Class type or ConfiguredModel type. */

--- a/packages/language-service/test/Diagnostics.test.ts
+++ b/packages/language-service/test/Diagnostics.test.ts
@@ -255,6 +255,137 @@ describe("Diagnostics", () => {
       )
       expect(unknownAttr).toHaveLength(0)
     })
+
+    it("EDD-9002: no false positive for ref-derived <field>Id composites (#54)", () => {
+      const source = `
+        const TeamPlayerSelections = Entity.make({
+          model: TeamPlayerSelection,
+          entityType: "TeamPlayerSelection",
+          primaryKey: {
+            pk: { field: "pk", composite: ["id"] },
+            sk: { field: "sk", composite: [] },
+          },
+          indexes: {
+            byTeam: {
+              name: "gsi6",
+              pk: { field: "gsi6pk", composite: ["teamId"] },
+              sk: { field: "gsi6sk", composite: ["league", "season"] },
+            },
+            byPlayer: {
+              name: "gsi7",
+              pk: { field: "gsi7pk", composite: ["playerId"] },
+              sk: { field: "gsi7sk", composite: ["league"] },
+            },
+          },
+          refs: {
+            team: { entity: Teams },
+            player: { entity: Players },
+          },
+        })
+      `
+      const sf = parseSource(source)
+      // Model exposes the bare ref fields `team` / `player` (no `teamId`/`playerId`)
+      const info = mockInfoWithModelFields(sf, [
+        "id",
+        "team",
+        "player",
+        "league",
+        "season",
+        "series",
+        "matchType",
+        "role",
+      ])
+      const diagnostics = getDiagnostics(ts, info, "test.ts", [])
+
+      const unknownAttr = diagnostics.filter(
+        (d) => d.code === DiagnosticCode.UNKNOWN_COMPOSITE_ATTR,
+      )
+      expect(unknownAttr).toHaveLength(0)
+    })
+
+    it("EDD-9002: ref substitution also accepts ref-derived composite in the primary key", () => {
+      const source = `
+        const Memberships = Entity.make({
+          model: Membership,
+          entityType: "Membership",
+          primaryKey: {
+            pk: { field: "pk", composite: ["teamId"] },
+            sk: { field: "sk", composite: ["playerId"] },
+          },
+          refs: {
+            team: { entity: Teams },
+            player: { entity: Players },
+          },
+        })
+      `
+      const sf = parseSource(source)
+      const info = mockInfoWithModelFields(sf, ["team", "player", "joinedAt"])
+      const diagnostics = getDiagnostics(ts, info, "test.ts", [])
+
+      const unknownAttr = diagnostics.filter(
+        (d) => d.code === DiagnosticCode.UNKNOWN_COMPOSITE_ATTR,
+      )
+      expect(unknownAttr).toHaveLength(0)
+    })
+
+    it("EDD-9002: still flags the bare ref field name (replaced by <field>Id)", () => {
+      const source = `
+        const Memberships = Entity.make({
+          model: Membership,
+          entityType: "Membership",
+          primaryKey: {
+            pk: { field: "pk", composite: ["team"] },
+            sk: { field: "sk", composite: [] },
+          },
+          refs: {
+            team: { entity: Teams },
+          },
+        })
+      `
+      const sf = parseSource(source)
+      const info = mockInfoWithModelFields(sf, ["team", "joinedAt"])
+      const diagnostics = getDiagnostics(ts, info, "test.ts", [])
+
+      // The bare `team` is removed from the valid set (replaced by `teamId`), so
+      // referencing it is a genuine error — mirrors what `tsc` rejects.
+      const unknownAttr = diagnostics.filter(
+        (d) => d.code === DiagnosticCode.UNKNOWN_COMPOSITE_ATTR,
+      )
+      expect(unknownAttr).toHaveLength(1)
+      expect(unknownAttr[0]!.messageText).toContain("`team`")
+    })
+
+    it("EDD-9002: still flags genuinely unknown attributes when refs are present", () => {
+      const source = `
+        const TeamPlayerSelections = Entity.make({
+          model: TeamPlayerSelection,
+          entityType: "TeamPlayerSelection",
+          primaryKey: {
+            pk: { field: "pk", composite: ["id"] },
+            sk: { field: "sk", composite: [] },
+          },
+          indexes: {
+            byTeam: {
+              name: "gsi6",
+              pk: { field: "gsi6pk", composite: ["teamId"] },
+              sk: { field: "gsi6sk", composite: ["nonExistent"] },
+            },
+          },
+          refs: {
+            team: { entity: Teams },
+          },
+        })
+      `
+      const sf = parseSource(source)
+      const info = mockInfoWithModelFields(sf, ["id", "team", "league"])
+      const diagnostics = getDiagnostics(ts, info, "test.ts", [])
+
+      const unknownAttr = diagnostics.filter(
+        (d) => d.code === DiagnosticCode.UNKNOWN_COMPOSITE_ATTR,
+      )
+      expect(unknownAttr).toHaveLength(1)
+      expect(unknownAttr[0]!.messageText).toContain("`nonExistent`")
+    })
   })
 
   describe("DynamoModel.configure validations", () => {


### PR DESCRIPTION
## Summary

Fixes a confirmed false positive in `@effect-dynamodb/language-service`: **EDD-9002 (UNKNOWN_COMPOSITE_ATTR)** was raised for index/primary-key composites that reference a **ref-derived `<field>Id` attribute** (e.g. `teamId` for a `team` ref). These names are valid at the type level (`tsc` accepts them) and are exactly what the runtime expects, so the diagnostic was wrong — not the code.

Closes #54.

## Root cause

In `packages/language-service/src/features/diagnostics.ts`, the valid-attribute set (`modelFields`) was derived **only** from the model schema's read-side `Type` properties. The config walk handled `{ field }` renames but **ignored `refs`**, and nothing constructed the `<field>Id` name. So ref-derived composite names were never added to `modelFields`, and EDD-9002 rejected them.

## Fix

Mirror the runtime key/input schema derivation (`internal/EntitySchemas.ts`, `Entity.ts`). The `refs` config keys are the authoritative signal for which fields are refs — the runtime builds its `resolvedRefs` list solely from `config.refs`. When building the valid-composite set, each ref field is **removed** and its surfaced `<field>Id` form is **added** in its place:

- `composite: ["teamId"]` → ✅ valid (matches `tsc`)
- `composite: ["team"]` → ❌ still an error (the bare ref field is replaced; `tsc` rejects it too)

Two small pure helpers — `extractRefFields` (AST walk of the `refs` property) and `applyRefFields` (set substitution) — feed the existing EDD-9002 checks in `validatePrimaryKey` and `validateGsiIndexes`.

## Tests

4 new `Diagnostics.test.ts` cases, **all verified to fail without the fix and pass with it**:

1. No false positive for ref-derived `<field>Id` composites on GSIs (the #54 repro)
2. Ref-derived composite accepted in the **primary key** too
3. Bare ref field name (`team`) is **still flagged** (replaced by `teamId`)
4. Genuinely unknown attributes are **still flagged** when refs are present

## Validation

- ✅ `pnpm lint` — clean
- ✅ `pnpm check` — clean (all packages, incl. docs astro check)
- ✅ `pnpm test` — full workspace suite green (language-service 71, core 1087, geo 56, doctest 47)
- ✅ New tests fail on a reverted `diagnostics.ts` (guards against no-op tests)

The connected suite (gate 4) is **not applicable** — this change is confined to the language-service diagnostics and touches none of `KeyComposer`, `Entity`, `Query`, `Collection`, `Transaction`, `Aggregate`, `EventStore`, `Errors`, or the `internal/` Entity helpers.

## Docs & release

- Documented the ref-derived composite exception under **EDD-9002** in `guides/validations.mdx`.
- Changeset consumed via `pnpm changeset version` — lockstep patch bump **1.8.1 → 1.8.2** across all three publishable packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
