### PR TITLE
fix(release+aggregate): make the #62 split installable and pure-authorable (1.9.1) — fixes #64, #66

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,9 +98,26 @@ jobs:
           node <<'EOF'
           const { execSync } = require('child_process');
           const targets = require('/tmp/publish.json');
+          execSync('mkdir -p /tmp/pkgs');
           for (const { name, version, dir } of targets) {
-            console.log(`Publishing ${name}@${version} from ${dir}`);
-            execSync('npm publish --provenance --access public', { cwd: dir, stdio: 'inherit' });
+            console.log(`Packing ${name}@${version} from ${dir}`);
+            // `pnpm pack` rewrites the `workspace:` protocol in dependencies AND
+            // peerDependencies to concrete ranges; a plain `npm publish` does NOT,
+            // which shipped an uninstallable `workspace:^` in 1.9.0 (issue #64).
+            // We publish the packed tarball so the resolved manifest is what ships.
+            const out = execSync('pnpm pack --pack-destination /tmp/pkgs', { cwd: dir, encoding: 'utf8' });
+            const tgz = out.trim().split('\n').pop().trim();
+            // Guard: refuse to publish if any unresolved `workspace:` spec remains.
+            const pkg = JSON.parse(execSync(`tar -xzOf ${tgz} package/package.json`, { encoding: 'utf8' }));
+            for (const field of ['dependencies', 'peerDependencies', 'optionalDependencies']) {
+              for (const [dep, spec] of Object.entries(pkg[field] || {})) {
+                if (String(spec).startsWith('workspace:')) {
+                  throw new Error(`Refusing to publish ${name}: ${field}.${dep} = "${spec}" — unresolved workspace: protocol (issue #64).`);
+                }
+              }
+            }
+            console.log(`Publishing ${tgz}`);
+            execSync(`npm publish ${tgz} --provenance --access public`, { stdio: 'inherit' });
           }
           EOF
 

--- a/packages/effect-dynamodb-geo/CHANGELOG.md
+++ b/packages/effect-dynamodb-geo/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @effect-dynamodb/geo
 
