### PR TITLE
fix(schema): usable AWS-free pure-authoring path (1.9.2) — fixes #66, #67

### DIFF
--- a/packages/effect-dynamodb-geo/CHANGELOG.md
+++ b/packages/effect-dynamodb-geo/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @effect-dynamodb/geo
 
+## 1.9.2
+
+### Patch Changes
+
+- fix(schema): make the AWS-free pure-authoring path actually usable (closes #66, closes #67).
+
+  Two follow-ups to the #62 schema/runtime split, both blocking its headline use case
+  (deriving a typed aggregate input/create payload from `@effect-dynamodb/schema` with
+  no AWS SDK):
+  - **#66** — the pure edge constructors (`Aggregate.ref` / `one` / `many`) required a
+    `RefEntity` with a runtime `get` method, so aggregate edges could not be authored
+    from pure `Entity.make` definitions (which have no `get`). `RefEntity` is now the
+    minimal structural bound used only for derivation (`_tag`/`entityType`/`model`/
+    `indexes`/`schemas`); the runtime ref-hydration narrows back to a `get`-bearing
+    entity at its single call site.
+  - **#67** — `deriveAggregateSchemas` (the table-free derivation entry point) returned
+    `Schema.Top` members, so `typeof result.inputSchema.Type` collapsed to `unknown`.
+    It is now generic and returns `Schema.Codec<AggregateInputType<…>>` (plus a
+    `createSchema` alias), so the table-free path is as typed as the top-level
+    `Aggregate.make` — no stub `table` tag or GSI key config needed.
+
+  Type-checked regression tests for both land in the schema package's `tsconfig.test.json`
+  gate (now wired into `pnpm check`).
+
 ## 1.9.1
 
 ### Patch Changes

--- a/packages/effect-dynamodb-geo/package.json
+++ b/packages/effect-dynamodb-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/geo",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Geospatial index and search for effect-dynamodb using H3 hexagonal grid",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/CHANGELOG.md
+++ b/packages/effect-dynamodb/CHANGELOG.md
@@ -1,5 +1,32 @@
 # effect-dynamodb
 
+## 1.9.2
+
+### Patch Changes
+
+- fix(schema): make the AWS-free pure-authoring path actually usable (closes #66, closes #67).
+
+  Two follow-ups to the #62 schema/runtime split, both blocking its headline use case
+  (deriving a typed aggregate input/create payload from `@effect-dynamodb/schema` with
+  no AWS SDK):
+  - **#66** — the pure edge constructors (`Aggregate.ref` / `one` / `many`) required a
+    `RefEntity` with a runtime `get` method, so aggregate edges could not be authored
+    from pure `Entity.make` definitions (which have no `get`). `RefEntity` is now the
+    minimal structural bound used only for derivation (`_tag`/`entityType`/`model`/
+    `indexes`/`schemas`); the runtime ref-hydration narrows back to a `get`-bearing
+    entity at its single call site.
+  - **#67** — `deriveAggregateSchemas` (the table-free derivation entry point) returned
+    `Schema.Top` members, so `typeof result.inputSchema.Type` collapsed to `unknown`.
+    It is now generic and returns `Schema.Codec<AggregateInputType<…>>` (plus a
+    `createSchema` alias), so the table-free path is as typed as the top-level
+    `Aggregate.make` — no stub `table` tag or GSI key config needed.
+
+  Type-checked regression tests for both land in the schema package's `tsconfig.test.json`
+  gate (now wired into `pnpm check`).
+
+- Updated dependencies
+  - @effect-dynamodb/schema@1.9.2
+
 ## 1.9.1
 
 ### Patch Changes

--- a/packages/effect-dynamodb/package.json
+++ b/packages/effect-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effect-dynamodb",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Effect TS ORM for DynamoDB — schema-driven entity modeling, single-table design, composite keys, transactions, and Stream-based pagination",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-dynamodb/src/Aggregate.ts
+++ b/packages/effect-dynamodb/src/Aggregate.ts
@@ -1391,9 +1391,15 @@ const hydrateAggregateRefs = (
       // Deduplicate IDs for this entity type
       const uniqueIds = [...new Set(reqs.map((r) => r.id))]
 
+      // `RefEntity` is the pure structural bound (no `get` — issue #66) so that
+      // aggregate edges can be authored from AWS-free entity definitions. Ref
+      // hydration is a runtime operation, so narrow back to the get-bearing
+      // runtime entity here — the runtime path always supplies a real entity.
+      const runtimeEntity = entity as RefEntity & { readonly get: (key: any) => any }
+
       // Build EntityGet intermediates for batch fetching
       const getOps = uniqueIds.map(
-        (id) => entity.get({ [identifierName]: id }) as EntityGet<any, any, any, any>,
+        (id) => runtimeEntity.get({ [identifierName]: id }) as EntityGet<any, any, any, any>,
       )
 
       const results = yield* Batch.get(getOps)

--- a/packages/language-service/CHANGELOG.md
+++ b/packages/language-service/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @effect-dynamodb/language-service
 
+## 1.9.2
+
+### Patch Changes
+
+- fix(schema): make the AWS-free pure-authoring path actually usable (closes #66, closes #67).
+
+  Two follow-ups to the #62 schema/runtime split, both blocking its headline use case
+  (deriving a typed aggregate input/create payload from `@effect-dynamodb/schema` with
+  no AWS SDK):
+  - **#66** — the pure edge constructors (`Aggregate.ref` / `one` / `many`) required a
+    `RefEntity` with a runtime `get` method, so aggregate edges could not be authored
+    from pure `Entity.make` definitions (which have no `get`). `RefEntity` is now the
+    minimal structural bound used only for derivation (`_tag`/`entityType`/`model`/
+    `indexes`/`schemas`); the runtime ref-hydration narrows back to a `get`-bearing
+    entity at its single call site.
+  - **#67** — `deriveAggregateSchemas` (the table-free derivation entry point) returned
+    `Schema.Top` members, so `typeof result.inputSchema.Type` collapsed to `unknown`.
+    It is now generic and returns `Schema.Codec<AggregateInputType<…>>` (plus a
+    `createSchema` alias), so the table-free path is as typed as the top-level
+    `Aggregate.make` — no stub `table` tag or GSI key config needed.
+
+  Type-checked regression tests for both land in the schema package's `tsconfig.test.json`
+  gate (now wired into `pnpm check`).
+
 ## 1.9.1
 
 ### Patch Changes

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/language-service",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "TypeScript Language Service Plugin for effect-dynamodb — shows DynamoDB operations on hover",
   "license": "MIT",
   "author": "Justin Menga",

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @effect-dynamodb/schema
 
+## 1.9.2
+
+### Patch Changes
+
+- fix(schema): make the AWS-free pure-authoring path actually usable (closes #66, closes #67).
+
+  Two follow-ups to the #62 schema/runtime split, both blocking its headline use case
+  (deriving a typed aggregate input/create payload from `@effect-dynamodb/schema` with
+  no AWS SDK):
+  - **#66** — the pure edge constructors (`Aggregate.ref` / `one` / `many`) required a
+    `RefEntity` with a runtime `get` method, so aggregate edges could not be authored
+    from pure `Entity.make` definitions (which have no `get`). `RefEntity` is now the
+    minimal structural bound used only for derivation (`_tag`/`entityType`/`model`/
+    `indexes`/`schemas`); the runtime ref-hydration narrows back to a `get`-bearing
+    entity at its single call site.
+  - **#67** — `deriveAggregateSchemas` (the table-free derivation entry point) returned
+    `Schema.Top` members, so `typeof result.inputSchema.Type` collapsed to `unknown`.
+    It is now generic and returns `Schema.Codec<AggregateInputType<…>>` (plus a
+    `createSchema` alias), so the table-free path is as typed as the top-level
+    `Aggregate.make` — no stub `table` tag or GSI key config needed.
+
+  Type-checked regression tests for both land in the schema package's `tsconfig.test.json`
+  gate (now wired into `pnpm check`).
+
 ## 1.9.1
 
 ### Patch Changes

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-dynamodb/schema",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Pure Effect Schema-driven entity/aggregate modeling and relationship derivation for effect-dynamodb — importable without @aws-sdk",
   "type": "module",
   "license": "MIT",
@@ -53,7 +53,7 @@
     "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
-    "check": "tsc --noEmit",
+    "check": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "lint": "biome check .",
     "lint:fix": "biome check --write ."
   },

--- a/packages/schema/src/internal/AggregateEdges.ts
+++ b/packages/schema/src/internal/AggregateEdges.ts
@@ -22,6 +22,14 @@ import type { Schema } from "effect"
  * `indexes` mirrors `Entity.indexes` (`{ primary: { pk: { composite } }, ... }`);
  * `RefEntityIdentifierValue` reads `indexes.primary.pk.composite` to recover the
  * branded id type. A wider/looser `indexes` simply falls back to `string`.
+ *
+ * This is a PURE structural bound: edge derivation only reads
+ * `model`/`indexes`/`entityType`/`schemas` to recover the ref-id field and its
+ * (branded) identifier type — it never calls a runtime operation. It must
+ * therefore be satisfiable by a pure `EntityDefinition` (which has no `get`), so
+ * aggregate edges can be authored from `@effect-dynamodb/schema` entities with
+ * no AWS runtime (issue #66). The runtime ref-hydration path narrows back to a
+ * `get`-bearing entity at its single call site.
  */
 export interface RefEntity<M extends Schema.Top = Schema.Top, TIndexes = unknown> {
   readonly _tag: "Entity"
@@ -31,8 +39,6 @@ export interface RefEntity<M extends Schema.Top = Schema.Top, TIndexes = unknown
   readonly schemas: {
     readonly recordSchema: Schema.Codec<any>
   }
-  /** Get an entity by key — uses `any` for structural compatibility with Entity's narrower key type */
-  readonly get: (key: any) => any
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/schema/src/internal/AggregateSchemas.ts
+++ b/packages/schema/src/internal/AggregateSchemas.ts
@@ -7,7 +7,7 @@
 import { Schema } from "effect"
 import { ConfiguredModelTag } from "../DynamoModel.js"
 import type { AggregateEdge, ManyEdge, RefEntity } from "./AggregateEdges.js"
-import type { BoundSubAggregate } from "./AggregateTypes.js"
+import type { AggregateInputType, BoundSubAggregate } from "./AggregateTypes.js"
 import {
   extractArrayElement as extractArrayElementImpl,
   getSchemaFields as getSchemaFieldsImpl,
@@ -28,18 +28,37 @@ import {
  * - PK composite fields are omitted (auto-generated)
  * - `Schema.toCodecJson` is applied at the end so Date fields accept ISO strings
  */
-export interface DerivedAggregateSchemas {
-  readonly inputSchema: Schema.Top
-  readonly updateSchema: Schema.Top
+/**
+ * Precisely-typed derived aggregate schemas. `TInput` is the aggregate's derived
+ * input/create payload type (see {@link AggregateInputType}); `updateSchema` is
+ * the same shape with every field optional. This lets the table-free
+ * `deriveAggregateSchemas` path be as typed as the top-level `Aggregate.make`,
+ * so an AWS-free contract package can read `typeof result.inputSchema.Type`
+ * without fabricating a stub table tag (issue #67).
+ */
+export interface DerivedAggregateSchemas<TInput = unknown> {
+  readonly inputSchema: Schema.Codec<TInput>
+  /** Alias for `inputSchema` — aggregates have no PK-composite stripping on create. */
+  readonly createSchema: Schema.Codec<TInput>
+  readonly updateSchema: Schema.Codec<Partial<TInput>>
 }
 
-export const deriveAggregateSchemas = (
-  schema: Schema.Top,
-  edges: Record<string, AggregateEdge | BoundSubAggregate<any>>,
-  pkComposites: ReadonlyArray<string>,
-): DerivedAggregateSchemas => {
+export const deriveAggregateSchemas = <
+  TSchema extends Schema.Top,
+  const TEdges extends Record<string, AggregateEdge | BoundSubAggregate<any, any>>,
+  const TPK extends ReadonlyArray<string>,
+>(
+  schema: TSchema,
+  edges: TEdges,
+  pkComposites: TPK,
+): DerivedAggregateSchemas<AggregateInputType<Schema.Schema.Type<TSchema>, TEdges, TPK>> => {
+  type Result = DerivedAggregateSchemas<
+    AggregateInputType<Schema.Schema.Type<TSchema>, TEdges, TPK>
+  >
   const fields = getSchemaFields(schema)
-  if (!fields) return { inputSchema: schema, updateSchema: schema }
+  if (!fields) {
+    return { inputSchema: schema, createSchema: schema, updateSchema: schema } as unknown as Result
+  }
 
   const omit = new Set(pkComposites)
   const newFields: Record<string, unknown> = {}
@@ -90,7 +109,10 @@ export const deriveAggregateSchemas = (
   }
   const updateSchema = Schema.toCodecJson(Schema.Struct(optionalFields as any))
 
-  return { inputSchema, updateSchema }
+  // Runtime members are `Schema.Codec<unknown>`-shaped; the precise input type
+  // is a compile-time phantom (`AggregateInputType`) — same approach the
+  // top-level `Aggregate.make` overload uses. `createSchema` aliases `inputSchema`.
+  return { inputSchema, createSchema: inputSchema, updateSchema } as unknown as Result
 }
 
 /**

--- a/packages/schema/test/use-case.test.ts
+++ b/packages/schema/test/use-case.test.ts
@@ -114,6 +114,55 @@ describe("@effect-dynamodb/schema use-case", () => {
     expect((Roster as unknown as { get?: unknown }).get).toBeUndefined()
   })
 
+  it("authors aggregate edges from pure entity definitions (#66)", () => {
+    // The pure edge constructors must accept pure `EntityDefinition`s — which
+    // have no runtime `get` — so the aggregate edge graph can be built entirely
+    // from `@effect-dynamodb/schema` (no AWS runtime). Before the fix these
+    // failed to type-check ("Property 'get' is missing"). The tsconfig.test.json
+    // gate type-checks this file, so a regression fails the build.
+    const refEdge = Aggregate.ref(Teams)
+    const oneEdge = Aggregate.one("captain", { entityType: "Player", entity: Players })
+    const manyEdge = Aggregate.many("players", { entityType: "Player", entity: Players })
+    expect(refEdge._tag).toBe("RefEdge")
+    expect(oneEdge._tag).toBe("OneEdge")
+    expect(manyEdge._tag).toBe("ManyEdge")
+
+    // ...and they compose into an aggregate authored purely from definitions.
+    const AppSchema = DynamoSchema.make({ name: "squadapp", version: 1 })
+    const Squad = Aggregate.make(Player, {
+      table: { Tag: Symbol.for("test/squad-table") },
+      schema: AppSchema,
+      pk: { field: "pk", composite: ["playerId"] },
+      collection: { index: "gsi1", name: "squad", sk: { field: "gsi1sk", composite: [] } },
+      root: { entityType: "Player" },
+      edges: { team: Aggregate.ref(Teams) },
+    })
+    expect(Squad.inputSchema).toBeDefined()
+  })
+
+  it("deriveAggregateSchemas is typed without a table tag (#67)", () => {
+    // Table-free, AWS-free: no stub `table` tag and no GSI key config — just the
+    // model, edges, and pk composites. The returned schemas must be precisely
+    // typed (NOT `Schema.Top`/`unknown`), so a contract package can read the
+    // derived create payload type directly. Also exercises #66 (pure ref edge).
+    const derived = Aggregate.deriveAggregateSchemas(Player, { team: Aggregate.ref(Teams) }, [
+      "playerId",
+    ])
+    expect(derived.inputSchema).toBeDefined()
+    expect(derived.createSchema).toBeDefined()
+    expect(derived.updateSchema).toBeDefined()
+
+    // Regression guard for #67: the derived input is a precise object type, so
+    // accessing known fields type-checks. If it collapsed to `unknown` (the bug)
+    // these would be compile errors — the schema `tsconfig.test.json` gate
+    // type-checks this file, so a regression fails the build.
+    type DerivedInput = typeof derived.inputSchema.Type
+    const readDisplayName = (i: DerivedInput): string => i.displayName
+    const readTeamId = (i: DerivedInput): string => i.teamId // ref "team" flattened to "teamId"
+    void readDisplayName
+    void readTeamId
+  })
+
   it.effect("aggregate inputSchema decodes a typed payload", () =>
     Effect.gen(function* () {
       const AppSchema = DynamoSchema.make({ name: "myapp", version: 1 })

--- a/packages/schema/tsconfig.test.json
+++ b/packages/schema/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "test/use-case.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Two follow-ups to the #62 schema/runtime split, both blocking its headline use case — deriving a **typed** aggregate input/create payload from `@effect-dynamodb/schema` with **no AWS SDK** (e.g. an HTTP contract package).

> ⚠️ Note: #66's fix was originally written for PR #65 but pushed **after** that PR had already merged, so it never reached `main` (`main`'s `RefEntity` still had `get`). Recovered here. #66 is still open and is fixed by this PR.

## #66 — pure aggregate edges didn't type-check
`Aggregate.ref` / `one` / `many` required a `RefEntity` exposing a runtime `get`, so edges couldn't be built from pure `Entity.make` definitions (which have no `get`) — `Aggregate.ref(pureEntity)` → *"Property 'get' is missing"*.

**Fix:** `RefEntity` is now the minimal structural bound used only for derivation (`_tag`/`entityType`/`model`/`indexes`/`schemas`). The runtime ref-hydration narrows back to a `get`-bearing entity at its single call site (where a real entity is always supplied).

## #67 — table-free derivation was untyped
`deriveAggregateSchemas(schema, edges, pk)` needs no table tag, but returned `DerivedAggregateSchemas` with `Schema.Top` members → `typeof result.inputSchema.Type` collapsed to `unknown`. The only typed path (`Aggregate.make`) demanded a throwaway `table` tag + `collection`/`list` GSI config irrelevant to the input shape.

**Fix:** `deriveAggregateSchemas` is now generic and returns `Schema.Codec<AggregateInputType<…>>` (plus a `createSchema` alias) — the same precise type the top-level `Aggregate.make` produces. The table-free path is now the typed path; no stub tag or GSI config needed.

## Regression guards (type-checked, proven to bite)
Both covered by the schema package's `tsconfig.test.json` gate (wired into `pnpm check`) via `test/use-case.test.ts`:
- #66: builds aggregate edges from pure definitions — re-requiring `get` → **7** compile errors.
- #67: reads known fields off `typeof deriveAggregateSchemas(...).inputSchema.Type` — reverting to `Schema.Top` → **3** compile errors.

## Verification
- `pnpm lint` ✓ · `pnpm check` ✓ (build-before-check; both type-test gates) · `pnpm build` ✓
- `pnpm test` ✓ — effect-dynamodb 920, **@effect-dynamodb/schema 236** (+2 #66/#67 tests), geo 56, doctest 47, language-service
- `pnpm --filter effect-dynamodb test:connected` ✓ — **121 passed** (ref-hydration path exercised)

Lockstep patch bump → **1.9.2**.

Closes #66
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)