### PR TITLE
feat: post-beta.74 improvements — generatedId, TTL, DateTime.now, AST hardening

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -450,8 +450,17 @@ The entity definition still provides type derivation (`Entity.Record<typeof User
 | Config | Type | Fields Added |
 |--------|------|-------------|
 | `timestamps: true` | `boolean \| { created: string, updated: string }` | `createdAt`, `updatedAt` (or custom names) |
-| `versioned: true` | `boolean \| { field?: string, retain?: boolean, ttl?: Duration }` | `version` (or custom name) |
-| `softDelete: true` | `boolean \| { ttl?: Duration, preserveUnique?: boolean }` | `deletedAt` (when soft-deleted) |
+| `versioned: true` | `boolean \| { field?: string, retain?: boolean, ttl?: TtlInput }` | `version` (or custom name) |
+| `softDelete: true` | `boolean \| { ttl?: TtlInput, preserveUnique?: boolean }` | `deletedAt` (when soft-deleted) |
+
+**`TtlInput`** — every lifecycle `ttl` (`versioned`, `softDelete`, `timeSeries`,
+`unique`) accepts `Duration.Duration | \`${number} ${Duration.Unit}\``, i.e. an
+Effect `Duration` (`Duration.days(7)`) **or** a duration-string literal
+(`"7 days"`, `"24 hours"`, `"30 minutes"`). A bare `number` is rejected at compile
+time — `Duration` treats a number as milliseconds, so `3600` would silently mean
+3.6s, not an hour. TTL is **relative**: the stored epoch is `now + offset`, where
+`now` comes from the ambient `Clock` (`DateTime.now`). A non-finite duration
+(e.g. `Duration.infinity`) is rejected at `make()` time with **`[EDD-9020]`**.
 
 ### Unique Constraints
 
@@ -469,6 +478,13 @@ missing optional composite is silently excluded from the constraint, allowing
 multiple records to coexist with the field unset (no false collision on a
 literal `"undefined"` key). Update transitions claim/release the sentinel as
 the field becomes set/unset.
+
+The object form `{ fields, ttl }` gives the sentinel item a relative TTL
+(`now + ttl`): DynamoDB auto-deletes the sentinel after the offset, releasing
+the uniqueness reservation. The TTL is re-applied whenever the sentinel is
+written — on create, on update-rotation to a new value, and on restore. This
+backs the idempotency-key pattern (a time-bounded "processed once" marker). The
+bare field-list form (`["email"]`) never carries a TTL.
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -460,7 +460,38 @@ Effect `Duration` (`Duration.days(7)`) **or** a duration-string literal
 time — `Duration` treats a number as milliseconds, so `3600` would silently mean
 3.6s, not an hour. TTL is **relative**: the stored epoch is `now + offset`, where
 `now` comes from the ambient `Clock` (`DateTime.now`). A non-finite duration
-(e.g. `Duration.infinity`) is rejected at `make()` time with **`[EDD-9020]`**.
+(e.g. `Duration.infinity`) is rejected at `make()` time with **`[EDD-9017]`**.
+
+### Generated IDs
+
+```typescript
+Entity.make({
+  model: Doc,                 // Doc has an `id: Schema.String` field
+  entityType: "Doc",
+  primaryKey: { pk: { field: "pk", composite: ["id"] }, sk: { field: "sk", composite: [] } },
+  generatedId: { field: "id", version: "v4" },  // version: "v4" (default) | "v7"
+})
+
+// `id` is optional on put/create — omit it and a UUID is generated:
+const doc = yield* db.entities.Doc.put({ title: "Hello" })
+doc.id // "f93de86c-1461-4163-b689-bb8e7d58d219"
+```
+
+`generatedId` fills the named field with a **cryptographically-secure UUID** when
+the caller omits it on `put`/`create`. The value is sourced from the Effect
+`Crypto` service (a default instance backed by the platform Web Crypto CSPRNG,
+built once at module load) — `version: "v4"` (random, default) or `"v7"`
+(time-ordered/sortable). A caller-supplied value always wins.
+
+- The field becomes **optional** in the `put`/`create` input type (and is filled
+  before key composition, so it flows into the key, the stored item, and the
+  decoded record).
+- The field MUST be a model field that participates in the primary key, enforced
+  at `make()` with **`[EDD-9030]`**.
+- Generation uses a concrete `Crypto` instance whose effects have `R = never`, so
+  the bound client's `R = never` guarantee is preserved — no layer wiring needed.
+- Scope: `put`/`create`. `batchWrite`/`transactWrite` puts still require an
+  explicit id.
 
 ### Unique Constraints
 

--- a/packages/docs/src/content/docs/guides/lifecycle.mdx
+++ b/packages/docs/src/content/docs/guides/lifecycle.mdx
@@ -199,6 +199,10 @@ softDelete: { ttl: Duration.days(30) }
 
 The TTL is set on the DynamoDB item's TTL attribute when the item is soft-deleted. DynamoDB's background process handles cleanup.
 
+:::tip[Duration or string]
+Every lifecycle `ttl` (`versioned`, `softDelete`, `timeSeries`, and `unique`) accepts either an Effect `Duration` or a duration-string literal — `ttl: Duration.days(30)` and `ttl: "30 days"` are equivalent. A bare number is rejected at compile time (a `Duration` number means *milliseconds*), and a non-finite duration is rejected at `make()` time (`[EDD-9020]`). The stored expiry is relative: `now + ttl`, where `now` comes from the ambient `Clock`.
+:::
+
 Note: DynamoDB TTL deletion is eventually consistent — items may persist slightly beyond the TTL.
 
 ## Version Retention

--- a/packages/docs/src/content/docs/guides/modeling.mdx
+++ b/packages/docs/src/content/docs/guides/modeling.mdx
@@ -273,6 +273,46 @@ softDelete: { ttl: Duration.days(30), preserveUnique: true }
 
 See [Lifecycle](/effect-dynamodb/guides/lifecycle/) for details on versioning and soft delete.
 
+### Generated IDs
+
+Auto-fill a primary-key field with a cryptographically-secure UUID when the caller omits it. Use `version: "v4"` (random, default) or `"v7"` (time-ordered/sortable):
+
+```typescript region="entities" example="generated-id.ts"
+// `id` is filled with a random UUIDv4 when omitted on put/create.
+const Documents = Entity.make({
+  model: Document,
+  entityType: "Document",
+  primaryKey: {
+    pk: { field: "pk", composite: ["id"] },
+    sk: { field: "sk", composite: [] },
+  },
+  generatedId: { field: "id" },
+})
+
+// `eventId` is filled with a time-ordered UUIDv7 (sortable by creation time).
+const Events = Entity.make({
+  model: Event,
+  entityType: "Event",
+  primaryKey: {
+    pk: { field: "pk", composite: ["eventId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  generatedId: { field: "eventId", version: "v7" },
+})
+```
+
+On `put`/`create` the field becomes optional — omit it and a UUID is generated and returned on the decoded record:
+
+```typescript region="put-without-id" example="generated-id.ts"
+// Omit `id` — the framework generates a crypto-secure UUIDv4.
+const doc = yield* db.entities.Documents.put({ title: "Hello, world" })
+
+// The generated id composes the primary key, so the item is fetchable.
+const fetched = yield* db.entities.Documents.get({ id: doc.id })
+```
+
+The field must participate in the primary key. A caller-supplied value always wins. Generation uses a default `Crypto` instance (Web Crypto CSPRNG), so the bound client keeps `R = never` — no layer wiring required. Scope is `put`/`create`; batch and transaction puts still require an explicit id.
+
 ### Unique Constraints
 
 ```typescript

--- a/packages/effect-dynamodb-geo/CHANGELOG.md
+++ b/packages/effect-dynamodb-geo/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @effect-dynamodb/geo
 
+## 1.9.0
+
+### Minor Changes
+
+- Post-beta.74 improvements surfaced while reviewing new Effect v4 features.
+  - **`generatedId` ([#57](https://github.com/jmenga/effect-dynamodb/issues/57))** — `Entity.make({ generatedId: { field, version? } })` auto-fills a primary-key field with a cryptographically-secure UUID (v4 default, or time-ordered v7) when omitted on `put`/`create`. Sourced from the Effect `Crypto` module via a default instance, so the bound client keeps `R = never` with no layer wiring. The field is type-level optional on put/create and validated to be a primary-key model field (`[EDD-9030]`).
+  - **TTL: `unique.ttl` + `Duration | string` ([#58](https://github.com/jmenga/effect-dynamodb/issues/58))** — the previously-dead `unique: { fields, ttl }` config now expires the constraint's sentinel item (relative TTL, re-applied on create/rotate/restore). Every lifecycle `ttl` (`versioned`, `softDelete`, `timeSeries`, `unique`) now accepts a duration-string literal (`"30 days"`) alongside `Duration`; a bare number is rejected at compile time and a non-finite duration at `make()` (`[EDD-9017]`).
+  - **`DateTime.now` time source ([#56](https://github.com/jmenga/effect-dynamodb/issues/56))** — all write-path timestamps and TTLs now read the ambient `Clock` via `DateTime.now` instead of raw `Date.now()`/`new Date()` (a standing rule violation). Production behavior is unchanged; timestamps + TTL are now deterministic under `TestClock`.
+  - **Schema AST hardening ([#55](https://github.com/jmenga/effect-dynamodb/issues/55))** — internal schema-derivation reads use the typed `SchemaAST` guards (`isArrays`, `isObjects`, `isString`/`isNumber`) and accessors (`.value`, typed `.fields`/`.context`/`.encoding`) instead of `as any`/raw `_tag` poking, with AST-shape probe tests so a future Effect bump fails loudly instead of silently mis-deriving keys.
+
 ## 1.8.1
 
 ### Patch Changes

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/geo",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Geospatial index and search for effect-dynamodb using H3 hexagonal grid",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb-geo/src/GeoSearch.ts
+++ b/packages/effect-dynamodb-geo/src/GeoSearch.ts
@@ -7,7 +7,7 @@
  * @internal Used by GeoIndex — consumers should use `GeoIndex.nearby()`.
  */
 
-import { type Context, Effect, Schema } from "effect"
+import { Clock, type Context, Effect, Schema } from "effect"
 import type { DynamoClientError, DynamoSchema, Table } from "effect-dynamodb"
 import { type DynamoClient, KeyComposer, Query, ValidationError } from "effect-dynamodb"
 import * as h3 from "h3-js"
@@ -72,8 +72,8 @@ export const nearby = <A>(
     // Step 5: Group into contiguous chunks for BETWEEN queries
     const sortedChunks = H3.sequentialChunk(prunedCells.flat())
 
-    // Step 6: Time partitions
-    const now = Date.now()
+    // Step 6: Time partitions — current time from the ambient Clock.
+    const now = yield* Clock.currentTimeMillis
     const startTime = options.timeWindow?.start ?? now - 15 * 60 * 1000
     const endTime = options.timeWindow?.end ?? now
     const timePartitions = H3.getTimePartitions(startTime, endTime, config.bucketMs)

--- a/packages/effect-dynamodb/CHANGELOG.md
+++ b/packages/effect-dynamodb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # effect-dynamodb
 
+## 1.9.0
+
+### Minor Changes
+
+- Post-beta.74 improvements surfaced while reviewing new Effect v4 features.
+  - **`generatedId` ([#57](https://github.com/jmenga/effect-dynamodb/issues/57))** — `Entity.make({ generatedId: { field, version? } })` auto-fills a primary-key field with a cryptographically-secure UUID (v4 default, or time-ordered v7) when omitted on `put`/`create`. Sourced from the Effect `Crypto` module via a default instance, so the bound client keeps `R = never` with no layer wiring. The field is type-level optional on put/create and validated to be a primary-key model field (`[EDD-9030]`).
+  - **TTL: `unique.ttl` + `Duration | string` ([#58](https://github.com/jmenga/effect-dynamodb/issues/58))** — the previously-dead `unique: { fields, ttl }` config now expires the constraint's sentinel item (relative TTL, re-applied on create/rotate/restore). Every lifecycle `ttl` (`versioned`, `softDelete`, `timeSeries`, `unique`) now accepts a duration-string literal (`"30 days"`) alongside `Duration`; a bare number is rejected at compile time and a non-finite duration at `make()` (`[EDD-9017]`).
+  - **`DateTime.now` time source ([#56](https://github.com/jmenga/effect-dynamodb/issues/56))** — all write-path timestamps and TTLs now read the ambient `Clock` via `DateTime.now` instead of raw `Date.now()`/`new Date()` (a standing rule violation). Production behavior is unchanged; timestamps + TTL are now deterministic under `TestClock`.
+  - **Schema AST hardening ([#55](https://github.com/jmenga/effect-dynamodb/issues/55))** — internal schema-derivation reads use the typed `SchemaAST` guards (`isArrays`, `isObjects`, `isString`/`isNumber`) and accessors (`.value`, typed `.fields`/`.context`/`.encoding`) instead of `as any`/raw `_tag` poking, with AST-shape probe tests so a future Effect bump fails loudly instead of silently mis-deriving keys.
+
 ## 1.8.1
 
 ### Patch Changes

--- a/packages/effect-dynamodb/examples/generated-id.ts
+++ b/packages/effect-dynamodb/examples/generated-id.ts
@@ -1,0 +1,126 @@
+/**
+ * Generated IDs example — effect-dynamodb
+ *
+ * Demonstrates:
+ *   - `generatedId` entity option: auto-fill a primary-key field with a
+ *     cryptographically-secure UUID when the caller omits it
+ *   - `version: "v4"` (random, default) vs `"v7"` (time-ordered/sortable)
+ *   - A caller-supplied id always wins
+ *
+ * Prerequisites:
+ *   docker run -p 8000:8000 amazon/dynamodb-local
+ *
+ * Run:
+ *   npx tsx examples/generated-id.ts
+ */
+
+import { Console, Effect, Layer, Schema } from "effect"
+
+// Import from source (use "effect-dynamodb" when published)
+import { DynamoClient } from "../src/DynamoClient.js"
+import * as DynamoSchema from "../src/DynamoSchema.js"
+import * as Entity from "../src/Entity.js"
+import * as Table from "../src/Table.js"
+
+// ---------------------------------------------------------------------------
+// 1. Domain models
+// ---------------------------------------------------------------------------
+
+// #region models
+class Document extends Schema.Class<Document>("Document")({
+  id: Schema.String,
+  title: Schema.String,
+}) {}
+
+class Event extends Schema.Class<Event>("Event")({
+  eventId: Schema.String,
+  kind: Schema.String,
+}) {}
+// #endregion
+
+const AppSchema = DynamoSchema.make({ name: "genid-demo", version: 1 })
+
+// ---------------------------------------------------------------------------
+// 2. Entity definitions with generatedId
+// ---------------------------------------------------------------------------
+
+// #region entities
+// `id` is filled with a random UUIDv4 when omitted on put/create.
+const Documents = Entity.make({
+  model: Document,
+  entityType: "Document",
+  primaryKey: {
+    pk: { field: "pk", composite: ["id"] },
+    sk: { field: "sk", composite: [] },
+  },
+  generatedId: { field: "id" },
+})
+
+// `eventId` is filled with a time-ordered UUIDv7 (sortable by creation time).
+const Events = Entity.make({
+  model: Event,
+  entityType: "Event",
+  primaryKey: {
+    pk: { field: "pk", composite: ["eventId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  generatedId: { field: "eventId", version: "v7" },
+})
+// #endregion
+
+const MainTable = Table.make({
+  schema: AppSchema,
+  entities: { Documents, Events },
+})
+
+// ---------------------------------------------------------------------------
+// 3. Main program
+// ---------------------------------------------------------------------------
+
+const program = Effect.gen(function* () {
+  const db = yield* DynamoClient.make({ entities: { Documents, Events } })
+
+  yield* db.tables["genid-demo-table"]!.create()
+
+  // #region put-without-id
+  // Omit `id` — the framework generates a crypto-secure UUIDv4.
+  const doc = yield* db.entities.Documents.put({ title: "Hello, world" })
+  yield* Console.log(`Generated id: ${doc.id}`) // e.g. f93de86c-1461-4163-...
+
+  // The generated id composes the primary key, so the item is fetchable.
+  const fetched = yield* db.entities.Documents.get({ id: doc.id })
+  yield* Console.log(`Fetched: ${fetched.title}`)
+  // #endregion
+
+  // #region caller-supplied
+  // A caller-supplied id always wins — generation only fills a missing field.
+  const fixed = yield* db.entities.Documents.put({ id: "doc-fixed", title: "Pinned" })
+  yield* Console.log(`Kept id: ${fixed.id}`) // doc-fixed
+  // #endregion
+
+  // #region uuidv7
+  // UUIDv7 ids are time-ordered — useful as sortable keys.
+  const e1 = yield* db.entities.Events.put({ kind: "created" })
+  const e2 = yield* db.entities.Events.put({ kind: "updated" })
+  yield* Console.log(`v7 ids: ${e1.eventId} < ${e2.eventId}: ${e1.eventId < e2.eventId}`)
+  // #endregion
+
+  yield* db.tables["genid-demo-table"]!.delete()
+  yield* Console.log("Table deleted.")
+})
+
+const AppLayer = Layer.mergeAll(
+  DynamoClient.layer({
+    region: "us-east-1",
+    endpoint: "http://localhost:8000",
+    credentials: { accessKeyId: "local", secretAccessKey: "local" },
+  }),
+  MainTable.layer({ name: "genid-demo-table" }),
+)
+
+const main = program.pipe(Effect.provide(AppLayer))
+
+Effect.runPromise(main).then(
+  () => console.log("\nDone."),
+  (err) => console.error("\nFailed:", err),
+)

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-dynamodb",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Effect TS ORM for DynamoDB — schema-driven entity modeling, single-table design, composite keys, transactions, and Stream-based pagination",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/src/DynamoClient.ts
+++ b/packages/effect-dynamodb/src/DynamoClient.ts
@@ -497,10 +497,11 @@ export type TypedClient<
       any,
       infer R,
       any,
-      infer TS
+      infer TS,
+      infer GID
     >
       ? Resolve<
-          BoundEntity<M, I, R, ResolveKey<M, I>, TS, Ts, V> & {
+          BoundEntity<M, I, R, ResolveKey<M, I>, TS, Ts, V, GID> & {
             /** Scan this entity. Returns a BoundQuery for building scan queries. */
             readonly scan: () => import("./internal/BoundQuery.js").BoundQuery<
               Schema.Schema.Type<M>,

--- a/packages/effect-dynamodb/src/DynamoModel.ts
+++ b/packages/effect-dynamodb/src/DynamoModel.ts
@@ -633,18 +633,13 @@ export const getSparseFields = (model: Schema.Top): globalThis.Record<string, Sp
  * (a Record whose value is itself a Record).
  */
 export const isRecordSchema = (schema: Schema.Top): { readonly valueAst: unknown } | undefined => {
-  const ast = schema.ast as unknown as {
-    readonly _tag?: string
-    readonly propertySignatures?: ReadonlyArray<unknown>
-    readonly indexSignatures?: ReadonlyArray<{ readonly type?: unknown }>
-  }
-  if (!ast || ast._tag !== "Objects") return undefined
-  const propertySignatures = ast.propertySignatures
-  const indexSignatures = ast.indexSignatures
-  if (!Array.isArray(propertySignatures) || !Array.isArray(indexSignatures)) return undefined
-  if (propertySignatures.length !== 0 || indexSignatures.length !== 1) return undefined
-  const sig = indexSignatures[0]!
-  return { valueAst: sig.type }
+  const ast = schema.ast
+  // `Record(K, V)` → an `Objects` AST with no property signatures and exactly
+  // one index signature. `SchemaAST.isObjects` narrows to the typed node, so
+  // `propertySignatures`/`indexSignatures` are read without casts.
+  if (!SchemaAST.isObjects(ast)) return undefined
+  if (ast.propertySignatures.length !== 0 || ast.indexSignatures.length !== 1) return undefined
+  return { valueAst: ast.indexSignatures[0]!.type }
 }
 
 /** True iff `schema` is shaped like `Schema.Record(K, V)`. */
@@ -652,19 +647,10 @@ export const isRecord = (schema: Schema.Top): boolean => isRecordSchema(schema) 
 
 /** True iff `valueAst` (raw AST from a Record value position) is itself a Record AST. */
 export const isRecordAst = (valueAst: unknown): boolean => {
-  if (!valueAst || typeof valueAst !== "object") return false
-  const ast = valueAst as {
-    readonly _tag?: string
-    readonly propertySignatures?: ReadonlyArray<unknown>
-    readonly indexSignatures?: ReadonlyArray<unknown>
-  }
-  if (ast._tag !== "Objects") return false
-  return (
-    Array.isArray(ast.propertySignatures) &&
-    Array.isArray(ast.indexSignatures) &&
-    ast.propertySignatures.length === 0 &&
-    ast.indexSignatures.length === 1
-  )
+  if (valueAst == null || typeof valueAst !== "object" || !("_tag" in valueAst)) return false
+  const ast = valueAst as SchemaAST.AST
+  if (!SchemaAST.isObjects(ast)) return false
+  return ast.propertySignatures.length === 0 && ast.indexSignatures.length === 1
 }
 
 /**

--- a/packages/effect-dynamodb/src/Entity.ts
+++ b/packages/effect-dynamodb/src/Entity.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AttributeValue, DeleteItemCommandInput } from "@aws-sdk/client-dynamodb"
-import { DateTime, Duration, Effect, Option, Schema, SchemaAST, Stream } from "effect"
+import { Crypto, DateTime, Duration, Effect, Option, Schema, SchemaAST, Stream } from "effect"
 import { DynamoClient, type DynamoClientError } from "./DynamoClient.js"
 import {
   type ConfiguredModel,
@@ -165,6 +165,7 @@ import {
 } from "./internal/EntityCombinators.js"
 import type {
   CascadeIndexConfig,
+  GeneratedIdConfig,
   SoftDeleteConfig,
   TimeSeriesConfig,
   TimestampsConfig,
@@ -229,7 +230,7 @@ const normalizeTtlInput = (ttl: TtlInput): Duration.Duration =>
 
 /**
  * Validate a configured TTL at `make()` time: parseable and finite.
- * Throws `[EDD-9020]` on an invalid duration string or a non-finite duration
+ * Throws `[EDD-9017]` on an invalid duration string or a non-finite duration
  * (e.g. `Duration.infinity`) — an infinite TTL epoch is nonsensical for DynamoDB.
  */
 const validateTtlConfig = (entityType: string, label: string, ttl: TtlInput | undefined): void => {
@@ -239,7 +240,7 @@ const validateTtlConfig = (entityType: string, label: string, ttl: TtlInput | un
     const parsed = Duration.fromInput(ttl)
     if (Option.isNone(parsed)) {
       throw new Error(
-        `[EDD-9020] Entity "${entityType}": ${label} ttl "${ttl}" is not a valid duration string ` +
+        `[EDD-9017] Entity "${entityType}": ${label} ttl "${ttl}" is not a valid duration string ` +
           `(expected e.g. "7 days", "24 hours", "30 minutes").`,
       )
     }
@@ -249,10 +250,42 @@ const validateTtlConfig = (entityType: string, label: string, ttl: TtlInput | un
   }
   if (!Duration.isFinite(dur)) {
     throw new Error(
-      `[EDD-9020] Entity "${entityType}": ${label} ttl must be a finite duration (got infinity).`,
+      `[EDD-9017] Entity "${entityType}": ${label} ttl must be a finite duration (got infinity).`,
     )
   }
 }
+
+// ---------------------------------------------------------------------------
+// Auto-generated id (generatedId) — cryptographically-secure UUIDs
+// ---------------------------------------------------------------------------
+
+/**
+ * Default cryptographically-secure `Crypto` instance, backed by the platform
+ * Web Crypto CSPRNG (`globalThis.crypto.getRandomValues`). Built once at module
+ * load via the Effect `Crypto` module (beta.68). Its `randomUUIDv4`/`randomUUIDv7`
+ * effects have `R = never`, so id generation needs no service wiring and never
+ * touches the bound client's `R = never` guarantee.
+ *
+ * `digest` is unused — `randomUUIDv4`/`v7` derive purely from `randomBytes`.
+ */
+const defaultCrypto = Crypto.make({
+  randomBytes: (size: number): Uint8Array => {
+    const bytes = new Uint8Array(size)
+    globalThis.crypto.getRandomValues(bytes)
+    return bytes
+  },
+  digest: () =>
+    Effect.die(
+      new Error("Crypto.digest is not provided by effect-dynamodb's default UUID generator"),
+    ),
+})
+
+/**
+ * Generate a UUID for a {@link GeneratedIdConfig}. A CSPRNG failure is a defect
+ * (`orDie`), so this keeps the operation's error channel unchanged.
+ */
+const generateId = (version: "v4" | "v7" | undefined): Effect.Effect<string, never, never> =>
+  (version === "v7" ? defaultCrypto.randomUUIDv7 : defaultCrypto.randomUUIDv4).pipe(Effect.orDie)
 
 // ---------------------------------------------------------------------------
 // Sparse-aware unique sentinel composition
@@ -396,6 +429,7 @@ export interface Entity<
   TRefs extends globalThis.Record<string, AnyRefValue> | undefined = undefined,
   TIdentifier extends string | undefined = undefined,
   TTimeSeries extends TimeSeriesConfig<any> | undefined = undefined,
+  TGeneratedId extends GeneratedIdConfig | undefined = undefined,
 > {
   readonly _tag: "Entity"
   readonly model: TModel
@@ -407,6 +441,7 @@ export interface Entity<
   readonly unique: TUnique
   readonly identifier: TIdentifier
   readonly timeSeries: TTimeSeries
+  readonly generatedId: TGeneratedId
 
   /** @internal Resolved ref metadata — used by cascade to inspect target entities */
   readonly _resolvedRefs: ReadonlyArray<{
@@ -874,6 +909,17 @@ export interface Entity<
  * }) {}
  * ```
  */
+/**
+ * Make the configured `generatedId` field optional in an input type — callers
+ * may omit it and the framework fills a UUID at write time. No-op when no
+ * `generatedId` is configured.
+ */
+export type ApplyGeneratedId<I, TGeneratedId> = TGeneratedId extends {
+  readonly field: infer F extends string
+}
+  ? Omit<I, F> & { readonly [K in F & keyof I]?: I[K] }
+  : I
+
 export interface BoundEntity<
   TModel extends Schema.Top,
   TIndexes extends globalThis.Record<string, IndexDefinition>,
@@ -882,6 +928,7 @@ export interface BoundEntity<
   TTimeSeries extends TimeSeriesConfig<any> | undefined = undefined,
   TTimestamps extends TimestampsConfig | undefined = undefined,
   TVersioned extends VersionedConfig | undefined = undefined,
+  TGeneratedId extends GeneratedIdConfig | undefined = undefined,
 > {
   // --- CRUD Operations ---
 
@@ -900,7 +947,10 @@ export interface BoundEntity<
    * ```
    */
   readonly put: (
-    input: EntityRefInputType<TModel, TRefs, TTimestamps, TVersioned, TTimeSeries>,
+    input: ApplyGeneratedId<
+      EntityRefInputType<TModel, TRefs, TTimestamps, TVersioned, TTimeSeries>,
+      TGeneratedId
+    >,
   ) => import("./internal/BoundCrud.js").BoundPut<
     ModelType<TModel>,
     ModelType<TModel>,
@@ -912,7 +962,10 @@ export interface BoundEntity<
    * primary key already exists. Returns a fluent {@link BoundPut}.
    */
   readonly create: (
-    input: EntityRefInputType<TModel, TRefs, TTimestamps, TVersioned, TTimeSeries>,
+    input: ApplyGeneratedId<
+      EntityRefInputType<TModel, TRefs, TTimestamps, TVersioned, TTimeSeries>,
+      TGeneratedId
+    >,
   ) => import("./internal/BoundCrud.js").BoundPut<
     ModelType<TModel>,
     ModelType<TModel>,
@@ -1322,6 +1375,7 @@ export const make = <
   const TRefs extends globalThis.Record<string, AnyRefValue> | undefined = undefined,
   const TTimeSeries extends TimeSeriesConfig<any> | undefined = undefined,
   const TAttrs extends {} = {},
+  const TGeneratedId extends GeneratedIdConfig | undefined = undefined,
 >(config: {
   readonly model: TModel | ConfiguredModel<TModel, TAttrs>
   readonly entityType: TEntityType
@@ -1333,6 +1387,7 @@ export const make = <
   readonly unique?: TUnique
   readonly refs?: TRefs
   readonly timeSeries?: TTimeSeries
+  readonly generatedId?: TGeneratedId
 }): Entity<
   TModel,
   TEntityType,
@@ -1343,7 +1398,8 @@ export const make = <
   TUnique,
   TRefs,
   ExtractIdentifier<ConfiguredModel<TModel, TAttrs>>,
-  TTimeSeries
+  TTimeSeries,
+  TGeneratedId
 > => {
   // Normalize GSI configs to internal IndexDefinition format
   const gsiIndexes: globalThis.Record<string, IndexDefinition> = {}
@@ -1375,6 +1431,7 @@ const makeImpl = <
   const TRefs extends globalThis.Record<string, AnyRefValue> | undefined = undefined,
   const TTimeSeries extends TimeSeriesConfig<any> | undefined = undefined,
   const TAttrs extends {} = {},
+  const TGeneratedId extends GeneratedIdConfig | undefined = undefined,
 >(config: {
   readonly model: TModel | ConfiguredModel<TModel, TAttrs>
   readonly entityType: TEntityType
@@ -1385,6 +1442,7 @@ const makeImpl = <
   readonly unique?: TUnique
   readonly refs?: TRefs
   readonly timeSeries?: TTimeSeries
+  readonly generatedId?: TGeneratedId
 }): Entity<
   TModel,
   TEntityType,
@@ -1395,7 +1453,8 @@ const makeImpl = <
   TUnique,
   TRefs,
   ExtractIdentifier<ConfiguredModel<TModel, TAttrs>>,
-  TTimeSeries
+  TTimeSeries,
+  TGeneratedId
 > => {
   // Unwrap ConfiguredModel to get the raw model and attribute overrides
   const configured = isConfiguredModel(config.model) ? config.model : undefined
@@ -1563,7 +1622,7 @@ const makeImpl = <
   }
 
   // ---------------------------------------------------------------------------
-  // Validate lifecycle TTL configs (EDD-9020): parseable + finite durations
+  // Validate lifecycle TTL configs (EDD-9017): parseable + finite durations
   // ---------------------------------------------------------------------------
   if (typeof config.versioned === "object" && config.versioned !== null) {
     validateTtlConfig(config.entityType, "versioned", config.versioned.ttl)
@@ -1587,6 +1646,29 @@ const makeImpl = <
           (constraintDef as { readonly ttl?: TtlInput }).ttl,
         )
       }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Validate generatedId config (EDD-9030): field must be a model field that
+  // participates in the primary key (its value composes pk/sk).
+  // ---------------------------------------------------------------------------
+  const generatedIdCfg = (config as { readonly generatedId?: GeneratedIdConfig }).generatedId
+  if (generatedIdCfg) {
+    const f = generatedIdCfg.field
+    if (!(f in modelFields)) {
+      throw new Error(
+        `[EDD-9030] Entity "${config.entityType}": generatedId.field "${f}" does not name a model field. ` +
+          `Valid model fields: ${Object.keys(modelFields).sort().join(", ")}`,
+      )
+    }
+    const primary = config.indexes.primary
+    const pkSkComposites = new Set([...primary.pk.composite, ...primary.sk.composite])
+    if (!pkSkComposites.has(f)) {
+      throw new Error(
+        `[EDD-9030] Entity "${config.entityType}": generatedId.field "${f}" must participate in the ` +
+          `primary key (appear in the pk or sk composite) — its generated value composes the key.`,
+      )
     }
   }
 
@@ -2459,9 +2541,21 @@ const makeImpl = <
           //      instances) and the substituted date/Redacted transforms
           //      tolerate either form. The subsequent `encode` produces
           //      the canonical wire shape.
+          // generatedId: fill a cryptographically-secure UUID for the configured
+          // key field when the caller omits it. The value then flows through key
+          // composition, the stored item, and the decoded record like any other.
+          const genId = config.generatedId
+          const effectiveInput =
+            genId != null &&
+            typeof input === "object" &&
+            input !== null &&
+            (input as globalThis.Record<string, unknown>)[genId.field] === undefined
+              ? { ...(input as object), [genId.field]: yield* generateId(genId.version) }
+              : input
+
           const encodedInput = yield* encodeOrDecodeEncode(
             schemas.inputSchema as Schema.Codec<any>,
-            input,
+            effectiveInput,
             entityType,
             "put",
           )
@@ -5444,6 +5538,7 @@ const makeImpl = <
     unique: config.unique as TUnique,
     identifier: resolvedIdentifier as ExtractIdentifier<ConfiguredModel<TModel, TAttrs>>,
     timeSeries: config.timeSeries as TTimeSeries,
+    generatedId: (config as { readonly generatedId?: TGeneratedId }).generatedId as TGeneratedId,
     _resolvedRefs: resolvedRefs,
     /** @internal Full decode pipeline: rename + schema decode. Used by Batch/Aggregate. */
     _decodeRecord: decodeRecord,
@@ -5511,7 +5606,8 @@ const makeImpl = <
     TUnique,
     TRefs,
     ExtractIdentifier<ConfiguredModel<TModel, TAttrs>>,
-    TTimeSeries
+    TTimeSeries,
+    TGeneratedId
   >
 
   // Assign self so operation closures can reference the entity
@@ -5543,6 +5639,7 @@ export const bind = <
   TRefs extends globalThis.Record<string, AnyRefValue> | undefined,
   TIdentifier extends string | undefined,
   TTimeSeries extends TimeSeriesConfig<any> | undefined = undefined,
+  TGeneratedId extends GeneratedIdConfig | undefined = undefined,
 >(
   entity: Entity<
     TModel,
@@ -5554,7 +5651,8 @@ export const bind = <
     TUnique,
     TRefs,
     TIdentifier,
-    TTimeSeries
+    TTimeSeries,
+    TGeneratedId
   >,
 ): Effect.Effect<
   BoundEntity<
@@ -5564,7 +5662,8 @@ export const bind = <
     EntityKeyType<TModel, TIndexes>,
     TTimeSeries,
     TTimestamps,
-    TVersioned
+    TVersioned,
+    TGeneratedId
   >,
   never,
   DynamoClient | TableConfig
@@ -5577,6 +5676,8 @@ export const bind = <
 
     type Key = EntityKeyType<TModel, TIndexes>
     type Input = EntityRefInputType<TModel, TRefs, TTimestamps, TVersioned, TTimeSeries>
+    // Put/create accept the input with the generated id field made optional.
+    type PutInput = ApplyGeneratedId<Input, TGeneratedId>
 
     // Sparse-field map (if any) — extracted from the Entity's configured model
     // so the PathBuilder used by `.condition((t, ops) => ...)` exposes
@@ -5619,8 +5720,8 @@ export const bind = <
     return {
       // CRUD — fluent bound builders (yieldable, no .run() terminal)
       get: (key: Key) => provide((entity.get(key) as any)._run("record")),
-      put: (input: Input) => makeBoundPut(entity.put(input), boundCrudConfig),
-      create: (input: Input) => makeBoundPut(entity.create(input), boundCrudConfig),
+      put: (input: PutInput) => makeBoundPut(entity.put(input as Input), boundCrudConfig),
+      create: (input: PutInput) => makeBoundPut(entity.create(input as Input), boundCrudConfig),
       update: (key: Key) => makeBoundUpdate(entity.update(key), boundCrudConfig),
       delete: (key: Key) => makeBoundDelete(entity.delete(key), boundCrudConfig),
       upsert: (input: Input) => makeBoundPut(entity.upsert(input), boundCrudConfig),
@@ -5725,7 +5826,8 @@ export const bind = <
       EntityKeyType<TModel, TIndexes>,
       TTimeSeries,
       TTimestamps,
-      TVersioned
+      TVersioned,
+      TGeneratedId
     >
   })
 

--- a/packages/effect-dynamodb/src/Entity.ts
+++ b/packages/effect-dynamodb/src/Entity.ts
@@ -168,6 +168,7 @@ import type {
   SoftDeleteConfig,
   TimeSeriesConfig,
   TimestampsConfig,
+  TtlInput,
   UniqueConfig,
   UniqueConstraintDef,
   VersionedConfig,
@@ -215,6 +216,45 @@ import type {
 export type { IndexDefinition, KeyPart }
 
 // ---------------------------------------------------------------------------
+// TTL config normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a {@link TtlInput} to a `Duration`. Duration-string literals parse
+ * via `Duration.fromInputUnsafe` (the `TtlInput` type restricts strings to the
+ * valid `` `${number} ${Unit}` `` shape, so this never fails for typed callers).
+ */
+const normalizeTtlInput = (ttl: TtlInput): Duration.Duration =>
+  typeof ttl === "string" ? Duration.fromInputUnsafe(ttl) : ttl
+
+/**
+ * Validate a configured TTL at `make()` time: parseable and finite.
+ * Throws `[EDD-9020]` on an invalid duration string or a non-finite duration
+ * (e.g. `Duration.infinity`) — an infinite TTL epoch is nonsensical for DynamoDB.
+ */
+const validateTtlConfig = (entityType: string, label: string, ttl: TtlInput | undefined): void => {
+  if (ttl === undefined) return
+  let dur: Duration.Duration
+  if (typeof ttl === "string") {
+    const parsed = Duration.fromInput(ttl)
+    if (Option.isNone(parsed)) {
+      throw new Error(
+        `[EDD-9020] Entity "${entityType}": ${label} ttl "${ttl}" is not a valid duration string ` +
+          `(expected e.g. "7 days", "24 hours", "30 minutes").`,
+      )
+    }
+    dur = parsed.value
+  } else {
+    dur = ttl
+  }
+  if (!Duration.isFinite(dur)) {
+    throw new Error(
+      `[EDD-9020] Entity "${entityType}": ${label} ttl must be a finite duration (got infinity).`,
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Sparse-aware unique sentinel composition
 // ---------------------------------------------------------------------------
 
@@ -260,6 +300,15 @@ const composeUniqueSentinel = (
     fieldsRecord,
   }
 }
+
+/**
+ * The optional relative TTL configured on a unique constraint. Only the object
+ * form (`{ fields, ttl }`) can carry a TTL; a bare field-list array cannot.
+ * When set, the constraint's sentinel item expires after the offset — useful
+ * for temporary reservations (the uniqueness hold is released automatically).
+ */
+const uniqueConstraintTtl = (constraintDef: UniqueConstraintDef): TtlInput | undefined =>
+  Array.isArray(constraintDef) ? undefined : (constraintDef as { readonly ttl?: TtlInput }).ttl
 
 // ---------------------------------------------------------------------------
 // Encode-or-decode-encode helper
@@ -1514,6 +1563,34 @@ const makeImpl = <
   }
 
   // ---------------------------------------------------------------------------
+  // Validate lifecycle TTL configs (EDD-9020): parseable + finite durations
+  // ---------------------------------------------------------------------------
+  if (typeof config.versioned === "object" && config.versioned !== null) {
+    validateTtlConfig(config.entityType, "versioned", config.versioned.ttl)
+  }
+  if (typeof config.softDelete === "object" && config.softDelete !== null) {
+    validateTtlConfig(config.entityType, "softDelete", config.softDelete.ttl)
+  }
+  if (config.timeSeries !== undefined && config.timeSeries !== null) {
+    validateTtlConfig(
+      config.entityType,
+      "timeSeries",
+      (config.timeSeries as TimeSeriesConfig<any>).ttl,
+    )
+  }
+  if (config.unique) {
+    for (const [constraintName, constraintDef] of Object.entries(config.unique)) {
+      if (!Array.isArray(constraintDef)) {
+        validateTtlConfig(
+          config.entityType,
+          `unique:${constraintName}`,
+          (constraintDef as { readonly ttl?: TtlInput }).ttl,
+        )
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Validate timeSeries config (EDD-9010..9016)
   // ---------------------------------------------------------------------------
   if (config.timeSeries !== undefined && config.timeSeries !== null) {
@@ -1987,8 +2064,8 @@ const makeImpl = <
    * Absolute TTL epoch-seconds = `now` + the configured relative offset.
    * `now` is read once per operation from the ambient `Clock` via `DateTime.now`.
    */
-  const ttlEpochSeconds = (now: DateTime.Utc, ttl: Duration.Duration): number =>
-    Math.floor(DateTime.toEpochMillis(now) / 1000) + Duration.toSeconds(ttl)
+  const ttlEpochSeconds = (now: DateTime.Utc, ttl: TtlInput): number =>
+    Math.floor(DateTime.toEpochMillis(now) / 1000) + Duration.toSeconds(normalizeTtlInput(ttl))
 
   // ---------------------------------------------------------------------------
   // Lifecycle config helpers
@@ -2003,14 +2080,14 @@ const makeImpl = <
     config.softDelete === true ||
     (typeof config.softDelete === "object" && config.softDelete !== null)
 
-  const retainTtl = (): Duration.Duration | undefined => {
+  const retainTtl = (): TtlInput | undefined => {
     if (typeof config.versioned !== "object" || config.versioned === null) return undefined
-    return (config.versioned as { ttl?: Duration.Duration }).ttl
+    return (config.versioned as { ttl?: TtlInput }).ttl
   }
 
-  const softDeleteTtl = (): Duration.Duration | undefined => {
+  const softDeleteTtl = (): TtlInput | undefined => {
     if (typeof config.softDelete !== "object" || config.softDelete === null) return undefined
-    return (config.softDelete as { ttl?: Duration.Duration }).ttl
+    return (config.softDelete as { ttl?: TtlInput }).ttl
   }
 
   const preserveUnique = (): boolean => {
@@ -2489,16 +2566,21 @@ const makeImpl = <
                 )
                 if (!sentinel) continue
                 sentinelConstraints.push(constraintName)
+                const sentinelItem: globalThis.Record<string, unknown> = {
+                  [config.indexes.primary.pk.field]: sentinel.key.pk,
+                  [config.indexes.primary.sk.field]: sentinel.key.sk,
+                  __edd_e__: `${entityType}._unique.${constraintName}`,
+                  _entity_pk: keys[config.indexes.primary.pk.field],
+                  _entity_sk: keys[config.indexes.primary.sk.field],
+                }
+                // Optional TTL: sentinel expires after the configured offset,
+                // releasing the uniqueness reservation automatically.
+                const uTtl = uniqueConstraintTtl(constraintDef)
+                if (uTtl !== undefined) sentinelItem[ttlAttrName] = ttlEpochSeconds(now, uTtl)
                 transactItems.push({
                   Put: {
                     TableName: tableName,
-                    Item: toAttributeMap({
-                      [config.indexes.primary.pk.field]: sentinel.key.pk,
-                      [config.indexes.primary.sk.field]: sentinel.key.sk,
-                      __edd_e__: `${entityType}._unique.${constraintName}`,
-                      _entity_pk: keys[config.indexes.primary.pk.field],
-                      _entity_sk: keys[config.indexes.primary.sk.field],
-                    }),
+                    Item: toAttributeMap(sentinelItem),
                     ConditionExpression: "attribute_not_exists(pk)",
                   },
                 })
@@ -3144,16 +3226,24 @@ const makeImpl = <
                   constraintName: rotation.constraintName,
                   newFieldsRecord: rotation.newFieldsRecord,
                 })
+                const rotatedItem: globalThis.Record<string, unknown> = {
+                  [config.indexes.primary.pk.field]: rotation.newUniqueKey.pk,
+                  [config.indexes.primary.sk.field]: rotation.newUniqueKey.sk,
+                  __edd_e__: `${entityType}._unique.${rotation.constraintName}`,
+                  _entity_pk: primaryKey[config.indexes.primary.pk.field],
+                  _entity_sk: primaryKey[config.indexes.primary.sk.field],
+                }
+                // Re-apply the constraint's optional TTL to the rotated sentinel.
+                const rotatedTtl = config.unique
+                  ? uniqueConstraintTtl(config.unique[rotation.constraintName]!)
+                  : undefined
+                if (rotatedTtl !== undefined) {
+                  rotatedItem[ttlAttrName] = ttlEpochSeconds(now, rotatedTtl)
+                }
                 transactItems.push({
                   Put: {
                     TableName: tableName,
-                    Item: toAttributeMap({
-                      [config.indexes.primary.pk.field]: rotation.newUniqueKey.pk,
-                      [config.indexes.primary.sk.field]: rotation.newUniqueKey.sk,
-                      __edd_e__: `${entityType}._unique.${rotation.constraintName}`,
-                      _entity_pk: primaryKey[config.indexes.primary.pk.field],
-                      _entity_sk: primaryKey[config.indexes.primary.sk.field],
-                    }),
+                    Item: toAttributeMap(rotatedItem),
                     ConditionExpression: "attribute_not_exists(pk)",
                   },
                 })
@@ -5071,16 +5161,20 @@ const makeImpl = <
               )
               if (!sentinel) continue
               sentinelConstraints.push(constraintName)
+              const sentinelItem: globalThis.Record<string, unknown> = {
+                [primary.pk.field]: sentinel.key.pk,
+                [primary.sk.field]: sentinel.key.sk,
+                __edd_e__: `${entityType}._unique.${constraintName}`,
+                _entity_pk: restoredKeys[primary.pk.field],
+                _entity_sk: restoredKeys[primary.sk.field],
+              }
+              // Re-apply the constraint's optional TTL to the restored sentinel.
+              const uTtl = uniqueConstraintTtl(constraintDef)
+              if (uTtl !== undefined) sentinelItem[ttlAttrName] = ttlEpochSeconds(now, uTtl)
               transactItems.push({
                 Put: {
                   TableName: tableName,
-                  Item: toAttributeMap({
-                    [primary.pk.field]: sentinel.key.pk,
-                    [primary.sk.field]: sentinel.key.sk,
-                    __edd_e__: `${entityType}._unique.${constraintName}`,
-                    _entity_pk: restoredKeys[primary.pk.field],
-                    _entity_sk: restoredKeys[primary.sk.field],
-                  }),
+                  Item: toAttributeMap(sentinelItem),
                   ConditionExpression: "attribute_not_exists(#pk)",
                   ExpressionAttributeNames: { "#pk": primary.pk.field },
                 },

--- a/packages/effect-dynamodb/src/Entity.ts
+++ b/packages/effect-dynamodb/src/Entity.ts
@@ -1956,30 +1956,39 @@ const makeImpl = <
     )
   }
 
-  const nowIso = () => new Date().toISOString()
-
   /**
    * Generate a timestamp value as a wire primitive ready for marshalling.
    * Default (no encoding): ISO string. Custom encoding: serialized primitive.
    *
    * Used for system fields whether colliding or not — the value is always a
-   * wire primitive (string or number) ready for `toAttributeMap`.
+   * wire primitive (string or number) ready for `toAttributeMap`. `now` is the
+   * per-operation instant read once from the ambient `Clock` via `DateTime.now`
+   * (deterministic under `TestClock`).
    */
-  const generateTimestamp = (encoding: DynamoEncoding | null): string | number => {
-    if (!encoding) return nowIso()
-    const now = Date.now()
+  const generateTimestamp = (
+    now: DateTime.Utc,
+    encoding: DynamoEncoding | null,
+  ): string | number => {
+    if (!encoding) return DateTime.formatIso(now)
     switch (encoding.storage) {
       case "string":
         // For DateTime.Zoned this would need the extended ISO format, but
         // system timestamps generated here are UTC — DateTime.Zoned-typed
         // collision fields are rare and not previously special-cased either.
-        return new Date(now).toISOString()
+        return DateTime.formatIso(now)
       case "epochMs":
-        return now
+        return DateTime.toEpochMillis(now)
       case "epochSeconds":
-        return Math.floor(now / 1000)
+        return Math.floor(DateTime.toEpochMillis(now) / 1000)
     }
   }
+
+  /**
+   * Absolute TTL epoch-seconds = `now` + the configured relative offset.
+   * `now` is read once per operation from the ambient `Clock` via `DateTime.now`.
+   */
+  const ttlEpochSeconds = (now: DateTime.Utc, ttl: Duration.Duration): number =>
+    Math.floor(DateTime.toEpochMillis(now) / 1000) + Duration.toSeconds(ttl)
 
   // ---------------------------------------------------------------------------
   // Lifecycle config helpers
@@ -2033,6 +2042,7 @@ const makeImpl = <
     _tablePkField: string,
     tableSkField: string,
     ttlAttrName: string,
+    now: DateTime.Utc,
   ): globalThis.Record<string, unknown> => {
     const snapshot: globalThis.Record<string, unknown> = { ...item }
 
@@ -2047,7 +2057,7 @@ const makeImpl = <
     // Add optional TTL
     const ttl = retainTtl()
     if (ttl) {
-      snapshot[ttlAttrName] = Math.floor(Date.now() / 1000) + Duration.toSeconds(ttl)
+      snapshot[ttlAttrName] = ttlEpochSeconds(now, ttl)
     }
 
     return snapshot
@@ -2395,15 +2405,16 @@ const makeImpl = <
           // model-declared field, the user may have supplied their own value
           // (optional on collision in `inputSchema`). Respect their value if
           // present (already encoded to wire); otherwise generate a wire
-          // primitive directly.
+          // primitive directly. `now` is read once from the ambient Clock.
+          const now = yield* DateTime.now
           if (systemFields.createdAt) {
             if (item[systemFields.createdAt] === undefined) {
-              item[systemFields.createdAt] = generateTimestamp(systemFields.createdAtEncoding)
+              item[systemFields.createdAt] = generateTimestamp(now, systemFields.createdAtEncoding)
             }
           }
           if (systemFields.updatedAt) {
             if (item[systemFields.updatedAt] === undefined) {
-              item[systemFields.updatedAt] = generateTimestamp(systemFields.updatedAtEncoding)
+              item[systemFields.updatedAt] = generateTimestamp(now, systemFields.updatedAtEncoding)
             }
           }
           if (systemFields.version) item[systemFields.version] = 1
@@ -2502,6 +2513,7 @@ const makeImpl = <
                 config.indexes.primary.pk.field,
                 config.indexes.primary.sk.field,
                 ttlAttrName,
+                now,
               )
               transactItems.push({
                 Put: {
@@ -2707,6 +2719,8 @@ const makeImpl = <
           const tc = yield* tableTag
           const tableName = tc.name
           const ttlAttrName = resolveTtlAttributeName(tc)
+          // Per-operation instant from the ambient Clock (TestClock-friendly).
+          const now = yield* DateTime.now
 
           // Decode key
           const decodedKey = yield* Schema.decodeUnknownEffect(
@@ -2903,7 +2917,7 @@ const makeImpl = <
               newItem[systemFields.updatedAt] =
                 userSupplied !== undefined
                   ? userSupplied
-                  : generateTimestamp(systemFields.updatedAtEncoding)
+                  : generateTimestamp(now, systemFields.updatedAtEncoding)
             }
 
             // `newItem` is already in domain names (the merge built it from
@@ -3044,6 +3058,7 @@ const makeImpl = <
                   config.indexes.primary.pk.field,
                   config.indexes.primary.sk.field,
                   ttlAttrName,
+                  now,
                 )
               : undefined
 
@@ -3298,7 +3313,7 @@ const makeImpl = <
             values[valKey] = toAttributeValue(
               userSupplied !== undefined
                 ? userSupplied
-                : generateTimestamp(systemFields.updatedAtEncoding),
+                : generateTimestamp(now, systemFields.updatedAtEncoding),
             )
             setClauses.push(`${nameKey} = ${valKey}`)
             counter++
@@ -3745,7 +3760,9 @@ const makeImpl = <
             }
 
             const raw = fromAttributeMap(result.Item) as globalThis.Record<string, unknown>
-            const now = nowIso()
+            // Per-operation instant from the ambient Clock (TestClock-friendly).
+            const now = yield* DateTime.now
+            const deletedAtIso = DateTime.formatIso(now)
 
             // Build soft-deleted item: same PK, replace SK with deleted key, strip GSI keys
             const deletedItem: globalThis.Record<string, unknown> = { ...raw }
@@ -3756,15 +3773,19 @@ const makeImpl = <
             }
 
             // Replace SK with deleted sort key
-            deletedItem[primary.sk.field] = DynamoSchema.composeDeletedKey(schema, entityType, now)
+            deletedItem[primary.sk.field] = DynamoSchema.composeDeletedKey(
+              schema,
+              entityType,
+              deletedAtIso,
+            )
 
             // Add deletedAt
-            deletedItem.deletedAt = now
+            deletedItem.deletedAt = deletedAtIso
 
             // Add optional TTL
             const sdTtl = softDeleteTtl()
             if (sdTtl) {
-              deletedItem[ttlAttrName] = Math.floor(Date.now() / 1000) + Duration.toSeconds(sdTtl)
+              deletedItem[ttlAttrName] = ttlEpochSeconds(now, sdTtl)
             }
 
             // Build transaction
@@ -3798,6 +3819,7 @@ const makeImpl = <
                 primary.pk.field,
                 primary.sk.field,
                 ttlAttrName,
+                now,
               )
               transactItems.push({
                 Put: {
@@ -3946,6 +3968,8 @@ const makeImpl = <
         Effect.gen(function* () {
           const client = yield* DynamoClient
           const { name: tableName } = yield* tableTag
+          // Per-operation instant from the ambient Clock (TestClock-friendly).
+          const now = yield* DateTime.now
 
           // Encode user input → wire form (see `put` for strategy).
           const encodedInput = yield* encodeOrDecodeEncode(
@@ -4073,7 +4097,7 @@ const makeImpl = <
             values[valKey] = toAttributeValue(
               userSupplied !== undefined
                 ? userSupplied
-                : generateTimestamp(systemFields.createdAtEncoding),
+                : generateTimestamp(now, systemFields.createdAtEncoding),
             )
             setClauses.push(`${nameKey} = if_not_exists(${nameKey}, ${valKey})`)
             counter++
@@ -4088,7 +4112,7 @@ const makeImpl = <
             values[valKey] = toAttributeValue(
               userSupplied !== undefined
                 ? userSupplied
-                : generateTimestamp(systemFields.updatedAtEncoding),
+                : generateTimestamp(now, systemFields.updatedAtEncoding),
             )
             setClauses.push(`${nameKey} = ${valKey}`)
             counter++
@@ -4237,6 +4261,8 @@ const makeImpl = <
       const ttlAttrName = resolveTtlAttributeName(tc)
       const orderByField = timeSeriesConfig.orderBy
       const ttlDuration = timeSeriesConfig.ttl
+      // Per-operation instant from the ambient Clock (TestClock-friendly).
+      const now = yield* DateTime.now
       const appendInputSchema = schemas.appendInputSchema as Schema.Codec<any>
 
       // ---------- Validate removeAttrs (issue #49) ----------
@@ -4430,7 +4456,7 @@ const makeImpl = <
         const nameKey = `#a${counter}`
         const valKey = `:a${counter}`
         names[nameKey] = systemFields.createdAt
-        values[valKey] = toAttributeValue(generateTimestamp(systemFields.createdAtEncoding))
+        values[valKey] = toAttributeValue(generateTimestamp(now, systemFields.createdAtEncoding))
         setClauses.push(`${nameKey} = if_not_exists(${nameKey}, ${valKey})`)
         counter++
       }
@@ -4473,7 +4499,7 @@ const makeImpl = <
       eventItem.__edd_e__ = entityType
       // TTL — attribute name comes from TableConfig (default "_ttl")
       if (ttlDuration) {
-        eventItem[ttlAttrName] = Math.floor(Date.now() / 1000) + Duration.toSeconds(ttlDuration)
+        eventItem[ttlAttrName] = ttlEpochSeconds(now, ttlDuration)
       }
       // Events never participate in indexes: strip any GSI key fields that the
       // naive spread above may have carried over. gsiKeys weren't written into
@@ -4962,6 +4988,8 @@ const makeImpl = <
           })
 
           // Build restored item: original SK, recompose all GSI keys, remove deletedAt + TTL