+## 1.9.1
+
+### Patch Changes
+
+- fix(release): resolve `workspace:` protocol at publish time (closes #64).
+
+  `1.9.0` shipped with an unresolved `workspace:` spec (`effect-dynamodb`'s
+  `dependencies."@effect-dynamodb/schema": "workspace:^"`, and `@effect-dynamodb/geo`'s
+  `peerDependencies.effect-dynamodb`), making `effect-dynamodb@1.9.0` uninstallable for
+  consumers. Root cause: `release.yml` published via `npm publish`, which does not
+  rewrite the `workspace:` protocol.
+
+  The publish step now packs each package with `pnpm pack` (which rewrites `workspace:`
+  in `dependencies` and `peerDependencies` to concrete ranges) and publishes the
+  resulting tarball via `npm publish` (preserving OIDC Trusted Publishing + provenance),
+  with a guard that refuses to publish if any `workspace:` spec remains in the packed
+  manifest. No runtime/API changes — 1.9.1 republishes 1.9.0 with correctly resolved
+  dependency ranges.
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/geo",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Geospatial index and search for effect-dynamodb using H3 hexagonal grid",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/CHANGELOG.md
+++ b/packages/effect-dynamodb/CHANGELOG.md
@@ -1,5 +1,27 @@
 # effect-dynamodb
 
+## 1.9.1
+
+### Patch Changes
+
+- fix(release): resolve `workspace:` protocol at publish time (closes #64).
+
+  `1.9.0` shipped with an unresolved `workspace:` spec (`effect-dynamodb`'s
+  `dependencies."@effect-dynamodb/schema": "workspace:^"`, and `@effect-dynamodb/geo`'s
+  `peerDependencies.effect-dynamodb`), making `effect-dynamodb@1.9.0` uninstallable for
+  consumers. Root cause: `release.yml` published via `npm publish`, which does not
+  rewrite the `workspace:` protocol.
+
+  The publish step now packs each package with `pnpm pack` (which rewrites `workspace:`
+  in `dependencies` and `peerDependencies` to concrete ranges) and publishes the
+  resulting tarball via `npm publish` (preserving OIDC Trusted Publishing + provenance),
+  with a guard that refuses to publish if any `workspace:` spec remains in the packed
+  manifest. No runtime/API changes — 1.9.1 republishes 1.9.0 with correctly resolved
+  dependency ranges.
+
+- Updated dependencies
+  - @effect-dynamodb/schema@1.9.1
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-dynamodb",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Effect TS ORM for DynamoDB — schema-driven entity modeling, single-table design, composite keys, transactions, and Stream-based pagination",
   "type": "module",
   "license": "MIT",

--- a/packages/language-service/CHANGELOG.md
+++ b/packages/language-service/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @effect-dynamodb/language-service
 
+## 1.9.1
+
+### Patch Changes
+
+- fix(release): resolve `workspace:` protocol at publish time (closes #64).
+
+  `1.9.0` shipped with an unresolved `workspace:` spec (`effect-dynamodb`'s
+  `dependencies."@effect-dynamodb/schema": "workspace:^"`, and `@effect-dynamodb/geo`'s
+  `peerDependencies.effect-dynamodb`), making `effect-dynamodb@1.9.0` uninstallable for
+  consumers. Root cause: `release.yml` published via `npm publish`, which does not
+  rewrite the `workspace:` protocol.
+
+  The publish step now packs each package with `pnpm pack` (which rewrites `workspace:`
+  in `dependencies` and `peerDependencies` to concrete ranges) and publishes the
+  resulting tarball via `npm publish` (preserving OIDC Trusted Publishing + provenance),
+  with a guard that refuses to publish if any `workspace:` spec remains in the packed
+  manifest. No runtime/API changes — 1.9.1 republishes 1.9.0 with correctly resolved
+  dependency ranges.
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/language-service",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "TypeScript Language Service Plugin for effect-dynamodb — shows DynamoDB operations on hover",
   "license": "MIT",
   "author": "Justin Menga",

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @effect-dynamodb/schema
 
+## 1.9.1
+
+### Patch Changes
+
+- fix(release): resolve `workspace:` protocol at publish time (closes #64).
+
+  `1.9.0` shipped with an unresolved `workspace:` spec (`effect-dynamodb`'s
+  `dependencies."@effect-dynamodb/schema": "workspace:^"`, and `@effect-dynamodb/geo`'s
+  `peerDependencies.effect-dynamodb`), making `effect-dynamodb@1.9.0` uninstallable for
+  consumers. Root cause: `release.yml` published via `npm publish`, which does not
+  rewrite the `workspace:` protocol.
+
+  The publish step now packs each package with `pnpm pack` (which rewrites `workspace:`
+  in `dependencies` and `peerDependencies` to concrete ranges) and publishes the
+  resulting tarball via `npm publish` (preserving OIDC Trusted Publishing + provenance),
+  with a guard that refuses to publish if any `workspace:` spec remains in the packed
+  manifest. No runtime/API changes — 1.9.1 republishes 1.9.0 with correctly resolved
+  dependency ranges.
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/schema",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Pure Effect Schema-driven entity/aggregate modeling and relationship derivation for effect-dynamodb — importable without @aws-sdk",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Two post-#62-split fixes shipped together as **1.9.1** so the first working release is complete — the package is both **installable** (#64) and **pure-authorable** (#66).

## #64 — `effect-dynamodb@1.9.0` was uninstallable
Published with a literal `workspace:` spec (`dependencies."@effect-dynamodb/schema": "workspace:^"`; `@effect-dynamodb/geo`'s `peerDependencies.effect-dynamodb` too). Root cause: `release.yml` used `npm publish`, which doesn't rewrite the `workspace:` protocol.

**Fix:** publish step now `pnpm pack`s each package (rewrites `workspace:` in `dependencies` **and** `peerDependencies`) → guards the packed manifest against any remaining `workspace:` → `npm publish <tarball> --provenance --access public` (keeps OIDC Trusted Publishing + provenance). Verified locally: packed manifests resolve to `^1.9.1`.

## #66 — pure aggregate edges didn't type-check
`Aggregate.ref` / `one` / `many` required a `RefEntity` with a runtime `get`, so edges couldn't be authored from pure `@effect-dynamodb/schema` `Entity.make` definitions (no `get`) — defeating the AWS-free authoring path the split exists for.

**Fix:** `RefEntity` is now the minimal structural bound (`_tag`/`entityType`/`model`/`indexes`/`schemas`) used only for derivation; the runtime ref-hydration narrows back to a `get`-bearing entity at its one call site. Added a **type-checked** pure-path regression test (schema `tsconfig.test.json` wired into `pnpm check`) that builds edges from pure definitions — it fails to compile without the fix (verified: re-requiring `get` → 7 errors).

## Verification
- `pnpm lint` ✓ · `pnpm check` ✓ (both new type-test gates: effect-dynamodb + schema) · `pnpm build` ✓
- `pnpm test` ✓ — effect-dynamodb 920, schema (incl. pure-path #66 test), geo 56, doctest 47, language-service
- `pnpm --filter effect-dynamodb test:connected` ✓ — **121 passed** (ref-hydration path exercised)
- `pnpm pack` resolves `workspace:` → `^1.9.1` for `effect-dynamodb` (deps) and `@effect-dynamodb/geo` (peerDeps)

Lockstep patch bump → **1.9.1**. On merge, `release.yml` republishes all four with resolved ranges; the new guard prevents the `workspace:` class of bug from recurring.

Closes #64
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)