+          // Per-operation instant from the ambient Clock (TestClock-friendly).
+          const now = yield* DateTime.now
           const restoredItem: globalThis.Record<string, unknown> = {
             ...(deletedRaw as globalThis.Record<string, unknown>),
           }
@@ -4975,7 +5003,10 @@ const makeImpl = <
           const newVersion = currentVersion + 1
           if (systemFields.version) restoredItem[systemFields.version] = newVersion
           if (systemFields.updatedAt)
-            restoredItem[systemFields.updatedAt] = generateTimestamp(systemFields.updatedAtEncoding)
+            restoredItem[systemFields.updatedAt] = generateTimestamp(
+              now,
+              systemFields.updatedAtEncoding,
+            )
 
           // Recompose all keys (original SK, GSI keys)
           const restoredKeys = composeAllKeys(restoredItem)
@@ -5016,6 +5047,7 @@ const makeImpl = <
               primary.pk.field,
               primary.sk.field,
               ttlAttrName,
+              now,
             )
             transactItems.push({
               Put: {

--- a/packages/effect-dynamodb/src/EventStore.ts
+++ b/packages/effect-dynamodb/src/EventStore.ts
@@ -12,7 +12,7 @@
  * DynamoClient, Marshaller).
  */
 
-import { Effect, Function, Schema } from "effect"
+import { DateTime, Effect, Function, Schema } from "effect"
 import { DynamoClient, type DynamoClientError } from "./DynamoClient.js"
 import * as DynamoSchema from "./DynamoSchema.js"
 import {
@@ -260,7 +260,8 @@ export const makeStream = <
       const { name: tableName } = yield* config.table.Tag
 
       const pk = composeStreamPk(streamId as Record<string, unknown>)
-      const now = new Date().toISOString()
+      // Event timestamp from the ambient Clock (TestClock-friendly).
+      const now = DateTime.formatIso(yield* DateTime.now)
 
       // Resolve stream ID string for storage (join composites)
       const streamIdStr = compositeFields

--- a/packages/effect-dynamodb/src/internal/AggregateSchemas.ts
+++ b/packages/effect-dynamodb/src/internal/AggregateSchemas.ts
@@ -4,7 +4,7 @@
  * Extracted from Aggregate.ts for decomposition. Not part of the public API.
  */
 
-import { Schema } from "effect"
+import { Schema, SchemaAST } from "effect"
 import { ConfiguredModelTag } from "../DynamoModel.js"
 import type { AggregateEdge, ManyEdge, RefEntity } from "./AggregateEdges.js"
 import type { BoundSubAggregate } from "./AggregateTypes.js"
@@ -90,14 +90,11 @@ export const deriveAggregateSchemas = (
 
 /**
  * Check if a field schema represents an optional field.
- * In Effect v4, Schema.optionalKey(X) sets `ast.context.isOptional = true`.
+ * In Effect v4, `Schema.optionalKey(X)` sets `ast.context.isOptional = true`.
+ * `Base.context` is typed (`Context | undefined`), so no AST cast is needed.
  */
-export const isFieldOptional = (fieldSchema: Schema.Top): boolean => {
-  const ast = (fieldSchema as unknown as Record<string, unknown>).ast as
-    | { context?: { isOptional?: boolean } }
-    | undefined
-  return ast?.context?.isOptional === true
-}
+export const isFieldOptional = (fieldSchema: Schema.Top): boolean =>
+  fieldSchema.ast.context?.isOptional === true
 
 /**
  * Derive a field name from an entity's model identifier.
@@ -190,12 +187,17 @@ export const isSchemaMatchingEntity = (schema: Schema.Top, entity: RefEntity): b
  * Schema.optionalKey(Schema.Array(T)). Returns T.
  *
  * In Effect v4 (beta.71+ reintroduced `.value` on Array/NonEmptyArray):
- * - Schema.Array(T) has `ast._tag === "Arrays"`, `.value === T` (no `.schema`)
- * - Schema.optionalKey(Schema.Array(T)) inherits "Arrays" AST but `.schema === Array(T)`
- *   (the inner array, not the element). The element is `.schema.value`. Its AST has
+ * - `Schema.Array(T)` has an `Arrays` AST and `.value === T` (the element).
+ * - `Schema.optionalKey(Schema.Array(T))` inherits the `Arrays` AST but `.schema`
+ *   is the inner `Array(T)`, whose element is `.schema.value`. Its AST has
  *   `context.isOptional === true`.
+ * - `Schema.optional(Schema.Array(T))` is a `Union` AST; `.schema` is the union
+ *   whose array member carries the element.
  *
- * `.schema` is kept as a fallback for resilience across beta releases.
+ * Uses the typed `SchemaAST` guards (`isArrays`/`isUnion`) rather than raw
+ * `_tag` string comparisons, and reads the element via the wrapper's `.value`
+ * (`.schema` kept as a fallback for resilience across beta releases). This is
+ * the function that regressed on the `.schema`→`.value` move in beta.71.
  */
 const arrayElement = (s: Record<string, unknown>): Schema.Top | undefined => {
   if ("value" in s) return s.value as Schema.Top
@@ -204,10 +206,10 @@ const arrayElement = (s: Record<string, unknown>): Schema.Top | undefined => {
 }
 
 export const extractArrayElement = (fieldSchema: Schema.Top): Schema.Top | undefined => {
+  const ast = fieldSchema.ast
   const s = fieldSchema as unknown as Record<string, unknown>
-  const ast = s.ast as { _tag?: string; context?: { isOptional?: boolean } } | undefined
 
-  if (ast?._tag === "Arrays") {
+  if (SchemaAST.isArrays(ast)) {
     if (ast.context?.isOptional === true && "schema" in s) {
       // optionalKey(Array(T)): s.schema is Array(T), its element is s.schema.value
       return arrayElement(s.schema as Record<string, unknown>)
@@ -216,16 +218,15 @@ export const extractArrayElement = (fieldSchema: Schema.Top): Schema.Top | undef
     return arrayElement(s)
   }
 
-  // Schema.optional(Array(T)): ast._tag is "Union" with context.isOptional,
-  // .schema is Union with .members[0] being Schema.Array(T)
-  if (ast?._tag === "Union" && ast.context?.isOptional === true && "schema" in s) {
+  // Schema.optional(Array(T)): Union AST with context.isOptional; .schema is a
+  // Union whose array member holds the element.
+  if (SchemaAST.isUnion(ast) && ast.context?.isOptional === true && "schema" in s) {
     const unionSchema = s.schema as unknown as Record<string, unknown>
     const members = unionSchema?.members as unknown[] | undefined
     if (Array.isArray(members)) {
       for (const member of members) {
         const m = member as Record<string, unknown>
-        const mAst = m.ast as { _tag?: string } | undefined
-        if (mAst?._tag === "Arrays") {
+        if (m.ast != null && SchemaAST.isArrays(m.ast as SchemaAST.AST)) {
           return arrayElement(m)
         }
       }

--- a/packages/effect-dynamodb/src/internal/EntityConfig.ts
+++ b/packages/effect-dynamodb/src/internal/EntityConfig.ts
@@ -6,6 +6,18 @@
 
 import type { Duration, Schema } from "effect"
 
+/**
+ * A relative TTL offset accepted by lifecycle configs (`versioned`, `softDelete`,
+ * `timeSeries`, `unique`). Either an Effect `Duration` (e.g. `Duration.days(7)`)
+ * or a duration-string literal (e.g. `"7 days"`, `"24 hours"`, `"30 minutes"`).
+ *
+ * A bare `number` is deliberately NOT accepted: `Duration` treats a number as
+ * milliseconds, so `3600` would silently mean 3.6s rather than an hour. The
+ * `` `${number} ${Duration.Unit}` `` literal type rejects that — and any other
+ * malformed string — at compile time.
+ */
+export type TtlInput = Duration.Duration | `${number} ${Duration.Unit}`
+
 // ---------------------------------------------------------------------------
 // System field configuration types
 // ---------------------------------------------------------------------------
@@ -48,7 +60,7 @@ export type VersionedConfig =
   | {
       readonly field?: string | undefined
       readonly retain?: boolean | undefined
-      readonly ttl?: Duration.Duration | undefined
+      readonly ttl?: TtlInput | undefined
     }
 
 /**
@@ -61,7 +73,7 @@ export type VersionedConfig =
 export type SoftDeleteConfig =
   | boolean
   | {
-      readonly ttl?: Duration.Duration | undefined
+      readonly ttl?: TtlInput | undefined
       readonly preserveUnique?: boolean | undefined
     }
 
@@ -83,7 +95,7 @@ export type TimeSeriesConfig<TAppendInput extends Schema.Top = Schema.Top> = {
   /** Model attribute used as the monotonic clock for CAS and event SK decoration. Required. */
   readonly orderBy: string
   /** TTL applied to event items (not current). Omit for retention-forever. */
-  readonly ttl?: Duration.Duration | undefined
+  readonly ttl?: TtlInput | undefined
   /**
    * REQUIRED schema restricting which model fields are allowed in `.append()`
    * input AND which fields are written into the current-item SET clause.
@@ -109,7 +121,7 @@ export type UniqueFieldsDef = ReadonlyArray<string>
  */
 export type UniqueConstraintDef =
   | UniqueFieldsDef
-  | { readonly fields: UniqueFieldsDef; readonly ttl?: Duration.Duration | undefined }
+  | { readonly fields: UniqueFieldsDef; readonly ttl?: TtlInput | undefined }
 
 /**
  * Map of named unique constraints. Each key is the constraint name,

--- a/packages/effect-dynamodb/src/internal/EntityConfig.ts
+++ b/packages/effect-dynamodb/src/internal/EntityConfig.ts
@@ -112,6 +112,23 @@ export type TimeSeriesConfig<TAppendInput extends Schema.Top = Schema.Top> = {
   readonly appendInput: TAppendInput
 }
 
+/**
+ * Auto-generated primary-key id configuration.
+ *
+ * When set, the named field is filled with a cryptographically-secure UUID at
+ * `put`/`create` time if the caller omits it. The field MUST be a model field
+ * and MUST participate in the primary key (validated at `make()`, `[EDD-9030]`).
+ * The value flows through key composition, the stored item, and the decoded
+ * record, and is `optional` in the derived input type/schema.
+ *
+ * - `version: "v4"` (default) — random UUIDv4
+ * - `version: "v7"` — time-ordered UUIDv7 (sortable by creation time)
+ */
+export type GeneratedIdConfig = {
+  readonly field: string
+  readonly version?: "v4" | "v7" | undefined
+}
+
 /** An array of model field names that together form a unique constraint. */
 export type UniqueFieldsDef = ReadonlyArray<string>
 

--- a/packages/effect-dynamodb/src/internal/EntitySchemas.ts
+++ b/packages/effect-dynamodb/src/internal/EntitySchemas.ts
@@ -495,6 +495,11 @@ const tryGetRedactedInner = (schema: Schema.Top): Schema.Top | undefined => {
   // The decoded type is `Redacted<T>` where the inner schema is at
   // `ast.typeParameters[0]`. Walk the AST and rebuild the Schema via
   // `Schema.make` so we get a fully-functional Schema (with `.pipe`).
+  //
+  // NOTE: declaration `typeParameters` has no public typed accessor in v4, so
+  // this raw-AST read is the documented escape hatch — intentionally isolated
+  // in this single helper so a future AST shape change surfaces here (and in
+  // the AST-shape probe test) rather than silently across the codebase.
   const ast = schema.ast as unknown as { typeParameters?: ReadonlyArray<unknown> }
   const params = ast.typeParameters
   if (!params || params.length === 0) return undefined
@@ -655,13 +660,14 @@ export const validateNoTransformOverride = (
  * is missing or the leaf isn't a String / Number node.
  */
 const transformWireKind = (schema: Schema.Top): "string" | "number" | undefined => {
-  const enc = (schema.ast as { encoding?: ReadonlyArray<{ to: { _tag: string } }> }).encoding
+  // `Base.encoding` is typed (`Encoding | undefined`); the leaf `Link.to` is an
+  // AST narrowed via the typed `SchemaAST` guards — no `_tag` string compare.
+  const enc = schema.ast.encoding
   if (!enc || enc.length === 0) return undefined
   const leaf = enc[enc.length - 1]
   if (!leaf) return undefined
-  const tag = leaf.to._tag
-  if (tag === "String") return "string"
-  if (tag === "Number") return "number"
+  if (SchemaAST.isString(leaf.to)) return "string"
+  if (SchemaAST.isNumber(leaf.to)) return "number"
   return undefined
 }
 

--- a/packages/effect-dynamodb/src/internal/TransactableOps.ts
+++ b/packages/effect-dynamodb/src/internal/TransactableOps.ts
@@ -5,7 +5,7 @@
  * and put-item construction (validation + key composition + system fields).
  */
 
-import { Effect, Schema } from "effect"
+import { DateTime, Effect, Schema } from "effect"
 import type { DynamoEncoding } from "../DynamoModel.js"
 import type { Entity } from "../Entity.js"
 import { ValidationError } from "../Errors.js"
@@ -15,17 +15,21 @@ import { toAttributeMap } from "../Marshaller.js"
 /**
  * Generate a wire-form timestamp value for the configured encoding.
  * No-encoding default: ISO string. Custom encoding: serialized primitive.
+ * `now` is read once per operation from the ambient `Clock` via `DateTime.now`
+ * (deterministic under `TestClock`).
  */
-const generateTimestampPrimitive = (encoding: DynamoEncoding | null): string | number => {
-  if (!encoding) return new Date().toISOString()
-  const now = Date.now()
+const generateTimestampPrimitive = (
+  now: DateTime.Utc,
+  encoding: DynamoEncoding | null,
+): string | number => {
+  if (!encoding) return DateTime.formatIso(now)
   switch (encoding.storage) {
     case "string":
-      return new Date(now).toISOString()
+      return DateTime.formatIso(now)
     case "epochMs":
-      return now
+      return DateTime.toEpochMillis(now)
     case "epochSeconds":
-      return Math.floor(now / 1000)
+      return Math.floor(DateTime.toEpochMillis(now) / 1000)
   }
 }
 
@@ -111,14 +115,15 @@ export const validateAndBuildPutItem = (
     // (already encoded to wire by `Schema.encode`); else generate a wire
     // primitive directly.
     const sf = entity.systemFields
+    const now = yield* DateTime.now
     if (sf.createdAt) {
       if (item[sf.createdAt] === undefined) {
-        item[sf.createdAt] = generateTimestampPrimitive(sf.createdAtEncoding)
+        item[sf.createdAt] = generateTimestampPrimitive(now, sf.createdAtEncoding)
       }
     }
     if (sf.updatedAt) {
       if (item[sf.updatedAt] === undefined) {
-        item[sf.updatedAt] = generateTimestampPrimitive(sf.updatedAtEncoding)
+        item[sf.updatedAt] = generateTimestampPrimitive(now, sf.updatedAtEncoding)
       }
     }
     if (sf.version) item[sf.version] = 1

--- a/packages/effect-dynamodb/test/AstShape.test.ts
+++ b/packages/effect-dynamodb/test/AstShape.test.ts
@@ -1,0 +1,111 @@
+/**
+ * AST-shape probe tests (#55).
+ *
+ * The entity/aggregate schema-derivation layer reads a few Effect Schema AST
+ * internals via typed accessors (`SchemaAST` guards, `.value`, `.fields`,
+ * `.context.isOptional`, `.encoding`). A beta bump that moves any of these
+ * silently breaks key derivation — exactly the class of bug that shipped when
+ * the array element moved `.schema`→`.value` in beta.71.
+ *
+ * These tests assert the accessors still have the expected runtime shape, so a
+ * future Effect upgrade fails HERE (loudly) instead of mis-deriving keys.
+ */
+
+import { describe, expect, it } from "@effect/vitest"
+import { Schema, SchemaAST } from "effect"
+import { isRecord, isRecordAst, isRecordSchema } from "../src/DynamoModel.js"
+import {
+  extractArrayElement,
+  getSchemaFields,
+  isFieldOptional,
+} from "../src/internal/AggregateSchemas.js"
+
+class Player extends Schema.Class<Player>("Player")({ id: Schema.String }) {}
+
+describe("AST-shape probes (#55)", () => {
+  describe("SchemaAST guards + raw shape", () => {
+    it("Schema.Array carries an Arrays AST with the element on .value", () => {
+      const arr = Schema.Array(Player)
+      expect(SchemaAST.isArrays(arr.ast)).toBe(true)
+      expect((arr as unknown as { value: unknown }).value).toBe(Player)
+    })
+
+    it("optionalKey marks context.isOptional", () => {
+      expect(Schema.optionalKey(Schema.String).ast.context?.isOptional).toBe(true)
+      expect(Schema.String.ast.context?.isOptional ?? false).toBe(false)
+    })
+
+    it("Schema.Record is an Objects AST with one index signature, no properties", () => {
+      const rec = Schema.Record(Schema.String, Schema.Number)
+      const ast = rec.ast
+      expect(SchemaAST.isObjects(ast)).toBe(true)
+      if (SchemaAST.isObjects(ast)) {
+        expect(ast.propertySignatures.length).toBe(0)
+        expect(ast.indexSignatures.length).toBe(1)
+      }
+    })
+
+    it("Struct and Class expose typed .fields", () => {
+      const struct = Schema.Struct({ a: Schema.String })
+      expect(Object.keys(struct.fields)).toContain("a")
+      expect(Object.keys(Player.fields)).toContain("id")
+    })
+
+    it("encoding leaf is narrowed by isString / isNumber", () => {
+      const enc = Schema.DateTimeUtcFromString.ast.encoding
+      expect(enc).toBeDefined()
+      const leaf = enc![enc!.length - 1]!
+      expect(SchemaAST.isString(leaf.to)).toBe(true)
+    })
+  })
+
+  describe("extractArrayElement across shapes", () => {
+    it("Array(T) → T", () => {
+      expect(extractArrayElement(Schema.Array(Player))).toBe(Player)
+    })
+    it("NonEmptyArray(T) → T", () => {
+      expect(extractArrayElement(Schema.NonEmptyArray(Player))).toBe(Player)
+    })
+    it("optionalKey(Array(T)) → T", () => {
+      expect(extractArrayElement(Schema.optionalKey(Schema.Array(Player)))).toBe(Player)
+    })
+    it("optional(Array(T)) → T", () => {
+      expect(extractArrayElement(Schema.optional(Schema.Array(Player)))).toBe(Player)
+    })
+    it("non-array → undefined", () => {
+      expect(extractArrayElement(Schema.String)).toBeUndefined()
+    })
+  })
+
+  describe("isFieldOptional across shapes", () => {
+    it("required → false, optionalKey/optional → true", () => {
+      expect(isFieldOptional(Schema.String)).toBe(false)
+      expect(isFieldOptional(Schema.optionalKey(Schema.String))).toBe(true)
+      expect(isFieldOptional(Schema.optional(Schema.String))).toBe(true)
+    })
+  })
+
+  describe("getSchemaFields", () => {
+    it("returns fields for Struct and Class", () => {
+      expect(
+        Object.keys(getSchemaFields(Schema.Struct({ a: Schema.String, b: Schema.Number })) ?? {}),
+      ).toEqual(["a", "b"])
+      expect(Object.keys(getSchemaFields(Player) ?? {})).toEqual(["id"])
+    })
+  })
+
+  describe("DynamoModel record detection", () => {
+    it("Record matches, Struct does not", () => {
+      expect(isRecord(Schema.Record(Schema.String, Schema.Number))).toBe(true)
+      expect(isRecordSchema(Schema.Record(Schema.String, Schema.Number))).toBeDefined()
+      expect(isRecord(Schema.Struct({ a: Schema.String }))).toBe(false)
+    })
+
+    it("isRecordAst detects a nested Record value AST", () => {
+      const nested = Schema.Record(Schema.String, Schema.Record(Schema.String, Schema.Number))
+      const outer = isRecordSchema(nested)
+      expect(outer).toBeDefined()
+      expect(isRecordAst(outer!.valueAst)).toBe(true)
+    })
+  })
+})

--- a/packages/effect-dynamodb/test/Entity.test.ts
+++ b/packages/effect-dynamodb/test/Entity.test.ts
@@ -730,6 +730,97 @@ describe("Entity", () => {
   })
 
   // ---------------------------------------------------------------------------
+  // generatedId — auto-generated UUID primary keys via the Crypto service (#57)
+  // ---------------------------------------------------------------------------
+
+  describe("generatedId (#57)", () => {
+    class Doc extends Schema.Class<Doc>("Doc")({
+      id: Schema.String,
+      name: Schema.String,
+    }) {}
+
+    const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    const UUID_V7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+    const makeDocs = (version?: "v4" | "v7") =>
+      withConfig(
+        Entity.make({
+          model: Doc,
+          entityType: "Doc",
+          primaryKey: {
+            pk: { field: "pk", composite: ["id"] },
+            sk: { field: "sk", composite: [] },
+          },
+          generatedId: version ? { field: "id", version } : { field: "id" },
+        }),
+      )
+
+    it.effect("auto-fills a UUIDv4 for the configured field when omitted", () =>
+      Effect.gen(function* () {
+        const Docs = makeDocs()
+        mockPutItem.mockResolvedValue({})
+        // `id` omitted — the type makes it optional via the bound entity; here we
+        // exercise the entity-level op (requires a cast) to assert the runtime fill.
+        yield* Docs.put({ name: "Hello" } as any).asEffect()
+        const item = mockPutItem.mock.calls[0]![0].Item
+        const id = item.id.S as string
+        expect(id).toMatch(UUID_V4)
+        // The generated value composes the primary key.
+        expect(item.pk.S).toContain(id)
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    it.effect("respects a caller-supplied id (no overwrite)", () =>
+      Effect.gen(function* () {
+        const Docs = makeDocs()
+        mockPutItem.mockResolvedValue({})
+        yield* Docs.put({ id: "fixed-id", name: "Hello" }).asEffect()
+        const item = mockPutItem.mock.calls[0]![0].Item
+        expect(item.id.S).toBe("fixed-id")
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    it.effect("version: 'v7' generates a time-ordered UUIDv7", () =>
+      Effect.gen(function* () {
+        const Docs = makeDocs("v7")
+        mockPutItem.mockResolvedValue({})
+        yield* Docs.put({ name: "Hello" } as any).asEffect()
+        const id = mockPutItem.mock.calls[0]![0].Item.id.S as string
+        expect(id).toMatch(UUID_V7)
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    it("rejects generatedId.field not in the model (EDD-9030)", () => {
+      expect(() =>
+        Entity.make({
+          model: Doc,
+          entityType: "BadDoc1",
+          primaryKey: {
+            pk: { field: "pk", composite: ["id"] },
+            sk: { field: "sk", composite: [] },
+          },
+          generatedId: { field: "nope" },
+        }),
+      ).toThrow(/EDD-9030/)
+    })
+
+    it("rejects generatedId.field not in the primary key (EDD-9030)", () => {
+      expect(() =>
+        Entity.make({
+          model: Doc,
+          entityType: "BadDoc2",
+          primaryKey: {
+            pk: { field: "pk", composite: ["id"] },
+            sk: { field: "sk", composite: [] },
+          },
+          // `name` is a model field but not part of the primary key.
+          generatedId: { field: "name" },
+        }),
+      ).toThrow(/EDD-9030/)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // TTL config: unique.ttl wiring + Duration|string widening (#58)
   // ---------------------------------------------------------------------------
 
@@ -812,7 +903,7 @@ describe("Entity", () => {
       }).pipe(Effect.provide(TestLayer)),
     )
 
-    it("rejects a non-finite ttl at make() time (EDD-9020)", () => {
+    it("rejects a non-finite ttl at make() time (EDD-9017)", () => {
       expect(() =>
         Entity.make({
           model: SimpleItem,
@@ -823,7 +914,7 @@ describe("Entity", () => {
           },
           versioned: { retain: true, ttl: Duration.infinity },
         }),
-      ).toThrow(/EDD-9020/)
+      ).toThrow(/EDD-9017/)
     })
   })
 

--- a/packages/effect-dynamodb/test/Entity.test.ts
+++ b/packages/effect-dynamodb/test/Entity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest"
 import { DateTime, Duration, Effect, Layer, Schema } from "effect"
+import { TestClock } from "effect/testing"
 import { beforeEach, vi } from "vitest"
 import { DynamoClient } from "../src/DynamoClient.js"
 import * as DynamoModel from "../src/DynamoModel.js"
@@ -4319,13 +4320,16 @@ describe("Entity", () => {
           }),
         )
 
+        // Pin the ambient Clock: TTL = now + offset is now deterministic
+        // (DateTime.now reads the Clock — #56). 2026-01-01T00:00:00Z + 90 days.
+        yield* TestClock.setTime(1767225600000)
         yield* TtlRetainEntity.put({ itemId: "i-1", name: "Test" }).asEffect()
 
         const call = mockTransactWriteItems.mock.calls[0]![0]
         const snapshotPut = call.TransactItems[1].Put
-        // Snapshot should have _ttl
+        // Snapshot _ttl = pinned-now-seconds + 90 days, exactly.
         expect(snapshotPut.Item._ttl).toBeDefined()
-        expect(snapshotPut.Item._ttl.N).toBeDefined()
+        expect(Number(snapshotPut.Item._ttl.N)).toBe(1767225600 + 90 * 24 * 60 * 60)
       }).pipe(Effect.provide(TestLayer)),
     )
 
@@ -5568,18 +5572,17 @@ describe("Entity", () => {
           }),
         )
 
+        // Pin the ambient Clock so generated timestamps are deterministic.
+        yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
         mockPutItem.mockResolvedValue({})
         yield* MetricEntity.put({ metricId: "m-1", value: 42 }).asEffect()
         const call = mockPutItem.mock.calls[0]![0]
         const item = call.Item
-        // createdAt: DynamoModel.DateString → stored as ISO string
-        expect(item.createdAt.S).toBeDefined()
-        expect(typeof item.createdAt.S).toBe("string")
+        // createdAt: DynamoModel.DateString → stored as ISO string at the pinned instant
+        expect(item.createdAt.S).toBe("2026-01-01T00:00:00.000Z")
         // updatedAt: storedAs(DateEpochSeconds) → stored as epoch seconds number
         expect(item.updatedAt.N).toBeDefined()
-        const epochVal = Number(item.updatedAt.N)
-        expect(epochVal).toBeGreaterThan(1700000000) // reasonable epoch seconds
-        expect(epochVal).toBeLessThan(2000000000)
+        expect(Number(item.updatedAt.N)).toBe(1767225600)
       }).pipe(Effect.provide(TestLayer)),
     )
 
@@ -5630,6 +5633,8 @@ describe("Entity", () => {
           }),
         )
 
+        // Pin the ambient Clock so generated timestamps are deterministic.
+        yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
         mockPutItem.mockResolvedValue({})
         yield* MetricEntity.put({ metricId: "m-1", value: 42 }).asEffect()
         const call = mockPutItem.mock.calls[0]![0]
@@ -5637,8 +5642,7 @@ describe("Entity", () => {
         // updatedAt uses custom name "modifiedAt" and epoch seconds
         expect(item.modifiedAt.N).toBeDefined()
         expect(item.updatedAt).toBeUndefined()
-        const epochVal = Number(item.modifiedAt.N)
-        expect(epochVal).toBeGreaterThan(1700000000)
+        expect(Number(item.modifiedAt.N)).toBe(1767225600)
       }).pipe(Effect.provide(TestLayer)),
     )
   })
@@ -7677,13 +7681,15 @@ describe("Entity", () => {
 
     it.effect("put: library-generated timestamp respects model field encoding", () =>
       Effect.gen(function* () {
+        // Pin the ambient Clock so generated timestamps are deterministic.
+        yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
         mockPutItem.mockResolvedValue({})
         yield* EpochDocEntity.put({ id: "e-1" }).asEffect()
         const item = mockPutItem.mock.calls[0]![0].Item
         // createdAt stored as epoch-seconds number (not ISO string) because the
         // model field declares DateEpochSeconds storage.
         expect(item.createdAt.N).toBeTypeOf("string")
-        expect(Number.parseInt(item.createdAt.N as string, 10)).toBeGreaterThan(1_700_000_000)
+        expect(Number.parseInt(item.createdAt.N as string, 10)).toBe(1767225600)
       }).pipe(Effect.provide(TestLayer)),
     )
 

--- a/packages/effect-dynamodb/test/Entity.test.ts
+++ b/packages/effect-dynamodb/test/Entity.test.ts
@@ -730,6 +730,104 @@ describe("Entity", () => {
   })
 
   // ---------------------------------------------------------------------------
+  // TTL config: unique.ttl wiring + Duration|string widening (#58)
+  // ---------------------------------------------------------------------------
+
+  describe("TTL config (#58)", () => {
+    it.effect("unique constraint ttl writes _ttl on the sentinel item", () =>
+      Effect.gen(function* () {
+        mockTransactWriteItems.mockResolvedValueOnce({})
+        const Held = withConfig(
+          Entity.make({
+            model: User,
+            entityType: "HeldUser",
+            primaryKey: {
+              pk: { field: "pk", composite: ["userId"] },
+              sk: { field: "sk", composite: [] },
+            },
+            unique: { email: { fields: ["email"], ttl: Duration.days(1) } },
+          }),
+        )
+        // Pin the Clock: sentinel _ttl = now + 1 day (relative TTL via #56).
+        yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
+        yield* Held.put({
+          userId: "u-1",
+          email: "hold@test.com",
+          displayName: "Hold",
+          role: "admin",
+        }).asEffect()
+
+        const call = mockTransactWriteItems.mock.calls[0]![0]
+        // [0] = entity item, [1] = unique sentinel
+        const sentinel = call.TransactItems[1].Put
+        expect(sentinel.Item.__edd_e__.S).toBe("HeldUser._unique.email")
+        expect(Number(sentinel.Item._ttl.N)).toBe(1767225600 + 86400)
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    it.effect("a bare field-list unique constraint writes no sentinel ttl", () =>
+      Effect.gen(function* () {
+        mockTransactWriteItems.mockResolvedValueOnce({})
+        const Plain = withConfig(
+          Entity.make({
+            model: User,
+            entityType: "PlainUser",
+            primaryKey: {
+              pk: { field: "pk", composite: ["userId"] },
+              sk: { field: "sk", composite: [] },
+            },
+            unique: { email: ["email"] },
+          }),
+        )
+        yield* Plain.put({
+          userId: "u-1",
+          email: "a@test.com",
+          displayName: "A",
+          role: "admin",
+        }).asEffect()
+        const sentinel = mockTransactWriteItems.mock.calls[0]![0].TransactItems[1].Put
+        expect(sentinel.Item._ttl).toBeUndefined()
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    it.effect("ttl accepts a duration string with parity to Duration", () =>
+      Effect.gen(function* () {
+        mockTransactWriteItems.mockResolvedValueOnce({})
+        const StrTtl = withConfig(
+          Entity.make({
+            model: SimpleItem,
+            entityType: "StrTtlRetain",
+            primaryKey: {
+              pk: { field: "pk", composite: ["itemId"] },
+              sk: { field: "sk", composite: [] },
+            },
+            // String form — "90 days" must equal Duration.days(90).
+            versioned: { retain: true, ttl: "90 days" },
+          }),
+        )
+        yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
+        yield* StrTtl.put({ itemId: "i-1", name: "Test" }).asEffect()
+        const snapshotPut = mockTransactWriteItems.mock.calls[0]![0].TransactItems[1].Put
+        expect(Number(snapshotPut.Item._ttl.N)).toBe(1767225600 + 90 * 86400)
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    it("rejects a non-finite ttl at make() time (EDD-9020)", () => {
+      expect(() =>
+        Entity.make({
+          model: SimpleItem,
+          entityType: "InfTtl",
+          primaryKey: {
+            pk: { field: "pk", composite: ["itemId"] },
+            sk: { field: "sk", composite: [] },
+          },
+          versioned: { retain: true, ttl: Duration.infinity },
+        }),
+      ).toThrow(/EDD-9020/)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // Unique constraints
   // ---------------------------------------------------------------------------
 

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -184,9 +184,26 @@ const Reservations = Entity.make({
   unique: { slot: { fields: ["slot"], ttl: Duration.days(30) } },
 })
 
+// Auto-generated id fixture (#57) — `id` is omitted at write time and filled
+// with a cryptographically-secure UUID via the Crypto service.
+class Doc extends Schema.Class<Doc>("Doc")({
+  id: Schema.String,
+  title: Schema.String,
+}) {}
+
+const Docs = Entity.make({
+  model: Doc,
+  entityType: "Doc",
+  primaryKey: {
+    pk: { field: "pk", composite: ["id"] },
+    sk: { field: "sk", composite: [] },
+  },
+  generatedId: { field: "id" },
+})
+
 const MainTable = Table.make({
   schema: AppSchema,
-  entities: { Users, Tasks, Memberships, Vehicles, Reservations },
+  entities: { Users, Tasks, Memberships, Vehicles, Reservations, Docs },
 })
 
 // ---------------------------------------------------------------------------
@@ -697,6 +714,31 @@ describeConnected("Connected integration tests", () => {
         const sentinel = raw.Items?.find((i) => i.__edd_e__?.S === "Reservation._unique.slot")
         expect(sentinel).toBeDefined()
         expect(Number(sentinel!._ttl!.N)).toBe(1767225600 + 30 * 86400)
+      }).pipe(provide),
+    )
+  })
+
+  describe("generatedId (#57)", () => {
+    it.effect("auto-generates a UUID id, round-trips, and is queryable by key", () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({ entities: { Docs }, tables: { MainTable } })
+
+        // `id` omitted — filled with a crypto-secure UUID at write time.
+        const created = yield* db.entities.Docs.put({ title: "Generated" })
+        expect(created.id).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+        )
+        expect(created.title).toBe("Generated")
+
+        // The generated id composes the primary key and is fetchable.
+        const fetched = yield* db.entities.Docs.get({ id: created.id })
+        expect(fetched.id).toBe(created.id)
+        expect(fetched.title).toBe("Generated")
+
+        // Two writes without an id get distinct ids (no collision).
+        const a = yield* db.entities.Docs.put({ title: "A" })
+        const b = yield* db.entities.Docs.put({ title: "B" })
+        expect(a.id).not.toBe(b.id)
       }).pipe(provide),
     )
   })

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -167,9 +167,26 @@ const Vehicles = Entity.make({
   timestamps: true,
 })
 
+// Unique-constraint TTL fixture (#58) — the sentinel item expires after the
+// configured offset, releasing the reservation automatically.
+class Reservation extends Schema.Class<Reservation>("Reservation")({
+  reservationId: Schema.String,
+  slot: Schema.String,
+}) {}
+
+const Reservations = Entity.make({
+  model: Reservation,
+  entityType: "Reservation",
+  primaryKey: {
+    pk: { field: "pk", composite: ["reservationId"] },
+    sk: { field: "sk", composite: [] },
+  },
+  unique: { slot: { fields: ["slot"], ttl: Duration.days(30) } },
+})
+
 const MainTable = Table.make({
   schema: AppSchema,
-  entities: { Users, Tasks, Memberships, Vehicles },
+  entities: { Users, Tasks, Memberships, Vehicles, Reservations },
 })
 
 // ---------------------------------------------------------------------------
@@ -657,6 +674,29 @@ describeConnected("Connected integration tests", () => {
         // Original value unchanged
         const unchanged = yield* Users.get({ userId: "u-uniq-claim" }).asEffect()
         expect(unchanged.email).toBe("old-email@test.com")
+      }).pipe(provide),
+    )
+
+    it.effect("unique constraint ttl persists on the sentinel item (#58)", () =>
+      Effect.gen(function* () {
+        const db = yield* DynamoClient.make({
+          entities: { Reservations },
+          tables: { MainTable },
+        })
+        // Pin the Clock: sentinel _ttl = now + 30 days (relative TTL via #56).
+        yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
+        yield* db.entities.Reservations.put({ reservationId: "r-ttl-1", slot: "slot-ttl-a" })
+
+        // Locate the sentinel by its discriminator and assert the persisted TTL.
+        const raw = yield* (yield* DynamoClient).scan({
+          TableName: tableName,
+          FilterExpression: "#e = :e",
+          ExpressionAttributeNames: { "#e": "__edd_e__" },
+          ExpressionAttributeValues: { ":e": { S: "Reservation._unique.slot" } },
+        })
+        const sentinel = raw.Items?.find((i) => i.__edd_e__?.S === "Reservation._unique.slot")
+        expect(sentinel).toBeDefined()
+        expect(Number(sentinel!._ttl!.N)).toBe(1767225600 + 30 * 86400)
       }).pipe(provide),
     )
   })

--- a/packages/effect-dynamodb/test/connected.test.ts
+++ b/packages/effect-dynamodb/test/connected.test.ts
@@ -14,6 +14,7 @@
 
 import { it } from "@effect/vitest"
 import { Config, DateTime, Duration, Effect, Layer, Option, Schema, Stream } from "effect"
+import { TestClock } from "effect/testing"
 import { afterAll, beforeAll, describe, expect } from "vitest"
 import * as Aggregate from "../src/Aggregate.js"
 import * as Batch from "../src/Batch.js"
@@ -1796,6 +1797,10 @@ describeConnected("timeSeries integration tests", () => {
         tables: { TsTable },
       })
 
+      // Pin the ambient Clock so the TTL (now + Duration.days(7)) is exact.
+      // The library reads the Clock via DateTime.now (#56); under it.effect the
+      // ambient clock is the TestClock, so set it to a known instant.
+      yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
       yield* db.entities.Telemetries.append({
         channel: "c-ttl",
         deviceId: "d-1",
@@ -1816,10 +1821,8 @@ describeConnected("timeSeries integration tests", () => {
       const event = raw.Items![0]!
       const ttl = event._ttl?.N ? Number(event._ttl.N) : undefined
       expect(ttl).toBeDefined()
-      const now = Math.floor(Date.now() / 1000)
-      // Roughly 7 days out (Duration.days(7)).
-      expect(ttl!).toBeGreaterThan(now + 6 * 86400)
-      expect(ttl!).toBeLessThan(now + 8 * 86400)
+      // Exactly 7 days (Duration.days(7)) past the pinned instant.
+      expect(ttl!).toBe(1767225600 + 7 * 86400)
     }).pipe(provideTs),
   )
 
@@ -4072,6 +4075,8 @@ describeConnected("TableConfig.ttlAttributeName override (closes #51)", () => {
         tables: { TtlTable },
       })
 
+      // Pin the ambient Clock so TTL (now + offset, via DateTime.now — #56) is exact.
+      yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
       yield* db.entities.TtlEvents.append({
         channel: "c-cfg-1",
         deviceId: "d-1",
@@ -4092,10 +4097,8 @@ describeConnected("TableConfig.ttlAttributeName override (closes #51)", () => {
       const event = raw.Items![0]!
       // Configured attribute "ttl" carries the epoch-seconds expiry.
       expect(event.ttl?.N).toBeDefined()
-      const ttlVal = Number(event.ttl!.N)
-      const now = Math.floor(Date.now() / 1000)
-      expect(ttlVal).toBeGreaterThan(now + 6 * 86400)
-      expect(ttlVal).toBeLessThan(now + 8 * 86400)
+      // Exactly 7 days (Duration.days(7)) past the pinned instant.
+      expect(Number(event.ttl!.N)).toBe(1767225600 + 7 * 86400)
       // Library default "_ttl" must NOT be written when override is in effect.
       expect(event._ttl).toBeUndefined()
     }).pipe(provideTtl),
@@ -4108,6 +4111,8 @@ describeConnected("TableConfig.ttlAttributeName override (closes #51)", () => {
         tables: { TtlTable },
       })
 
+      // Pin the ambient Clock so TTL (now + offset, via DateTime.now — #56) is exact.
+      yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
       yield* db.entities.TtlSoftItems.put({ itemId: "sd-1", label: "to be deleted" })
       yield* db.entities.TtlSoftItems.delete({ itemId: "sd-1" })
 
@@ -4125,11 +4130,8 @@ describeConnected("TableConfig.ttlAttributeName override (closes #51)", () => {
       expect(raw.Items!.length).toBe(1)
       const deleted = raw.Items![0]!
       expect(deleted.ttl?.N).toBeDefined()
-      const ttlVal = Number(deleted.ttl!.N)
-      const now = Math.floor(Date.now() / 1000)
-      // Roughly 30 days from now.
-      expect(ttlVal).toBeGreaterThan(now + 29 * 86400)
-      expect(ttlVal).toBeLessThan(now + 31 * 86400)
+      // Exactly 30 days (Duration.days(30)) past the pinned instant.
+      expect(Number(deleted.ttl!.N)).toBe(1767225600 + 30 * 86400)
       expect(deleted._ttl).toBeUndefined()
     }).pipe(provideTtl),
   )
@@ -4166,6 +4168,8 @@ describeConnected("TableConfig.ttlAttributeName override (closes #51)", () => {
         tables: { TtlTable },
       })
 
+      // Pin the ambient Clock so TTL (now + offset, via DateTime.now — #56) is exact.
+      yield* TestClock.setTime(1767225600000) // 2026-01-01T00:00:00.000Z
       // First put produces a v1 snapshot under the retain config (which has ttl).
       yield* db.entities.TtlRetainItems.put({ itemId: "rt-1", payload: "initial" })
 
@@ -4182,11 +4186,8 @@ describeConnected("TableConfig.ttlAttributeName override (closes #51)", () => {
       expect(raw.Items!.length).toBe(1)
       const snapshot = raw.Items![0]!
       expect(snapshot.ttl?.N).toBeDefined()
-      const ttlVal = Number(snapshot.ttl!.N)
-      const now = Math.floor(Date.now() / 1000)
-      // Roughly 90 days from now.
-      expect(ttlVal).toBeGreaterThan(now + 89 * 86400)
-      expect(ttlVal).toBeLessThan(now + 91 * 86400)
+      // Exactly 90 days (Duration.days(90)) past the pinned instant.
+      expect(Number(snapshot.ttl!.N)).toBe(1767225600 + 90 * 86400)
       expect(snapshot._ttl).toBeUndefined()
     }).pipe(provideTtl),
   )

--- a/packages/language-service/CHANGELOG.md
+++ b/packages/language-service/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @effect-dynamodb/language-service
 
+## 1.9.0
+
+### Minor Changes
+
+- Post-beta.74 improvements surfaced while reviewing new Effect v4 features.
+  - **`generatedId` ([#57](https://github.com/jmenga/effect-dynamodb/issues/57))** — `Entity.make({ generatedId: { field, version? } })` auto-fills a primary-key field with a cryptographically-secure UUID (v4 default, or time-ordered v7) when omitted on `put`/`create`. Sourced from the Effect `Crypto` module via a default instance, so the bound client keeps `R = never` with no layer wiring. The field is type-level optional on put/create and validated to be a primary-key model field (`[EDD-9030]`).
+  - **TTL: `unique.ttl` + `Duration | string` ([#58](https://github.com/jmenga/effect-dynamodb/issues/58))** — the previously-dead `unique: { fields, ttl }` config now expires the constraint's sentinel item (relative TTL, re-applied on create/rotate/restore). Every lifecycle `ttl` (`versioned`, `softDelete`, `timeSeries`, `unique`) now accepts a duration-string literal (`"30 days"`) alongside `Duration`; a bare number is rejected at compile time and a non-finite duration at `make()` (`[EDD-9017]`).
+  - **`DateTime.now` time source ([#56](https://github.com/jmenga/effect-dynamodb/issues/56))** — all write-path timestamps and TTLs now read the ambient `Clock` via `DateTime.now` instead of raw `Date.now()`/`new Date()` (a standing rule violation). Production behavior is unchanged; timestamps + TTL are now deterministic under `TestClock`.
+  - **Schema AST hardening ([#55](https://github.com/jmenga/effect-dynamodb/issues/55))** — internal schema-derivation reads use the typed `SchemaAST` guards (`isArrays`, `isObjects`, `isString`/`isNumber`) and accessors (`.value`, typed `.fields`/`.context`/`.encoding`) instead of `as any`/raw `_tag` poking, with AST-shape probe tests so a future Effect bump fails loudly instead of silently mis-deriving keys.
+
 ## 1.8.1
 
 ### Patch Changes

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/language-service",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "TypeScript Language Service Plugin for effect-dynamodb — shows DynamoDB operations on hover",
   "license": "MIT",
   "author": "Justin Menga",


### PR DESCRIPTION
Implements the four follow-up issues surfaced while reviewing new Effect v4 features (#55–#58), with full unit + integration tests and documentation. **Stacked on #53** (base `chore/effect-beta74`) so the deps bump stays isolated; GitHub retargets this to `main` when #53 merges. Lockstep bump to **1.9.0**.

## What's in here (one commit per issue)

### feat: `generatedId` — auto-generated UUID primary keys (#57)
`Entity.make({ generatedId: { field, version? } })` auto-fills a primary-key field with a cryptographically-secure UUID (`v4` default, or time-ordered `v7`) when omitted on `put`/`create`.
- Sourced from the Effect **`Crypto` module** (beta.68) via a module-level default instance backed by the Web Crypto CSPRNG. Because it's a concrete instance (not a context service), its effect is `R = never` — **the headline `R = never` client guarantee is preserved with zero layer wiring**.
- Type-level optional on put/create (`ApplyGeneratedId` threaded through `Entity`/`BoundEntity`), filled before key composition, flows into key + stored item + decoded record. `make()` validates the field is a primary-key model field (`[EDD-9030]`).

### feat: wire `unique.ttl` + widen TTL to `Duration | string` (#58)
- The previously-**dead** `unique: { fields, ttl }` config now expires the constraint's sentinel item (re-applied on create/rotate/restore) — backs the idempotency-key pattern the docs already advertised.
- Every lifecycle `ttl` (`versioned`/`softDelete`/`timeSeries`/`unique`) accepts a duration-string literal (`"30 days"`) alongside `Duration`. Bare numbers rejected at compile time (millis footgun); non-finite rejected at `make()` (`[EDD-9017]`).

### fix: `DateTime.now` (Clock-backed) for timestamps + TTL (#56)
All write-path timestamps and TTLs read the ambient `Clock` via `DateTime.now` instead of raw `Date.now()`/`new Date()` (a standing rule violation). Production behavior unchanged; now deterministic under `TestClock`.

### refactor: harden Schema AST access (#55)
Internal schema-derivation uses typed `SchemaAST` guards (`isArrays`/`isObjects`/`isString`/`isNumber`) and accessors (`.value`, typed `.fields`/`.context`/`.encoding`) instead of `as any`/raw `_tag` poking — exactly the class of bug that broke `extractArrayElement` on the `.schema`→`.value` move. Adds `test/AstShape.test.ts` probes so the next Effect bump fails loudly.

## Verification — all gates green against DynamoDB Local
- `pnpm check` ✓ · `pnpm lint` ✓ · doctest sync (47) ✓
- Unit: effect-dynamodb **1110**, geo **56**, language-service **67**, doctest **47**
- Connected: core **120**, geo **3**
- Example runtime: **32** (incl. new `examples/generated-id.ts`)

## Docs
DESIGN.md (generatedId, TtlInput, unique.ttl, EDD codes), modeling guide (Generated IDs section + region-backed snippets), lifecycle guide (Duration/string tip), and a runnable `examples/generated-id.ts`.

## Notes
- The honest reframe from the review holds: #56 and #58 turned out to be debt-fixes/already-shipped rather than the features originally pitched (effectful Schema defaults was dropped as an API mismatch; Duration TTL was already partly shipped). Those commits reflect the real, in-scope work.
- `generatedId` scope is `put`/`create`; batch/transaction puts still require an explicit id (documented).

Closes #55
Closes #56
Closes #57
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)